### PR TITLE
Ensure alignment when computing reserved registers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,12 @@ Associate interrupt signals with peripheral instances:
 - Peripheral instance modules have an associated constant, `INTERRUPTS`,
   that is an array of zero or more interrupt signals.
 
+Change how reserved peripheral memory is computed, resolving incorrect
+register offsets for the following peripherals and chips:
+
+- FlexPWM for the 1011.
+- Quad timers for all applicable chips.
+
 ## [0.4.2] 2021-03-11
 
 This release may let you use `imxrt-ral` without including additional

--- a/imxrtral.py
+++ b/imxrtral.py
@@ -841,11 +841,11 @@ class PeripheralPrototype(Node):
             if register.offset != address:
                 gaps = []
                 u32s = (register.offset - address) // 4
-                if u32s != 0:
+                if u32s != 0 and address % 4 == 0:
                     gaps.append(f"[u32; {u32s}]")
                     address += u32s * 4
                 u16s = (register.offset - address) // 2
-                if u16s != 0:
+                if u16s != 0 and address % 2 == 0:
                     gaps.append(f"[u16; {u16s}]")
                     address += u16s * 2
                 u8s = register.offset - address

--- a/src/imxrt101/imxrt1011/pwm.rs
+++ b/src/imxrt101/imxrt1011/pwm.rs
@@ -4659,8 +4659,7 @@ pub struct RegisterBlock {
     /// Phase Delay Register
     pub SMPHASEDLY0: RWRegister<u16>,
 
-    _reserved2: [u32; 1],
-    _reserved3: [u16; 1],
+    _reserved2: [u16; 3],
 
     /// Counter Register
     pub SMCNT1: RORegister<u16>,
@@ -4674,7 +4673,7 @@ pub struct RegisterBlock {
     /// Control Register
     pub SMCTRL1: RWRegister<u16>,
 
-    _reserved4: [u16; 1],
+    _reserved3: [u16; 1],
 
     /// Value Register 0
     pub SMVAL01: RWRegister<u16>,
@@ -4796,8 +4795,7 @@ pub struct RegisterBlock {
     /// Phase Delay Register
     pub SMPHASEDLY1: RWRegister<u16>,
 
-    _reserved5: [u32; 1],
-    _reserved6: [u16; 1],
+    _reserved4: [u16; 3],
 
     /// Counter Register
     pub SMCNT2: RORegister<u16>,
@@ -4811,7 +4809,7 @@ pub struct RegisterBlock {
     /// Control Register
     pub SMCTRL2: RWRegister<u16>,
 
-    _reserved7: [u16; 1],
+    _reserved5: [u16; 1],
 
     /// Value Register 0
     pub SMVAL02: RWRegister<u16>,
@@ -4933,8 +4931,7 @@ pub struct RegisterBlock {
     /// Phase Delay Register
     pub SMPHASEDLY2: RWRegister<u16>,
 
-    _reserved8: [u32; 1],
-    _reserved9: [u16; 1],
+    _reserved6: [u16; 3],
 
     /// Counter Register
     pub SMCNT3: RORegister<u16>,
@@ -4948,7 +4945,7 @@ pub struct RegisterBlock {
     /// Control Register
     pub SMCTRL3: RWRegister<u16>,
 
-    _reserved10: [u16; 1],
+    _reserved7: [u16; 1],
 
     /// Value Register 0
     pub SMVAL03: RWRegister<u16>,
@@ -5070,8 +5067,7 @@ pub struct RegisterBlock {
     /// Phase Delay Register
     pub SMPHASEDLY3: RWRegister<u16>,
 
-    _reserved11: [u32; 1],
-    _reserved12: [u16; 1],
+    _reserved8: [u16; 3],
 
     /// Output Enable Register
     pub OUTEN: RWRegister<u16>,

--- a/src/imxrt101/imxrt1015/tmr1.rs
+++ b/src/imxrt101/imxrt1015/tmr1.rs
@@ -1330,7 +1330,7 @@ pub struct RegisterBlock {
     /// Timer Channel DMA Enable Register
     pub DMA0: RWRegister<u16>,
 
-    _reserved1: [u32; 1],
+    _reserved1: [u16; 2],
 
     /// Timer Channel Enable Register
     pub ENBL: RWRegister<u16>,
@@ -1374,8 +1374,7 @@ pub struct RegisterBlock {
     /// Timer Channel DMA Enable Register
     pub DMA1: RWRegister<u16>,
 
-    _reserved2: [u32; 1],
-    _reserved3: [u16; 1],
+    _reserved2: [u16; 3],
 
     /// Timer Channel Compare Register 1
     pub COMP12: RWRegister<u16>,
@@ -1416,8 +1415,7 @@ pub struct RegisterBlock {
     /// Timer Channel DMA Enable Register
     pub DMA2: RWRegister<u16>,
 
-    _reserved4: [u32; 1],
-    _reserved5: [u16; 1],
+    _reserved3: [u16; 3],
 
     /// Timer Channel Compare Register 1
     pub COMP13: RWRegister<u16>,

--- a/src/imxrt102/imxrt1021/tmr.rs
+++ b/src/imxrt102/imxrt1021/tmr.rs
@@ -1330,7 +1330,7 @@ pub struct RegisterBlock {
     /// Timer Channel DMA Enable Register
     pub DMA0: RWRegister<u16>,
 
-    _reserved1: [u32; 1],
+    _reserved1: [u16; 2],
 
     /// Timer Channel Enable Register
     pub ENBL: RWRegister<u16>,
@@ -1374,8 +1374,7 @@ pub struct RegisterBlock {
     /// Timer Channel DMA Enable Register
     pub DMA1: RWRegister<u16>,
 
-    _reserved2: [u32; 1],
-    _reserved3: [u16; 1],
+    _reserved2: [u16; 3],
 
     /// Timer Channel Compare Register 1
     pub COMP12: RWRegister<u16>,
@@ -1416,8 +1415,7 @@ pub struct RegisterBlock {
     /// Timer Channel DMA Enable Register
     pub DMA2: RWRegister<u16>,
 
-    _reserved4: [u32; 1],
-    _reserved5: [u16; 1],
+    _reserved3: [u16; 3],
 
     /// Timer Channel Compare Register 1
     pub COMP13: RWRegister<u16>,

--- a/src/imxrt105/peripherals/tmr.rs
+++ b/src/imxrt105/peripherals/tmr.rs
@@ -1330,7 +1330,7 @@ pub struct RegisterBlock {
     /// Timer Channel DMA Enable Register
     pub DMA0: RWRegister<u16>,
 
-    _reserved1: [u32; 1],
+    _reserved1: [u16; 2],
 
     /// Timer Channel Enable Register
     pub ENBL: RWRegister<u16>,
@@ -1374,8 +1374,7 @@ pub struct RegisterBlock {
     /// Timer Channel DMA Enable Register
     pub DMA1: RWRegister<u16>,
 
-    _reserved2: [u32; 1],
-    _reserved3: [u16; 1],
+    _reserved2: [u16; 3],
 
     /// Timer Channel Compare Register 1
     pub COMP12: RWRegister<u16>,
@@ -1416,8 +1415,7 @@ pub struct RegisterBlock {
     /// Timer Channel DMA Enable Register
     pub DMA2: RWRegister<u16>,
 
-    _reserved4: [u32; 1],
-    _reserved5: [u16; 1],
+    _reserved3: [u16; 3],
 
     /// Timer Channel Compare Register 1
     pub COMP13: RWRegister<u16>,

--- a/src/imxrt106/peripherals/tmr.rs
+++ b/src/imxrt106/peripherals/tmr.rs
@@ -1330,7 +1330,7 @@ pub struct RegisterBlock {
     /// Timer Channel DMA Enable Register
     pub DMA0: RWRegister<u16>,
 
-    _reserved1: [u32; 1],
+    _reserved1: [u16; 2],
 
     /// Timer Channel Enable Register
     pub ENBL: RWRegister<u16>,
@@ -1374,8 +1374,7 @@ pub struct RegisterBlock {
     /// Timer Channel DMA Enable Register
     pub DMA1: RWRegister<u16>,
 
-    _reserved2: [u32; 1],
-    _reserved3: [u16; 1],
+    _reserved2: [u16; 3],
 
     /// Timer Channel Compare Register 1
     pub COMP12: RWRegister<u16>,
@@ -1416,8 +1415,7 @@ pub struct RegisterBlock {
     /// Timer Channel DMA Enable Register
     pub DMA2: RWRegister<u16>,
 
-    _reserved4: [u32; 1],
-    _reserved5: [u16; 1],
+    _reserved3: [u16; 3],
 
     /// Timer Channel Compare Register 1
     pub COMP13: RWRegister<u16>,

--- a/tests/reserved_register_padding.rs
+++ b/tests/reserved_register_padding.rs
@@ -1,0 +1,31 @@
+//! Show that we compute reserved peripheral memory properly.
+
+/// The 1011's PWM peripheral requires padding after a u16 register.
+/// The next address is two byte aligned, but not four byte aligned,
+/// so we should be careful about using a u32.
+#[cfg(feature = "imxrt1011")]
+#[test]
+fn reserved_1011_pwm() {
+    // See reference manual for addresses and offsets.
+    const PWM_BASE_ADDRESS: u32 = 0x401C_C000;
+    const SMCNT_OFFSETS: [u32; 4] = [0x000, 0x060, 0x0C0, 0x120];
+
+    let pwm = imxrt_ral::pwm::PWM::take().unwrap();
+
+    assert_eq!(
+        core::ptr::addr_of!(pwm.SMCNT0) as u32,
+        PWM_BASE_ADDRESS + SMCNT_OFFSETS[0]
+    );
+    assert_eq!(
+        core::ptr::addr_of!(pwm.SMCNT1) as u32,
+        PWM_BASE_ADDRESS + SMCNT_OFFSETS[1],
+    );
+    assert_eq!(
+        core::ptr::addr_of!(pwm.SMCNT2) as u32,
+        PWM_BASE_ADDRESS + SMCNT_OFFSETS[2],
+    );
+    assert_eq!(
+        core::ptr::addr_of!(pwm.SMCNT3) as u32,
+        PWM_BASE_ADDRESS + SMCNT_OFFSETS[3],
+    );
+}


### PR DESCRIPTION
If the routine for computing reserved peripheral memory places at least
one u32 after a u16 register, the compiler could insert an extra u16 of
padding to align the u32 reservation. The extra padding is not
considered by the routine. This can result in incorrect register offsets
for all registers placed after the reservation.

This commit ensures that we only use larger-than-byte padding when the
address is aligned for that primitive. If the address isn't aligned, use
the next-largest primitive. Byte array reservations should be the safest
approach, but going that route changes all _reserved members of all
register blocks, making it harder to see what peripherals were affected
by this issue.

I wasn't having much luck with a FlexPWM driver on the 1011 until this
commit. This commit also adds a local test to ensure proper reservations
and padding; the test now passes.