### PR TITLE
Update RAL dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ SVD files. The changes manifest in the `imxrt-ral` crate.
 
 This release also removes mention of 'stm32ral' in the API documentation.
 
+* **BREAKING** The RAL depends on `cortex-m`, version `0.7`. All `Interrupt`
+  enumerations now implement `cortex_m::interrupt::InterruptNumber`, instead
+  of `bare_metal::Nr`.
+
 ## [0.4.0] 2020-08-29
 
 * **BREAKING** The RAL's `"rtfm"` feature is changed to `"rtic"`, reflecting the framework's

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ include = [
 ]
 
 # Change version in imxrtral.py, not in Cargo.toml!
-version = "0.4.2"
+version = "0.5.0"
 
 [package.metadata.docs.rs]
 features = ["doc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,13 +25,9 @@ no-default-features = true
 default-target = "thumbv7em-none-eabihf"
 
 # Change dependencies in imxrtral.py, not here!
-[dependencies.bare-metal]
-version = "0.2.5"
-optional = true
-
 [dependencies.external-cortex-m]
 package = "cortex-m"
-version = "0.6.2"
+version = "0.7.2"
 optional = true
 
 [lib]
@@ -44,15 +40,15 @@ inline-asm = ["external-cortex-m/inline-asm"]
 rtic = []
 default = []
 nosync = []
-doc = ["bare-metal", "external-cortex-m"]
+doc = ["external-cortex-m"]
 armv6m = []
 armv7em = []
 armv7m = []
-imxrt1011 = ["armv7em", "bare-metal", "external-cortex-m"]
-imxrt1015 = ["armv7em", "bare-metal", "external-cortex-m"]
-imxrt1021 = ["armv7em", "bare-metal", "external-cortex-m"]
-imxrt1051 = ["armv7em", "bare-metal", "external-cortex-m"]
-imxrt1052 = ["armv7em", "bare-metal", "external-cortex-m"]
-imxrt1061 = ["armv7em", "bare-metal", "external-cortex-m"]
-imxrt1062 = ["armv7em", "bare-metal", "external-cortex-m"]
-imxrt1064 = ["armv7em", "bare-metal", "external-cortex-m"]
+imxrt1011 = ["armv7em", "external-cortex-m"]
+imxrt1015 = ["armv7em", "external-cortex-m"]
+imxrt1021 = ["armv7em", "external-cortex-m"]
+imxrt1051 = ["armv7em", "external-cortex-m"]
+imxrt1052 = ["armv7em", "external-cortex-m"]
+imxrt1061 = ["armv7em", "external-cortex-m"]
+imxrt1062 = ["armv7em", "external-cortex-m"]
+imxrt1064 = ["armv7em", "external-cortex-m"]

--- a/imxrtral.py
+++ b/imxrtral.py
@@ -76,13 +76,9 @@ no-default-features = true
 default-target = "thumbv7em-none-eabihf"
 
 # Change dependencies in imxrtral.py, not here!
-[dependencies.bare-metal]
-version = "0.2.5"
-optional = true
-
 [dependencies.external-cortex-m]
 package = "cortex-m"
-version = "0.6.2"
+version = "0.7.2"
 optional = true
 
 [lib]
@@ -95,9 +91,9 @@ inline-asm = ["external-cortex-m/inline-asm"]
 rtic = []
 default = []
 nosync = []
-doc = ["bare-metal", "external-cortex-m"]
+doc = ["external-cortex-m"]
 """
-CHIP_DEPENDENCIES = '"bare-metal", "external-cortex-m"'
+CHIP_DEPENDENCIES = '"external-cortex-m"'
 
 BUILD_RS_TEMPLATE = """\
 use std::env;
@@ -1199,7 +1195,6 @@ class Device(Node):
         devicepath = os.path.join(familypath, self.name)
         iname = os.path.join(devicepath, "interrupts.rs")
         with open(iname, "w") as f:
-            f.write("extern crate bare_metal;\n")
             f.write('#[cfg(feature="rt")]\nextern "C" {\n')
             for interrupt in self.interrupts:
                 f.write(f'    fn {interrupt.name}();\n')
@@ -1241,10 +1236,10 @@ class Device(Node):
                 f.write(f"{interrupt.name} = {interrupt.value},\n")
             f.write("}\n")
             f.write("""\
-                unsafe impl bare_metal::Nr for Interrupt {
+                unsafe impl external_cortex_m::interrupt::InterruptNumber for Interrupt {
                     #[inline]
-                    fn nr(&self) -> u8 {
-                        *self as u8
+                    fn number(self) -> u16 {
+                        self as u16
                     }
                 }\n""")
         rustfmt(iname)

--- a/imxrtral.py
+++ b/imxrtral.py
@@ -26,16 +26,12 @@ CRATE_LIB_PREAMBLE = """\
 //!
 //! When built, you must specify a device feature, such as `imxrt1062`.
 //! This will cause all modules in that device's module to be re-exported
-//! from the top level, so that for example `imxrt::gpio` will resolve to
-//! `imxrt::imxrt1062::gpio`.
+//! from the top level, so that for example `imxrt_ral::gpio` will resolve to
+//! `imxrt_ral::imxrt1062::gpio`.
 //!
 //! In the generated documentation, all devices are visible inside their family
 //! modules, but when built for a specific device, only that devices' constants
 //! will be available.
-//!
-//! See the
-//! [README](https://github.com/imxrt-rs/imxrt-ral/blob/master/README.md)
-//! for example usage.
 
 #![no_std]
 #![allow(clippy::all)]

--- a/imxrtral.py
+++ b/imxrtral.py
@@ -68,7 +68,7 @@ include = [
 ]
 
 # Change version in imxrtral.py, not in Cargo.toml!
-version = "0.4.2"
+version = "0.5.0"
 
 [package.metadata.docs.rs]
 features = ["doc"]

--- a/src/imxrt101/imxrt1011/interrupts.rs
+++ b/src/imxrt101/imxrt1011/interrupts.rs
@@ -1,4 +1,3 @@
-extern crate bare_metal;
 #[cfg(feature = "rt")]
 extern "C" {
     fn DMA0();
@@ -386,9 +385,9 @@ pub enum Interrupt {
     /// 79:
     ADC_ETC_ERROR_IRQ = 79,
 }
-unsafe impl bare_metal::Nr for Interrupt {
+unsafe impl external_cortex_m::interrupt::InterruptNumber for Interrupt {
     #[inline]
-    fn nr(&self) -> u8 {
-        *self as u8
+    fn number(self) -> u16 {
+        self as u16
     }
 }

--- a/src/imxrt101/imxrt1015/interrupts.rs
+++ b/src/imxrt101/imxrt1015/interrupts.rs
@@ -1,4 +1,3 @@
-extern crate bare_metal;
 #[cfg(feature = "rt")]
 extern "C" {
     fn DMA0_DMA16();
@@ -624,9 +623,9 @@ pub enum Interrupt {
     /// 133:
     TMR1 = 133,
 }
-unsafe impl bare_metal::Nr for Interrupt {
+unsafe impl external_cortex_m::interrupt::InterruptNumber for Interrupt {
     #[inline]
-    fn nr(&self) -> u8 {
-        *self as u8
+    fn number(self) -> u16 {
+        self as u16
     }
 }

--- a/src/imxrt102/imxrt1021/interrupts.rs
+++ b/src/imxrt102/imxrt1021/interrupts.rs
@@ -1,4 +1,3 @@
-extern crate bare_metal;
 #[cfg(feature = "rt")]
 extern "C" {
     fn DMA0_DMA16();
@@ -727,9 +726,9 @@ pub enum Interrupt {
     /// 141:
     PWM2_FAULT = 141,
 }
-unsafe impl bare_metal::Nr for Interrupt {
+unsafe impl external_cortex_m::interrupt::InterruptNumber for Interrupt {
     #[inline]
-    fn nr(&self) -> u8 {
-        *self as u8
+    fn number(self) -> u16 {
+        self as u16
     }
 }

--- a/src/imxrt105/imxrt1051/interrupts.rs
+++ b/src/imxrt105/imxrt1051/interrupts.rs
@@ -1,4 +1,3 @@
-extern crate bare_metal;
 #[cfg(feature = "rt")]
 extern "C" {
     fn DMA0_DMA16();
@@ -745,9 +744,9 @@ pub enum Interrupt {
     /// 151:
     PWM4_FAULT = 151,
 }
-unsafe impl bare_metal::Nr for Interrupt {
+unsafe impl external_cortex_m::interrupt::InterruptNumber for Interrupt {
     #[inline]
-    fn nr(&self) -> u8 {
-        *self as u8
+    fn number(self) -> u16 {
+        self as u16
     }
 }

--- a/src/imxrt105/imxrt1052/interrupts.rs
+++ b/src/imxrt105/imxrt1052/interrupts.rs
@@ -1,4 +1,3 @@
-extern crate bare_metal;
 #[cfg(feature = "rt")]
 extern "C" {
     fn DMA0_DMA16();
@@ -754,9 +753,9 @@ pub enum Interrupt {
     /// 151:
     PWM4_FAULT = 151,
 }
-unsafe impl bare_metal::Nr for Interrupt {
+unsafe impl external_cortex_m::interrupt::InterruptNumber for Interrupt {
     #[inline]
-    fn nr(&self) -> u8 {
-        *self as u8
+    fn number(self) -> u16 {
+        self as u16
     }
 }

--- a/src/imxrt106/imxrt1061/interrupts.rs
+++ b/src/imxrt106/imxrt1061/interrupts.rs
@@ -1,4 +1,3 @@
-extern crate bare_metal;
 #[cfg(feature = "rt")]
 extern "C" {
     fn DMA0_DMA16();
@@ -773,9 +772,9 @@ pub enum Interrupt {
     /// 157:
     GPIO6_7_8_9 = 157,
 }
-unsafe impl bare_metal::Nr for Interrupt {
+unsafe impl external_cortex_m::interrupt::InterruptNumber for Interrupt {
     #[inline]
-    fn nr(&self) -> u8 {
-        *self as u8
+    fn number(self) -> u16 {
+        self as u16
     }
 }

--- a/src/imxrt106/imxrt1062/interrupts.rs
+++ b/src/imxrt106/imxrt1062/interrupts.rs
@@ -1,4 +1,3 @@
-extern crate bare_metal;
 #[cfg(feature = "rt")]
 extern "C" {
     fn DMA0_DMA16();
@@ -782,9 +781,9 @@ pub enum Interrupt {
     /// 157:
     GPIO6_7_8_9 = 157,
 }
-unsafe impl bare_metal::Nr for Interrupt {
+unsafe impl external_cortex_m::interrupt::InterruptNumber for Interrupt {
     #[inline]
-    fn nr(&self) -> u8 {
-        *self as u8
+    fn number(self) -> u16 {
+        self as u16
     }
 }

--- a/src/imxrt106/imxrt1064/interrupts.rs
+++ b/src/imxrt106/imxrt1064/interrupts.rs
@@ -1,4 +1,3 @@
-extern crate bare_metal;
 #[cfg(feature = "rt")]
 extern "C" {
     fn DMA0_DMA16();
@@ -782,9 +781,9 @@ pub enum Interrupt {
     /// 157:
     GPIO6_7_8_9 = 157,
 }
-unsafe impl bare_metal::Nr for Interrupt {
+unsafe impl external_cortex_m::interrupt::InterruptNumber for Interrupt {
     #[inline]
-    fn nr(&self) -> u8 {
-        *self as u8
+    fn number(self) -> u16 {
+        self as u16
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,16 +6,12 @@
 //!
 //! When built, you must specify a device feature, such as `imxrt1062`.
 //! This will cause all modules in that device's module to be re-exported
-//! from the top level, so that for example `imxrt::gpio` will resolve to
-//! `imxrt::imxrt1062::gpio`.
+//! from the top level, so that for example `imxrt_ral::gpio` will resolve to
+//! `imxrt_ral::imxrt1062::gpio`.
 //!
 //! In the generated documentation, all devices are visible inside their family
 //! modules, but when built for a specific device, only that devices' constants
 //! will be available.
-//!
-//! See the
-//! [README](https://github.com/imxrt-rs/imxrt-ral/blob/master/README.md)
-//! for example usage.
 
 #![no_std]
 #![allow(clippy::all)]


### PR DESCRIPTION
The PR updates `imxrt-ral` dependencies. It removes the `bare_metal` crate, since the required trait is now part of the latest `cortex-m` crate, version `0.7`. We use the latest `cortex-m` crate, and implement `InterruptNumber` instead of `Nr`. The docs [hint](https://docs.rs/cortex-m/0.7.0/src/cortex_m/interrupt.rs.html#26-27) that the `Nr` trait will be removed in a future, breaking release, so I eagerly made the update.

The dependency update is a breaking change. The PR bumps the RAL version to 0.5.

The PR also has a few documentation and link updates.