### PR TITLE
Fix nosync feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -67,6 +67,22 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build for (${{ matrix.feature }}) RAL
       run: cargo build --verbose --features ${{ matrix.feature }}
+
+  # Run unit, documentation tests
+  #
+  # Docs and unit tests might not work for all features. For example,
+  # documentation might assume that the "nosync" feature isn't enabled.
+  test-ral:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        feature:
+          - "imxrt1021"
+          - "imxrt1062"
+          - "imxrt1062,rt,rtic"
+          - "imxrt1021,rt,rtic"
+    steps:
+    - uses: actions/checkout@v2
     - name: Run tests for (${{ matrix.feature }}) RAL
       run: cargo test --verbose --features ${{ matrix.feature }}
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,11 +53,16 @@ jobs:
           - "imxrt1064"
           # Chip + other features
           #
-          # Only checking this once, assuming that code gen
-          # is consistent across all chips.
+          # A chip that's combined into a chip family...
+          - "imxrt1062,nosync"
           - "imxrt1062,rt"
           - "imxrt1062,rtic"
-          - "imxrt1062,rt,rtic"
+          - "imxrt1062,rt,rtic,nosync"
+          # A chip that's not combined into a family...
+          - "imxrt1021,nosync"
+          - "imxrt1021,rt"
+          - "imxrt1021,rtic"
+          - "imxrt1021,rt,rtic,nosync"
     steps:
     - uses: actions/checkout@v2
     - name: Build for (${{ matrix.feature }}) RAL

--- a/imxrtral.py
+++ b/imxrtral.py
@@ -810,6 +810,7 @@ class PeripheralPrototype(Node):
             }
         }
 
