### PR TITLE
No deps without features

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,6 +20,15 @@ jobs:
       - name: Check format for RAL
         run: cargo fmt --all -- --check
 
+  build-ral-core:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build imxrt-ral for core features
+      run: cargo build --verbose
+    - name: Test imxrt-ral for core features
+      run: cargo test --verbose --tests --lib
+
   build-ral:
     runs-on: ubuntu-latest
     strategy:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ include = [
 ]
 
 # Change version in imxrtral.py, not in Cargo.toml!
-version = "0.4.1"
+version = "0.4.2"
 
 [package.metadata.docs.rs]
 features = ["doc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,11 +24,15 @@ features = ["doc"]
 no-default-features = true
 default-target = "thumbv7em-none-eabihf"
 
-[dependencies]
-# Change dependency versions in imxrtral.py, not here!
-bare-metal = "0.2.5"
-external_cortex_m = { package = "cortex-m", version = "0.6.2" }
-# TODO use imxrt-rt here in place cortex-m-rt = { version = "0.6.12", optional = true }
+# Change dependencies in imxrtral.py, not here!
+[dependencies.bare-metal]
+version = "0.2.5"
+optional = true
+
+[dependencies.external-cortex-m]
+package = "cortex-m"
+version = "0.6.2"
+optional = true
 
 [lib]
 bench = false
@@ -36,7 +40,7 @@ test = false
 
 [features]
 rt = []
-inline-asm = ["external_cortex_m/inline-asm"]
+inline-asm = ["external-cortex-m/inline-asm"]
 rtic = []
 default = []
 nosync = []
@@ -44,11 +48,11 @@ doc = []
 armv6m = []
 armv7em = []
 armv7m = []
-imxrt1011 = ["armv7em"]
-imxrt1015 = ["armv7em"]
-imxrt1021 = ["armv7em"]
-imxrt1051 = ["armv7em"]
-imxrt1052 = ["armv7em"]
-imxrt1061 = ["armv7em"]
-imxrt1062 = ["armv7em"]
-imxrt1064 = ["armv7em"]
+imxrt1011 = ["armv7em", "bare-metal", "external-cortex-m"]
+imxrt1015 = ["armv7em", "bare-metal", "external-cortex-m"]
+imxrt1021 = ["armv7em", "bare-metal", "external-cortex-m"]
+imxrt1051 = ["armv7em", "bare-metal", "external-cortex-m"]
+imxrt1052 = ["armv7em", "bare-metal", "external-cortex-m"]
+imxrt1061 = ["armv7em", "bare-metal", "external-cortex-m"]
+imxrt1062 = ["armv7em", "bare-metal", "external-cortex-m"]
+imxrt1064 = ["armv7em", "bare-metal", "external-cortex-m"]

--- a/imxrtral.py
+++ b/imxrtral.py
@@ -68,7 +68,7 @@ include = [
 ]
 
 # Change version in imxrtral.py, not in Cargo.toml!
-version = "0.4.1"
+version = "0.4.2"
 
 [package.metadata.docs.rs]
 features = ["doc"]

--- a/imxrtral.py
+++ b/imxrtral.py
@@ -75,11 +75,15 @@ features = ["doc"]
 no-default-features = true
 default-target = "thumbv7em-none-eabihf"
 
-[dependencies]
-# Change dependency versions in imxrtral.py, not here!
-bare-metal = "0.2.5"
-external_cortex_m = { package = "cortex-m", version = "0.6.2" }
-# TODO use imxrt-rt here in place cortex-m-rt = { version = "0.6.12", optional = true }
+# Change dependencies in imxrtral.py, not here!
+[dependencies.bare-metal]
+version = "0.2.5"
+optional = true
+
+[dependencies.external-cortex-m]
+package = "cortex-m"
+version = "0.6.2"
+optional = true
 
 [lib]
 bench = false
@@ -87,13 +91,13 @@ test = false
 
 [features]
 rt = []
-inline-asm = ["external_cortex_m/inline-asm"]
+inline-asm = ["external-cortex-m/inline-asm"]
 rtic = []
 default = []
 nosync = []
 doc = []
 """
-
+CHIP_DEPENDENCIES = '"bare-metal", "external-cortex-m"'
 
 BUILD_RS_TEMPLATE = """\
 use std::env;
@@ -1623,7 +1627,7 @@ class Crate:
                 if device.special:
                     cargo_f.write(f'{dname} = []\n')
                 else:
-                    cargo_f.write(f'{dname} = ["{arch}"]\n')
+                    cargo_f.write(f'{dname} = ["{arch}", {CHIP_DEPENDENCIES}]\n')
                 lib_f.write(f'#[cfg(feature="{dname}")]\n')
                 lib_f.write(f'pub use {fname}::{dname}::*;\n\n')
         if self.peripherals:

--- a/tests/core.rs
+++ b/tests/core.rs
@@ -1,0 +1,67 @@
+//! Ensures that the core imxrt-ral features, like
+//!
+//! - the read, write, modify, and reset macros,
+//! - the register types
+//!
+//! are always avaliable, no matter the build.
+
+/// Ensures that the imxrt-ral core API is available without
+/// features (and with features). Failure manifests at compile
+/// time.
+mod import_test {
+    #![allow(unused)]
+    use imxrt_ral::{modify_reg, read_reg, reset_reg, write_reg};
+    use imxrt_ral::{
+        RORegister, RWRegister, UnsafeRORegister, UnsafeRWRegister, UnsafeWORegister, WORegister,
+    };
+}
+
+use imxrt_ral as ral;
+
+struct DummyRegisterBlock {
+    register: ral::RWRegister<u32>,
+}
+
+mod register {
+    #![allow(non_upper_case_globals, non_snake_case)] // Macro conventions...
+
+    pub mod field_foo {
+        pub const offset: u32 = 10;
+        pub const mask: u32 = 0x7 << offset;
+        pub mod RW {}
+        pub mod W {}
+        pub mod R {}
+    }
+}
+
+fn dummy_register_block() -> DummyRegisterBlock {
+    use core::mem::MaybeUninit;
+    let register_block = MaybeUninit::zeroed();
+    // Safety: 0 is a safe bitpattern
+    unsafe { register_block.assume_init() }
+}
+
+#[test]
+fn register_read() {
+    let register_block = dummy_register_block();
+    register_block.register.write(0b111 << 10);
+    assert_eq!(
+        0x7,
+        ral::read_reg!(self, &register_block, register, field_foo)
+    );
+}
+
+#[test]
+fn register_write() {
+    let register_block = dummy_register_block();
+    ral::write_reg!(self, &register_block, register, field_foo: 5);
+    assert_eq!(5 << 10, register_block.register.read());
+}
+
+#[test]
+fn register_modify() {
+    let register_block = dummy_register_block();
+    register_block.register.write(1 << 10);
+    ral::modify_reg!(self, &register_block, register, field_foo: 6);
+    assert_eq!(6 << 10, register_block.register.read());
+}


### PR DESCRIPTION
The `bare-metal` and `cortex-m` dependencies are only necessary when a chip feature is selected. This commit lets us depend on `imxrt-ral` -- which exposes the read/modify/write/reset macros, and the register types by default -- without also building unnecessary dependencies.

One use-case for a feature-less `imxrt-ral` is in the USB driver, `imxrt-usbd`. We want to access the `imxrt-ral` macros, and register types, to create our own RAL-like API directly in the driver. That's do-able today; this change just lets us simplify the build and dependency hierarchy.

`cargo tree` before this PR:

```
imxrt-ral v0.4.1 (/Users/mciantyre/Desktop/imxrt-rs/ral)
├── bare-metal v0.2.5
│   [build-dependencies]
│   └── rustc_version v0.2.3
│       └── semver v0.9.0
│           └── semver-parser v0.7.0
└── cortex-m v0.6.4
    ├── aligned v0.3.4
    │   └── as-slice v0.1.4
    │       ├── generic-array v0.12.3
    │       │   └── typenum v1.12.0
    │       ├── generic-array v0.13.2
    │       │   └── typenum v1.12.0
    │       ├── generic-array v0.14.4
    │       │   └── typenum v1.12.0
    │       │   [build-dependencies]
    │       │   └── version_check v0.9.2
    │       └── stable_deref_trait v1.2.0
    ├── bare-metal v0.2.5 (*)
    ├── bitfield v0.13.2
    └── volatile-register v0.2.0
        └── vcell v0.1.2
```

`cargo tree` after this PR reveals that we bring in no dependencies. Of course, `cargo tree --features {chip}` continues the resemble the "before" case.

This should be a backwards-compatible change, since nothing from these dependencies were exposed by a feature-less build.