+        #[cfg(not(feature="nosync"))]
         unsafe impl Send for Instance {}
 
         """

--- a/src/imxrt101/imxrt1011/adc1.rs
+++ b/src/imxrt101/imxrt1011/adc1.rs
@@ -857,6 +857,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the ADC1 peripheral instance

--- a/src/imxrt101/imxrt1011/adc_etc.rs
+++ b/src/imxrt101/imxrt1011/adc_etc.rs
@@ -2237,6 +2237,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the ADC_ETC peripheral instance

--- a/src/imxrt101/imxrt1011/ccm.rs
+++ b/src/imxrt101/imxrt1011/ccm.rs
@@ -3354,6 +3354,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the CCM peripheral instance

--- a/src/imxrt101/imxrt1011/dma0.rs
+++ b/src/imxrt101/imxrt1011/dma0.rs
@@ -5955,6 +5955,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the DMA0 peripheral instance

--- a/src/imxrt101/imxrt1011/dmamux.rs
+++ b/src/imxrt101/imxrt1011/dmamux.rs
@@ -288,6 +288,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the DMAMUX peripheral instance

--- a/src/imxrt101/imxrt1011/flexram.rs
+++ b/src/imxrt101/imxrt1011/flexram.rs
@@ -618,6 +618,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the FLEXRAM peripheral instance

--- a/src/imxrt101/imxrt1011/flexspi.rs
+++ b/src/imxrt101/imxrt1011/flexspi.rs
@@ -3864,6 +3864,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the FLEXSPI peripheral instance

--- a/src/imxrt101/imxrt1011/gpc.rs
+++ b/src/imxrt101/imxrt1011/gpc.rs
@@ -305,6 +305,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the GPC peripheral instance

--- a/src/imxrt101/imxrt1011/iomuxc.rs
+++ b/src/imxrt101/imxrt1011/iomuxc.rs
@@ -5069,6 +5069,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the IOMUXC peripheral instance

--- a/src/imxrt101/imxrt1011/iomuxc_gpr.rs
+++ b/src/imxrt101/imxrt1011/iomuxc_gpr.rs
@@ -2770,6 +2770,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the IOMUXC_GPR peripheral instance

--- a/src/imxrt101/imxrt1011/iomuxc_snvs.rs
+++ b/src/imxrt101/imxrt1011/iomuxc_snvs.rs
@@ -318,6 +318,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the IOMUXC_SNVS peripheral instance

--- a/src/imxrt101/imxrt1011/lpspi.rs
+++ b/src/imxrt101/imxrt1011/lpspi.rs
@@ -1579,6 +1579,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the LPSPI1 peripheral instance

--- a/src/imxrt101/imxrt1011/nvic.rs
+++ b/src/imxrt101/imxrt1011/nvic.rs
@@ -2062,6 +2062,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the NVIC peripheral instance

--- a/src/imxrt101/imxrt1011/ocotp.rs
+++ b/src/imxrt101/imxrt1011/ocotp.rs
@@ -1169,6 +1169,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the OCOTP peripheral instance

--- a/src/imxrt101/imxrt1011/otfad.rs
+++ b/src/imxrt101/imxrt1011/otfad.rs
@@ -965,6 +965,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the OTFAD peripheral instance

--- a/src/imxrt101/imxrt1011/pit.rs
+++ b/src/imxrt101/imxrt1011/pit.rs
@@ -379,6 +379,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the PIT peripheral instance

--- a/src/imxrt101/imxrt1011/pmu.rs
+++ b/src/imxrt101/imxrt1011/pmu.rs
@@ -1915,6 +1915,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the PMU peripheral instance

--- a/src/imxrt101/imxrt1011/pwm1.rs
+++ b/src/imxrt101/imxrt1011/pwm1.rs
@@ -5309,6 +5309,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the PWM1 peripheral instance

--- a/src/imxrt101/imxrt1011/sai.rs
+++ b/src/imxrt101/imxrt1011/sai.rs
@@ -2125,6 +2125,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the SAI1 peripheral instance

--- a/src/imxrt101/imxrt1011/src.rs
+++ b/src/imxrt101/imxrt1011/src.rs
@@ -613,6 +613,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the SRC peripheral instance

--- a/src/imxrt101/imxrt1011/trng.rs
+++ b/src/imxrt101/imxrt1011/trng.rs
@@ -2056,6 +2056,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the TRNG peripheral instance

--- a/src/imxrt101/imxrt1011/usb_analog.rs
+++ b/src/imxrt101/imxrt1011/usb_analog.rs
@@ -560,6 +560,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the USB_ANALOG peripheral instance

--- a/src/imxrt101/imxrt1015/adc1.rs
+++ b/src/imxrt101/imxrt1015/adc1.rs
@@ -854,6 +854,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the ADC1 peripheral instance

--- a/src/imxrt101/imxrt1015/adc_etc.rs
+++ b/src/imxrt101/imxrt1015/adc_etc.rs
@@ -1972,6 +1972,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the ADC_ETC peripheral instance

--- a/src/imxrt101/imxrt1015/bee.rs
+++ b/src/imxrt101/imxrt1015/bee.rs
@@ -832,6 +832,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the BEE peripheral instance

--- a/src/imxrt101/imxrt1015/ccm.rs
+++ b/src/imxrt101/imxrt1015/ccm.rs
@@ -3731,6 +3731,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the CCM peripheral instance

--- a/src/imxrt101/imxrt1015/dma0.rs
+++ b/src/imxrt101/imxrt1015/dma0.rs
@@ -10813,6 +10813,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the DMA0 peripheral instance

--- a/src/imxrt101/imxrt1015/dmamux.rs
+++ b/src/imxrt101/imxrt1015/dmamux.rs
@@ -480,6 +480,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the DMAMUX peripheral instance

--- a/src/imxrt101/imxrt1015/enc1.rs
+++ b/src/imxrt101/imxrt1015/enc1.rs
@@ -1147,6 +1147,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the ENC1 peripheral instance

--- a/src/imxrt101/imxrt1015/flexram.rs
+++ b/src/imxrt101/imxrt1015/flexram.rs
@@ -302,6 +302,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the FLEXRAM peripheral instance

--- a/src/imxrt101/imxrt1015/flexspi.rs
+++ b/src/imxrt101/imxrt1015/flexspi.rs
@@ -3720,6 +3720,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the FLEXSPI peripheral instance

--- a/src/imxrt101/imxrt1015/gpc.rs
+++ b/src/imxrt101/imxrt1015/gpc.rs
@@ -305,6 +305,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the GPC peripheral instance

--- a/src/imxrt101/imxrt1015/iomuxc.rs
+++ b/src/imxrt101/imxrt1015/iomuxc.rs
@@ -6180,6 +6180,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the IOMUXC peripheral instance

--- a/src/imxrt101/imxrt1015/iomuxc_gpr.rs
+++ b/src/imxrt101/imxrt1015/iomuxc_gpr.rs
@@ -3938,6 +3938,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the IOMUXC_GPR peripheral instance

--- a/src/imxrt101/imxrt1015/iomuxc_snvs.rs
+++ b/src/imxrt101/imxrt1015/iomuxc_snvs.rs
@@ -324,6 +324,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the IOMUXC_SNVS peripheral instance

--- a/src/imxrt101/imxrt1015/lpspi.rs
+++ b/src/imxrt101/imxrt1015/lpspi.rs
@@ -1579,6 +1579,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the LPSPI1 peripheral instance

--- a/src/imxrt101/imxrt1015/nvic.rs
+++ b/src/imxrt101/imxrt1015/nvic.rs
@@ -3296,6 +3296,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the NVIC peripheral instance

--- a/src/imxrt101/imxrt1015/ocotp.rs
+++ b/src/imxrt101/imxrt1015/ocotp.rs
@@ -1169,6 +1169,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the OCOTP peripheral instance

--- a/src/imxrt101/imxrt1015/pit.rs
+++ b/src/imxrt101/imxrt1015/pit.rs
@@ -379,6 +379,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the PIT peripheral instance

--- a/src/imxrt101/imxrt1015/pmu.rs
+++ b/src/imxrt101/imxrt1015/pmu.rs
@@ -1881,6 +1881,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the PMU peripheral instance

--- a/src/imxrt101/imxrt1015/pwm1.rs
+++ b/src/imxrt101/imxrt1015/pwm1.rs
@@ -5256,6 +5256,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the PWM1 peripheral instance

--- a/src/imxrt101/imxrt1015/sai.rs
+++ b/src/imxrt101/imxrt1015/sai.rs
@@ -2205,6 +2205,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the SAI1 peripheral instance

--- a/src/imxrt101/imxrt1015/src.rs
+++ b/src/imxrt101/imxrt1015/src.rs
@@ -584,6 +584,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the SRC peripheral instance

--- a/src/imxrt101/imxrt1015/tmr1.rs
+++ b/src/imxrt101/imxrt1015/tmr1.rs
@@ -1527,6 +1527,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the TMR1 peripheral instance

--- a/src/imxrt101/imxrt1015/trng.rs
+++ b/src/imxrt101/imxrt1015/trng.rs
@@ -2056,6 +2056,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the TRNG peripheral instance

--- a/src/imxrt101/imxrt1015/usb_analog.rs
+++ b/src/imxrt101/imxrt1015/usb_analog.rs
@@ -560,6 +560,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the USB_ANALOG peripheral instance

--- a/src/imxrt101/imxrt1015/xbarb.rs
+++ b/src/imxrt101/imxrt1015/xbarb.rs
@@ -311,6 +311,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the XBARB peripheral instance

--- a/src/imxrt101/peripherals/aipstz.rs
+++ b/src/imxrt101/peripherals/aipstz.rs
@@ -630,4 +630,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt101/peripherals/aoi.rs
+++ b/src/imxrt101/peripherals/aoi.rs
@@ -569,4 +569,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt101/peripherals/ccm_analog.rs
+++ b/src/imxrt101/peripherals/ccm_analog.rs
@@ -1969,4 +1969,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt101/peripherals/csu.rs
+++ b/src/imxrt101/peripherals/csu.rs
@@ -2507,4 +2507,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt101/peripherals/dcdc.rs
+++ b/src/imxrt101/peripherals/dcdc.rs
@@ -631,4 +631,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt101/peripherals/dcp.rs
+++ b/src/imxrt101/peripherals/dcp.rs
@@ -2394,4 +2394,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt101/peripherals/ewm.rs
+++ b/src/imxrt101/peripherals/ewm.rs
@@ -199,4 +199,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt101/peripherals/flexio1.rs
+++ b/src/imxrt101/peripherals/flexio1.rs
@@ -2165,4 +2165,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt101/peripherals/gpio.rs
+++ b/src/imxrt101/peripherals/gpio.rs
@@ -685,4 +685,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt101/peripherals/gpt.rs
+++ b/src/imxrt101/peripherals/gpt.rs
@@ -778,4 +778,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt101/peripherals/iomuxc_snvs_gpr.rs
+++ b/src/imxrt101/peripherals/iomuxc_snvs_gpr.rs
@@ -152,4 +152,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt101/peripherals/kpp.rs
+++ b/src/imxrt101/peripherals/kpp.rs
@@ -295,4 +295,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt101/peripherals/lpi2c.rs
+++ b/src/imxrt101/peripherals/lpi2c.rs
@@ -2702,4 +2702,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt101/peripherals/lpuart.rs
+++ b/src/imxrt101/peripherals/lpuart.rs
@@ -2437,4 +2437,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt101/peripherals/pgc.rs
+++ b/src/imxrt101/peripherals/pgc.rs
@@ -197,4 +197,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt101/peripherals/romc.rs
+++ b/src/imxrt101/peripherals/romc.rs
@@ -446,4 +446,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt101/peripherals/rtwdog.rs
+++ b/src/imxrt101/peripherals/rtwdog.rs
@@ -447,4 +447,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt101/peripherals/snvs.rs
+++ b/src/imxrt101/peripherals/snvs.rs
@@ -3280,4 +3280,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt101/peripherals/spdif.rs
+++ b/src/imxrt101/peripherals/spdif.rs
@@ -1344,4 +1344,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt101/peripherals/systemcontrol.rs
+++ b/src/imxrt101/peripherals/systemcontrol.rs
@@ -4693,4 +4693,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt101/peripherals/tempmon.rs
+++ b/src/imxrt101/peripherals/tempmon.rs
@@ -282,4 +282,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt101/peripherals/usb.rs
+++ b/src/imxrt101/peripherals/usb.rs
@@ -3384,4 +3384,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt101/peripherals/usbnc.rs
+++ b/src/imxrt101/peripherals/usbnc.rs
@@ -276,4 +276,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt101/peripherals/usbphy.rs
+++ b/src/imxrt101/peripherals/usbphy.rs
@@ -1696,4 +1696,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt101/peripherals/wdog.rs
+++ b/src/imxrt101/peripherals/wdog.rs
@@ -437,4 +437,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt101/peripherals/xbara.rs
+++ b/src/imxrt101/peripherals/xbara.rs
@@ -2777,4 +2777,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt101/peripherals/xtalosc24m.rs
+++ b/src/imxrt101/peripherals/xtalosc24m.rs
@@ -1057,4 +1057,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt102/imxrt1021/adc.rs
+++ b/src/imxrt102/imxrt1021/adc.rs
@@ -854,6 +854,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the ADC1 peripheral instance

--- a/src/imxrt102/imxrt1021/adc_etc.rs
+++ b/src/imxrt102/imxrt1021/adc_etc.rs
@@ -2466,6 +2466,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the ADC_ETC peripheral instance

--- a/src/imxrt102/imxrt1021/aipstz.rs
+++ b/src/imxrt102/imxrt1021/aipstz.rs
@@ -628,6 +628,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the AIPSTZ1 peripheral instance

--- a/src/imxrt102/imxrt1021/aoi.rs
+++ b/src/imxrt102/imxrt1021/aoi.rs
@@ -567,6 +567,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the AOI peripheral instance

--- a/src/imxrt102/imxrt1021/bee.rs
+++ b/src/imxrt102/imxrt1021/bee.rs
@@ -832,6 +832,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the BEE peripheral instance

--- a/src/imxrt102/imxrt1021/can.rs
+++ b/src/imxrt102/imxrt1021/can.rs
@@ -5823,6 +5823,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the CAN1 peripheral instance

--- a/src/imxrt102/imxrt1021/ccm.rs
+++ b/src/imxrt102/imxrt1021/ccm.rs
@@ -4157,6 +4157,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the CCM peripheral instance

--- a/src/imxrt102/imxrt1021/ccm_analog.rs
+++ b/src/imxrt102/imxrt1021/ccm_analog.rs
@@ -2048,6 +2048,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the CCM_ANALOG peripheral instance

--- a/src/imxrt102/imxrt1021/cmp.rs
+++ b/src/imxrt102/imxrt1021/cmp.rs
@@ -551,6 +551,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the CMP1 peripheral instance

--- a/src/imxrt102/imxrt1021/csu.rs
+++ b/src/imxrt102/imxrt1021/csu.rs
@@ -2505,6 +2505,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the CSU peripheral instance

--- a/src/imxrt102/imxrt1021/dcdc.rs
+++ b/src/imxrt102/imxrt1021/dcdc.rs
@@ -629,6 +629,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the DCDC peripheral instance

--- a/src/imxrt102/imxrt1021/dcp.rs
+++ b/src/imxrt102/imxrt1021/dcp.rs
@@ -2392,6 +2392,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the DCP peripheral instance

--- a/src/imxrt102/imxrt1021/dma0.rs
+++ b/src/imxrt102/imxrt1021/dma0.rs
@@ -10813,6 +10813,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the DMA0 peripheral instance

--- a/src/imxrt102/imxrt1021/dmamux.rs
+++ b/src/imxrt102/imxrt1021/dmamux.rs
@@ -480,6 +480,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the DMAMUX peripheral instance

--- a/src/imxrt102/imxrt1021/enc.rs
+++ b/src/imxrt102/imxrt1021/enc.rs
@@ -1147,6 +1147,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the ENC1 peripheral instance

--- a/src/imxrt102/imxrt1021/enet.rs
+++ b/src/imxrt102/imxrt1021/enet.rs
@@ -3378,6 +3378,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the ENET peripheral instance

--- a/src/imxrt102/imxrt1021/ewm.rs
+++ b/src/imxrt102/imxrt1021/ewm.rs
@@ -197,6 +197,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the EWM peripheral instance

--- a/src/imxrt102/imxrt1021/flexio1.rs
+++ b/src/imxrt102/imxrt1021/flexio1.rs
@@ -2163,6 +2163,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the FLEXIO1 peripheral instance

--- a/src/imxrt102/imxrt1021/flexram.rs
+++ b/src/imxrt102/imxrt1021/flexram.rs
@@ -302,6 +302,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the FLEXRAM peripheral instance

--- a/src/imxrt102/imxrt1021/flexspi.rs
+++ b/src/imxrt102/imxrt1021/flexspi.rs
@@ -3720,6 +3720,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the FLEXSPI peripheral instance

--- a/src/imxrt102/imxrt1021/gpc.rs
+++ b/src/imxrt102/imxrt1021/gpc.rs
@@ -305,6 +305,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the GPC peripheral instance

--- a/src/imxrt102/imxrt1021/gpio.rs
+++ b/src/imxrt102/imxrt1021/gpio.rs
@@ -683,6 +683,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the GPIO1 peripheral instance

--- a/src/imxrt102/imxrt1021/gpt.rs
+++ b/src/imxrt102/imxrt1021/gpt.rs
@@ -776,6 +776,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the GPT1 peripheral instance

--- a/src/imxrt102/imxrt1021/iomuxc.rs
+++ b/src/imxrt102/imxrt1021/iomuxc.rs
@@ -11138,6 +11138,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the IOMUXC peripheral instance

--- a/src/imxrt102/imxrt1021/iomuxc_gpr.rs
+++ b/src/imxrt102/imxrt1021/iomuxc_gpr.rs
@@ -5341,6 +5341,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the IOMUXC_GPR peripheral instance

--- a/src/imxrt102/imxrt1021/iomuxc_snvs.rs
+++ b/src/imxrt102/imxrt1021/iomuxc_snvs.rs
@@ -450,6 +450,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the IOMUXC_SNVS peripheral instance

--- a/src/imxrt102/imxrt1021/iomuxc_snvs_gpr.rs
+++ b/src/imxrt102/imxrt1021/iomuxc_snvs_gpr.rs
@@ -150,6 +150,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the IOMUXC_SNVS_GPR peripheral instance

--- a/src/imxrt102/imxrt1021/kpp.rs
+++ b/src/imxrt102/imxrt1021/kpp.rs
@@ -293,6 +293,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the KPP peripheral instance

--- a/src/imxrt102/imxrt1021/lpi2c.rs
+++ b/src/imxrt102/imxrt1021/lpi2c.rs
@@ -2700,6 +2700,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the LPI2C1 peripheral instance

--- a/src/imxrt102/imxrt1021/lpspi.rs
+++ b/src/imxrt102/imxrt1021/lpspi.rs
@@ -1579,6 +1579,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the LPSPI1 peripheral instance

--- a/src/imxrt102/imxrt1021/lpuart.rs
+++ b/src/imxrt102/imxrt1021/lpuart.rs
@@ -2435,6 +2435,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the LPUART1 peripheral instance

--- a/src/imxrt102/imxrt1021/nvic.rs
+++ b/src/imxrt102/imxrt1021/nvic.rs
@@ -3472,6 +3472,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the NVIC peripheral instance

--- a/src/imxrt102/imxrt1021/ocotp.rs
+++ b/src/imxrt102/imxrt1021/ocotp.rs
@@ -1211,6 +1211,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the OCOTP peripheral instance

--- a/src/imxrt102/imxrt1021/pgc.rs
+++ b/src/imxrt102/imxrt1021/pgc.rs
@@ -195,6 +195,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the PGC peripheral instance

--- a/src/imxrt102/imxrt1021/pit.rs
+++ b/src/imxrt102/imxrt1021/pit.rs
@@ -379,6 +379,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the PIT peripheral instance

--- a/src/imxrt102/imxrt1021/pmu.rs
+++ b/src/imxrt102/imxrt1021/pmu.rs
@@ -1911,6 +1911,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the PMU peripheral instance

--- a/src/imxrt102/imxrt1021/pwm.rs
+++ b/src/imxrt102/imxrt1021/pwm.rs
@@ -5256,6 +5256,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the PWM1 peripheral instance

--- a/src/imxrt102/imxrt1021/romc.rs
+++ b/src/imxrt102/imxrt1021/romc.rs
@@ -444,6 +444,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the ROMC peripheral instance

--- a/src/imxrt102/imxrt1021/rtwdog.rs
+++ b/src/imxrt102/imxrt1021/rtwdog.rs
@@ -445,6 +445,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the RTWDOG peripheral instance

--- a/src/imxrt102/imxrt1021/sai.rs
+++ b/src/imxrt102/imxrt1021/sai.rs
@@ -2205,6 +2205,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the SAI1 peripheral instance

--- a/src/imxrt102/imxrt1021/semc.rs
+++ b/src/imxrt102/imxrt1021/semc.rs
@@ -3023,6 +3023,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the SEMC peripheral instance

--- a/src/imxrt102/imxrt1021/snvs.rs
+++ b/src/imxrt102/imxrt1021/snvs.rs
@@ -3278,6 +3278,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the SNVS peripheral instance

--- a/src/imxrt102/imxrt1021/spdif.rs
+++ b/src/imxrt102/imxrt1021/spdif.rs
@@ -1333,6 +1333,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the SPDIF peripheral instance

--- a/src/imxrt102/imxrt1021/src.rs
+++ b/src/imxrt102/imxrt1021/src.rs
@@ -584,6 +584,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the SRC peripheral instance

--- a/src/imxrt102/imxrt1021/systemcontrol.rs
+++ b/src/imxrt102/imxrt1021/systemcontrol.rs
@@ -4691,6 +4691,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the SystemControl peripheral instance

--- a/src/imxrt102/imxrt1021/tempmon.rs
+++ b/src/imxrt102/imxrt1021/tempmon.rs
@@ -280,6 +280,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the TEMPMON peripheral instance

--- a/src/imxrt102/imxrt1021/tmr.rs
+++ b/src/imxrt102/imxrt1021/tmr.rs
@@ -1527,6 +1527,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the TMR1 peripheral instance

--- a/src/imxrt102/imxrt1021/trng.rs
+++ b/src/imxrt102/imxrt1021/trng.rs
@@ -2056,6 +2056,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the TRNG peripheral instance

--- a/src/imxrt102/imxrt1021/usb.rs
+++ b/src/imxrt102/imxrt1021/usb.rs
@@ -3382,6 +3382,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the USB peripheral instance

--- a/src/imxrt102/imxrt1021/usb_analog.rs
+++ b/src/imxrt102/imxrt1021/usb_analog.rs
@@ -560,6 +560,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the USB_ANALOG peripheral instance

--- a/src/imxrt102/imxrt1021/usbnc.rs
+++ b/src/imxrt102/imxrt1021/usbnc.rs
@@ -274,6 +274,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the USBNC peripheral instance

--- a/src/imxrt102/imxrt1021/usbphy.rs
+++ b/src/imxrt102/imxrt1021/usbphy.rs
@@ -1694,6 +1694,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the USBPHY peripheral instance

--- a/src/imxrt102/imxrt1021/usdhc.rs
+++ b/src/imxrt102/imxrt1021/usdhc.rs
@@ -4621,6 +4621,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the USDHC1 peripheral instance

--- a/src/imxrt102/imxrt1021/wdog.rs
+++ b/src/imxrt102/imxrt1021/wdog.rs
@@ -435,6 +435,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the WDOG1 peripheral instance

--- a/src/imxrt102/imxrt1021/xbara.rs
+++ b/src/imxrt102/imxrt1021/xbara.rs
@@ -2775,6 +2775,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the XBARA peripheral instance

--- a/src/imxrt102/imxrt1021/xbarb.rs
+++ b/src/imxrt102/imxrt1021/xbarb.rs
@@ -311,6 +311,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the XBARB peripheral instance

--- a/src/imxrt102/imxrt1021/xtalosc24m.rs
+++ b/src/imxrt102/imxrt1021/xtalosc24m.rs
@@ -1055,6 +1055,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the XTALOSC24M peripheral instance

--- a/src/imxrt105/imxrt1052/csi.rs
+++ b/src/imxrt105/imxrt1052/csi.rs
@@ -1934,6 +1934,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the CSI peripheral instance

--- a/src/imxrt105/imxrt1052/lcdif.rs
+++ b/src/imxrt105/imxrt1052/lcdif.rs
@@ -2519,6 +2519,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the LCDIF peripheral instance

--- a/src/imxrt105/imxrt1052/pxp.rs
+++ b/src/imxrt105/imxrt1052/pxp.rs
@@ -2129,6 +2129,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the PXP peripheral instance

--- a/src/imxrt105/peripherals/adc.rs
+++ b/src/imxrt105/peripherals/adc.rs
@@ -856,4 +856,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/adc_etc.rs
+++ b/src/imxrt105/peripherals/adc_etc.rs
@@ -2482,4 +2482,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/aipstz.rs
+++ b/src/imxrt105/peripherals/aipstz.rs
@@ -630,4 +630,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/aoi.rs
+++ b/src/imxrt105/peripherals/aoi.rs
@@ -569,4 +569,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/bee.rs
+++ b/src/imxrt105/peripherals/bee.rs
@@ -834,4 +834,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/can.rs
+++ b/src/imxrt105/peripherals/can.rs
@@ -5825,4 +5825,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/ccm.rs
+++ b/src/imxrt105/peripherals/ccm.rs
@@ -4414,4 +4414,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/ccm_analog.rs
+++ b/src/imxrt105/peripherals/ccm_analog.rs
@@ -2594,4 +2594,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/cmp.rs
+++ b/src/imxrt105/peripherals/cmp.rs
@@ -553,4 +553,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/csu.rs
+++ b/src/imxrt105/peripherals/csu.rs
@@ -2507,4 +2507,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/dcdc.rs
+++ b/src/imxrt105/peripherals/dcdc.rs
@@ -617,4 +617,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/dcp.rs
+++ b/src/imxrt105/peripherals/dcp.rs
@@ -2394,4 +2394,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/dma0.rs
+++ b/src/imxrt105/peripherals/dma0.rs
@@ -10408,4 +10408,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/dmamux.rs
+++ b/src/imxrt105/peripherals/dmamux.rs
@@ -482,4 +482,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/enc.rs
+++ b/src/imxrt105/peripherals/enc.rs
@@ -1149,4 +1149,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/enet.rs
+++ b/src/imxrt105/peripherals/enet.rs
@@ -3380,4 +3380,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/ewm.rs
+++ b/src/imxrt105/peripherals/ewm.rs
@@ -199,4 +199,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/flexio.rs
+++ b/src/imxrt105/peripherals/flexio.rs
@@ -1653,4 +1653,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/flexram.rs
+++ b/src/imxrt105/peripherals/flexram.rs
@@ -304,4 +304,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/flexspi.rs
+++ b/src/imxrt105/peripherals/flexspi.rs
@@ -3722,4 +3722,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/gpc.rs
+++ b/src/imxrt105/peripherals/gpc.rs
@@ -307,4 +307,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/gpio.rs
+++ b/src/imxrt105/peripherals/gpio.rs
@@ -685,4 +685,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/gpt.rs
+++ b/src/imxrt105/peripherals/gpt.rs
@@ -778,4 +778,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/iomuxc.rs
+++ b/src/imxrt105/peripherals/iomuxc.rs
@@ -14811,4 +14811,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/iomuxc_gpr.rs
+++ b/src/imxrt105/peripherals/iomuxc_gpr.rs
@@ -5622,4 +5622,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/iomuxc_snvs.rs
+++ b/src/imxrt105/peripherals/iomuxc_snvs.rs
@@ -452,4 +452,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/iomuxc_snvs_gpr.rs
+++ b/src/imxrt105/peripherals/iomuxc_snvs_gpr.rs
@@ -152,4 +152,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/kpp.rs
+++ b/src/imxrt105/peripherals/kpp.rs
@@ -295,4 +295,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/lpi2c.rs
+++ b/src/imxrt105/peripherals/lpi2c.rs
@@ -2702,4 +2702,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/lpspi.rs
+++ b/src/imxrt105/peripherals/lpspi.rs
@@ -1581,4 +1581,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/lpuart.rs
+++ b/src/imxrt105/peripherals/lpuart.rs
@@ -2437,4 +2437,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/nvic.rs
+++ b/src/imxrt105/peripherals/nvic.rs
@@ -3693,4 +3693,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/ocotp.rs
+++ b/src/imxrt105/peripherals/ocotp.rs
@@ -1213,4 +1213,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/pgc.rs
+++ b/src/imxrt105/peripherals/pgc.rs
@@ -197,4 +197,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/pit.rs
+++ b/src/imxrt105/peripherals/pit.rs
@@ -381,4 +381,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/pmu.rs
+++ b/src/imxrt105/peripherals/pmu.rs
@@ -2152,4 +2152,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/pwm.rs
+++ b/src/imxrt105/peripherals/pwm.rs
@@ -5258,4 +5258,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/romc.rs
+++ b/src/imxrt105/peripherals/romc.rs
@@ -446,4 +446,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/rtwdog.rs
+++ b/src/imxrt105/peripherals/rtwdog.rs
@@ -447,4 +447,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/sai.rs
+++ b/src/imxrt105/peripherals/sai.rs
@@ -2207,4 +2207,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/semc.rs
+++ b/src/imxrt105/peripherals/semc.rs
@@ -3053,4 +3053,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/snvs.rs
+++ b/src/imxrt105/peripherals/snvs.rs
@@ -3316,4 +3316,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/spdif.rs
+++ b/src/imxrt105/peripherals/spdif.rs
@@ -1335,4 +1335,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/src.rs
+++ b/src/imxrt105/peripherals/src.rs
@@ -565,4 +565,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/systemcontrol.rs
+++ b/src/imxrt105/peripherals/systemcontrol.rs
@@ -4693,4 +4693,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/tempmon.rs
+++ b/src/imxrt105/peripherals/tempmon.rs
@@ -282,4 +282,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/tmr.rs
+++ b/src/imxrt105/peripherals/tmr.rs
@@ -1529,4 +1529,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/trng.rs
+++ b/src/imxrt105/peripherals/trng.rs
@@ -2058,4 +2058,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/tsc.rs
+++ b/src/imxrt105/peripherals/tsc.rs
@@ -1142,4 +1142,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/usb.rs
+++ b/src/imxrt105/peripherals/usb.rs
@@ -3384,4 +3384,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/usb_analog.rs
+++ b/src/imxrt105/peripherals/usb_analog.rs
@@ -760,4 +760,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/usbnc.rs
+++ b/src/imxrt105/peripherals/usbnc.rs
@@ -276,4 +276,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/usbphy.rs
+++ b/src/imxrt105/peripherals/usbphy.rs
@@ -1696,4 +1696,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/usdhc.rs
+++ b/src/imxrt105/peripherals/usdhc.rs
@@ -4623,4 +4623,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/wdog.rs
+++ b/src/imxrt105/peripherals/wdog.rs
@@ -437,4 +437,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/xbara1.rs
+++ b/src/imxrt105/peripherals/xbara1.rs
@@ -2777,4 +2777,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/xbarb.rs
+++ b/src/imxrt105/peripherals/xbarb.rs
@@ -313,4 +313,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt105/peripherals/xtalosc24m.rs
+++ b/src/imxrt105/peripherals/xtalosc24m.rs
@@ -1057,4 +1057,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/imxrt1064/iomuxc.rs
+++ b/src/imxrt106/imxrt1064/iomuxc.rs
@@ -16365,6 +16365,7 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}
 
 /// Access functions for the IOMUXC peripheral instance

--- a/src/imxrt106/peripherals/adc.rs
+++ b/src/imxrt106/peripherals/adc.rs
@@ -856,4 +856,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/adc_etc.rs
+++ b/src/imxrt106/peripherals/adc_etc.rs
@@ -2482,4 +2482,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/aipstz.rs
+++ b/src/imxrt106/peripherals/aipstz.rs
@@ -630,4 +630,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/aoi.rs
+++ b/src/imxrt106/peripherals/aoi.rs
@@ -569,4 +569,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/bee.rs
+++ b/src/imxrt106/peripherals/bee.rs
@@ -834,4 +834,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/can.rs
+++ b/src/imxrt106/peripherals/can.rs
@@ -2466,4 +2466,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/can3.rs
+++ b/src/imxrt106/peripherals/can3.rs
@@ -42081,4 +42081,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/ccm.rs
+++ b/src/imxrt106/peripherals/ccm.rs
@@ -4602,4 +4602,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/ccm_analog.rs
+++ b/src/imxrt106/peripherals/ccm_analog.rs
@@ -2586,4 +2586,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/cmp.rs
+++ b/src/imxrt106/peripherals/cmp.rs
@@ -553,4 +553,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/csi.rs
+++ b/src/imxrt106/peripherals/csi.rs
@@ -1936,4 +1936,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/csu.rs
+++ b/src/imxrt106/peripherals/csu.rs
@@ -2507,4 +2507,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/dcdc.rs
+++ b/src/imxrt106/peripherals/dcdc.rs
@@ -617,4 +617,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/dcp.rs
+++ b/src/imxrt106/peripherals/dcp.rs
@@ -2394,4 +2394,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/dma0.rs
+++ b/src/imxrt106/peripherals/dma0.rs
@@ -10408,4 +10408,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/dmamux.rs
+++ b/src/imxrt106/peripherals/dmamux.rs
@@ -482,4 +482,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/enc.rs
+++ b/src/imxrt106/peripherals/enc.rs
@@ -1149,4 +1149,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/enet.rs
+++ b/src/imxrt106/peripherals/enet.rs
@@ -3380,4 +3380,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/ewm.rs
+++ b/src/imxrt106/peripherals/ewm.rs
@@ -199,4 +199,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/flexio.rs
+++ b/src/imxrt106/peripherals/flexio.rs
@@ -1653,4 +1653,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/flexram.rs
+++ b/src/imxrt106/peripherals/flexram.rs
@@ -304,4 +304,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/flexspi.rs
+++ b/src/imxrt106/peripherals/flexspi.rs
@@ -3722,4 +3722,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/gpc.rs
+++ b/src/imxrt106/peripherals/gpc.rs
@@ -307,4 +307,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/gpio.rs
+++ b/src/imxrt106/peripherals/gpio.rs
@@ -685,4 +685,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/gpt.rs
+++ b/src/imxrt106/peripherals/gpt.rs
@@ -778,4 +778,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/iomuxc.rs
+++ b/src/imxrt106/peripherals/iomuxc.rs
@@ -17728,4 +17728,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/iomuxc_gpr.rs
+++ b/src/imxrt106/peripherals/iomuxc_gpr.rs
@@ -6359,4 +6359,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/iomuxc_snvs.rs
+++ b/src/imxrt106/peripherals/iomuxc_snvs.rs
@@ -452,4 +452,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/iomuxc_snvs_gpr.rs
+++ b/src/imxrt106/peripherals/iomuxc_snvs_gpr.rs
@@ -152,4 +152,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/kpp.rs
+++ b/src/imxrt106/peripherals/kpp.rs
@@ -295,4 +295,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/lcdif.rs
+++ b/src/imxrt106/peripherals/lcdif.rs
@@ -2483,4 +2483,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/lpi2c.rs
+++ b/src/imxrt106/peripherals/lpi2c.rs
@@ -2702,4 +2702,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/lpspi.rs
+++ b/src/imxrt106/peripherals/lpspi.rs
@@ -1581,4 +1581,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/lpuart.rs
+++ b/src/imxrt106/peripherals/lpuart.rs
@@ -2437,4 +2437,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/nvic.rs
+++ b/src/imxrt106/peripherals/nvic.rs
@@ -3826,4 +3826,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/ocotp.rs
+++ b/src/imxrt106/peripherals/ocotp.rs
@@ -1850,4 +1850,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/pgc.rs
+++ b/src/imxrt106/peripherals/pgc.rs
@@ -197,4 +197,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/pit.rs
+++ b/src/imxrt106/peripherals/pit.rs
@@ -381,4 +381,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/pmu.rs
+++ b/src/imxrt106/peripherals/pmu.rs
@@ -2152,4 +2152,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/pwm.rs
+++ b/src/imxrt106/peripherals/pwm.rs
@@ -5258,4 +5258,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/pxp.rs
+++ b/src/imxrt106/peripherals/pxp.rs
@@ -2131,4 +2131,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/romc.rs
+++ b/src/imxrt106/peripherals/romc.rs
@@ -446,4 +446,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/rtwdog.rs
+++ b/src/imxrt106/peripherals/rtwdog.rs
@@ -447,4 +447,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/sai.rs
+++ b/src/imxrt106/peripherals/sai.rs
@@ -2207,4 +2207,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/semc.rs
+++ b/src/imxrt106/peripherals/semc.rs
@@ -3553,4 +3553,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/snvs.rs
+++ b/src/imxrt106/peripherals/snvs.rs
@@ -3316,4 +3316,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/spdif.rs
+++ b/src/imxrt106/peripherals/spdif.rs
@@ -1344,4 +1344,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/src.rs
+++ b/src/imxrt106/peripherals/src.rs
@@ -565,4 +565,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/systemcontrol.rs
+++ b/src/imxrt106/peripherals/systemcontrol.rs
@@ -4693,4 +4693,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/tempmon.rs
+++ b/src/imxrt106/peripherals/tempmon.rs
@@ -282,4 +282,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/tmr.rs
+++ b/src/imxrt106/peripherals/tmr.rs
@@ -1529,4 +1529,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/trng.rs
+++ b/src/imxrt106/peripherals/trng.rs
@@ -2058,4 +2058,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/tsc.rs
+++ b/src/imxrt106/peripherals/tsc.rs
@@ -1142,4 +1142,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/usb.rs
+++ b/src/imxrt106/peripherals/usb.rs
@@ -3384,4 +3384,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/usb_analog.rs
+++ b/src/imxrt106/peripherals/usb_analog.rs
@@ -760,4 +760,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/usbnc.rs
+++ b/src/imxrt106/peripherals/usbnc.rs
@@ -276,4 +276,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/usbphy.rs
+++ b/src/imxrt106/peripherals/usbphy.rs
@@ -1696,4 +1696,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/usdhc.rs
+++ b/src/imxrt106/peripherals/usdhc.rs
@@ -4623,4 +4623,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/wdog.rs
+++ b/src/imxrt106/peripherals/wdog.rs
@@ -437,4 +437,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/xbara1.rs
+++ b/src/imxrt106/peripherals/xbara1.rs
@@ -2777,4 +2777,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/xbarb.rs
+++ b/src/imxrt106/peripherals/xbarb.rs
@@ -313,4 +313,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}

--- a/src/imxrt106/peripherals/xtalosc24m.rs
+++ b/src/imxrt106/peripherals/xtalosc24m.rs
@@ -1057,4 +1057,5 @@ impl ::core::ops::Deref for Instance {
     }
 }
 
+#[cfg(not(feature = "nosync"))]
 unsafe impl Send for Instance {}


### PR DESCRIPTION
Before this PR, building imxrt-ral with the `"nosync"` feature would fail to compile:

```
cargo build --features imxrt1062 --features nosync
```

This PR corrects the breakage, and adds tests.

From the original docs:

> `nosync`: disables all synchronised access (take()/release() functions). The only way to access registers is with the direct unsafe access, such as write_reg!(stm32ral::gpio, GPIOA, MODER, MODER1: Input). Removes all associated synchronisation overhead, but of course the user must ensure they do not cause race conditions. "C" mode. Especially useful if enabled by a HAL crate which will perform its own synchronisation but can still permit unsafe direct access to peripherals by users (which is why this is a 'negative' feature).
