### PR TITLE
Handle alternate binary values, don't-care bits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ of `bare_metal::Nr`.
 
 Depend on `ral-registers`, and expose the API through the `imxrt-ral` package.
 
+Correct enumerated values that were specified with alternate binary values in
+the SVD files.
+
 ## [0.4.3] 2022-07-06
 
 Mark all registers as `#[repr(transparent)]`.

--- a/imxrtral.py
+++ b/imxrtral.py
@@ -1750,8 +1750,17 @@ def get_int(node, tag, default=None):
         return 0
     elif text[:2] == "0x":
         return int(text[2:], 16)
+    # Binary values can have two prefixes. They
+    # also use "x" to represent don't-care bits.
+    # Replace don't-care bits with zeros to generate
+    # a valid value.
+    #
+    # Unclear if the "x" is always lowercase, so
+    # we're being conservative.
     elif text[:2] == "0b":
-        return int(text[2:], 2)
+        return int(text[2:].lower().replace("x", "0"), 2)
+    elif text[0] == "#":
+        return int(text[1:].lower().replace("x", "0"), 2)
     else:
         # Annoyingly sometimes constants are base-10 with leading zeros,
         # so int(text, 0) for autodetection does not work.

--- a/src/imxrt101/imxrt1011/ccm.rs
+++ b/src/imxrt101/imxrt1011/ccm.rs
@@ -2760,8 +2760,8 @@ pub mod CGPR {
             /// 0b01: Enable memory (outside ARM platform) DS mode when system STOP and PLL are disabled
             pub const SYS_MEM_DS_CTRL_1: u32 = 0b01;
 
-            /// 0b00: enable memory (outside ARM platform) DS mode when system is in STOP mode
-            pub const SYS_MEM_DS_CTRL_2: u32 = 0b00;
+            /// 0b10: enable memory (outside ARM platform) DS mode when system is in STOP mode
+            pub const SYS_MEM_DS_CTRL_2: u32 = 0b10;
         }
     }
 

--- a/src/imxrt101/imxrt1015/ccm.rs
+++ b/src/imxrt101/imxrt1015/ccm.rs
@@ -3129,8 +3129,8 @@ pub mod CGPR {
             /// 0b01: Enable memory (outside ARM platform) DS mode when system STOP and PLL are disabled
             pub const SYS_MEM_DS_CTRL_1: u32 = 0b01;
 
-            /// 0b00: enable memory (outside ARM platform) DS mode when system is in STOP mode
-            pub const SYS_MEM_DS_CTRL_2: u32 = 0b00;
+            /// 0b10: enable memory (outside ARM platform) DS mode when system is in STOP mode
+            pub const SYS_MEM_DS_CTRL_2: u32 = 0b10;
         }
     }
 

--- a/src/imxrt101/peripherals/aipstz.rs
+++ b/src/imxrt101/peripherals/aipstz.rs
@@ -25,8 +25,8 @@ pub mod MPR {
             /// 0b0000: Accesses from this master are forced to user-mode (ips_supervisor_access is forced to zero) regardless of the hprot\[1\] access attribute.
             pub const MPL0: u32 = 0b0000;
 
-            /// 0b0000: Accesses from this master are not forced to user-mode. The hprot\[1\] access attribute is used directly to determine ips_supervisor_access.
-            pub const MPL1: u32 = 0b0000;
+            /// 0b0001: Accesses from this master are not forced to user-mode. The hprot\[1\] access attribute is used directly to determine ips_supervisor_access.
+            pub const MPL1: u32 = 0b0001;
         }
     }
 
@@ -102,8 +102,8 @@ pub mod OPACR {
             /// 0b0000: Accesses from an untrusted master are allowed.
             pub const TP0: u32 = 0b0000;
 
-            /// 0b0000: Accesses from an untrusted master are not allowed. If an access is attempted by an untrusted master, the access is terminated with an error response and no peripheral access is initiated on the IPS bus.
-            pub const TP1: u32 = 0b0000;
+            /// 0b0001: Accesses from an untrusted master are not allowed. If an access is attempted by an untrusted master, the access is terminated with an error response and no peripheral access is initiated on the IPS bus.
+            pub const TP1: u32 = 0b0001;
         }
     }
 
@@ -218,8 +218,8 @@ pub mod OPACR1 {
             /// 0b0000: Accesses from an untrusted master are allowed.
             pub const TP0: u32 = 0b0000;
 
-            /// 0b0000: Accesses from an untrusted master are not allowed. If an access is attempted by an untrusted master, the access is terminated with an error response and no peripheral access is initiated on the IPS bus.
-            pub const TP1: u32 = 0b0000;
+            /// 0b0001: Accesses from an untrusted master are not allowed. If an access is attempted by an untrusted master, the access is terminated with an error response and no peripheral access is initiated on the IPS bus.
+            pub const TP1: u32 = 0b0001;
         }
     }
 
@@ -334,8 +334,8 @@ pub mod OPACR2 {
             /// 0b0000: Accesses from an untrusted master are allowed.
             pub const TP0: u32 = 0b0000;
 
-            /// 0b0000: Accesses from an untrusted master are not allowed. If an access is attempted by an untrusted master, the access is terminated with an error response and no peripheral access is initiated on the IPS bus.
-            pub const TP1: u32 = 0b0000;
+            /// 0b0001: Accesses from an untrusted master are not allowed. If an access is attempted by an untrusted master, the access is terminated with an error response and no peripheral access is initiated on the IPS bus.
+            pub const TP1: u32 = 0b0001;
         }
     }
 
@@ -450,8 +450,8 @@ pub mod OPACR3 {
             /// 0b0000: Accesses from an untrusted master are allowed.
             pub const TP0: u32 = 0b0000;
 
-            /// 0b0000: Accesses from an untrusted master are not allowed. If an access is attempted by an untrusted master, the access is terminated with an error response and no peripheral access is initiated on the IPS bus.
-            pub const TP1: u32 = 0b0000;
+            /// 0b0001: Accesses from an untrusted master are not allowed. If an access is attempted by an untrusted master, the access is terminated with an error response and no peripheral access is initiated on the IPS bus.
+            pub const TP1: u32 = 0b0001;
         }
     }
 
@@ -566,8 +566,8 @@ pub mod OPACR4 {
             /// 0b0000: Accesses from an untrusted master are allowed.
             pub const TP0: u32 = 0b0000;
 
-            /// 0b0000: Accesses from an untrusted master are not allowed. If an access is attempted by an untrusted master, the access is terminated with an error response and no peripheral access is initiated on the IPS bus.
-            pub const TP1: u32 = 0b0000;
+            /// 0b0001: Accesses from an untrusted master are not allowed. If an access is attempted by an untrusted master, the access is terminated with an error response and no peripheral access is initiated on the IPS bus.
+            pub const TP1: u32 = 0b0001;
         }
     }
 

--- a/src/imxrt101/peripherals/gpt.rs
+++ b/src/imxrt101/peripherals/gpt.rs
@@ -325,8 +325,8 @@ pub mod CR {
             /// 0b011: Set output pin
             pub const OM3_3: u32 = 0b011;
 
-            /// 0b000: Generate an active low pulse (that is one input clock wide) on the output pin.
-            pub const OM3_4: u32 = 0b000;
+            /// 0b100: Generate an active low pulse (that is one input clock wide) on the output pin.
+            pub const OM3_4: u32 = 0b100;
         }
     }
 

--- a/src/imxrt101/peripherals/snvs.rs
+++ b/src/imxrt101/peripherals/snvs.rs
@@ -1077,8 +1077,8 @@ pub mod HPSVCR {
             /// 0b01: Security Violation 5 is a non-fatal violation
             pub const SV5_CFG_1: u32 = 0b01;
 
-            /// 0b00: Security Violation 5 is a fatal violation
-            pub const SV5_CFG_2: u32 = 0b00;
+            /// 0b10: Security Violation 5 is a fatal violation
+            pub const SV5_CFG_2: u32 = 0b10;
         }
     }
 
@@ -1101,8 +1101,8 @@ pub mod HPSVCR {
             /// 0b01: LP security violation is a non-fatal violation
             pub const LPSV_CFG_1: u32 = 0b01;
 
-            /// 0b00: LP security violation is a fatal violation
-            pub const LPSV_CFG_2: u32 = 0b00;
+            /// 0b10: LP security violation is a fatal violation
+            pub const LPSV_CFG_2: u32 = 0b10;
         }
     }
 }

--- a/src/imxrt102/imxrt1021/aipstz.rs
+++ b/src/imxrt102/imxrt1021/aipstz.rs
@@ -25,8 +25,8 @@ pub mod MPR {
             /// 0b0000: Accesses from this master are forced to user-mode (ips_supervisor_access is forced to zero) regardless of the hprot\[1\] access attribute.
             pub const MPL0: u32 = 0b0000;
 
-            /// 0b0000: Accesses from this master are not forced to user-mode. The hprot\[1\] access attribute is used directly to determine ips_supervisor_access.
-            pub const MPL1: u32 = 0b0000;
+            /// 0b0001: Accesses from this master are not forced to user-mode. The hprot\[1\] access attribute is used directly to determine ips_supervisor_access.
+            pub const MPL1: u32 = 0b0001;
         }
     }
 
@@ -102,8 +102,8 @@ pub mod OPACR {
             /// 0b0000: Accesses from an untrusted master are allowed.
             pub const TP0: u32 = 0b0000;
 
-            /// 0b0000: Accesses from an untrusted master are not allowed. If an access is attempted by an untrusted master, the access is terminated with an error response and no peripheral access is initiated on the IPS bus.
-            pub const TP1: u32 = 0b0000;
+            /// 0b0001: Accesses from an untrusted master are not allowed. If an access is attempted by an untrusted master, the access is terminated with an error response and no peripheral access is initiated on the IPS bus.
+            pub const TP1: u32 = 0b0001;
         }
     }
 
@@ -218,8 +218,8 @@ pub mod OPACR1 {
             /// 0b0000: Accesses from an untrusted master are allowed.
             pub const TP0: u32 = 0b0000;
 
-            /// 0b0000: Accesses from an untrusted master are not allowed. If an access is attempted by an untrusted master, the access is terminated with an error response and no peripheral access is initiated on the IPS bus.
-            pub const TP1: u32 = 0b0000;
+            /// 0b0001: Accesses from an untrusted master are not allowed. If an access is attempted by an untrusted master, the access is terminated with an error response and no peripheral access is initiated on the IPS bus.
+            pub const TP1: u32 = 0b0001;
         }
     }
 
@@ -334,8 +334,8 @@ pub mod OPACR2 {
             /// 0b0000: Accesses from an untrusted master are allowed.
             pub const TP0: u32 = 0b0000;
 
-            /// 0b0000: Accesses from an untrusted master are not allowed. If an access is attempted by an untrusted master, the access is terminated with an error response and no peripheral access is initiated on the IPS bus.
-            pub const TP1: u32 = 0b0000;
+            /// 0b0001: Accesses from an untrusted master are not allowed. If an access is attempted by an untrusted master, the access is terminated with an error response and no peripheral access is initiated on the IPS bus.
+            pub const TP1: u32 = 0b0001;
         }
     }
 
@@ -450,8 +450,8 @@ pub mod OPACR3 {
             /// 0b0000: Accesses from an untrusted master are allowed.
             pub const TP0: u32 = 0b0000;
 
-            /// 0b0000: Accesses from an untrusted master are not allowed. If an access is attempted by an untrusted master, the access is terminated with an error response and no peripheral access is initiated on the IPS bus.
-            pub const TP1: u32 = 0b0000;
+            /// 0b0001: Accesses from an untrusted master are not allowed. If an access is attempted by an untrusted master, the access is terminated with an error response and no peripheral access is initiated on the IPS bus.
+            pub const TP1: u32 = 0b0001;
         }
     }
 
@@ -566,8 +566,8 @@ pub mod OPACR4 {
             /// 0b0000: Accesses from an untrusted master are allowed.
             pub const TP0: u32 = 0b0000;
 
-            /// 0b0000: Accesses from an untrusted master are not allowed. If an access is attempted by an untrusted master, the access is terminated with an error response and no peripheral access is initiated on the IPS bus.
-            pub const TP1: u32 = 0b0000;
+            /// 0b0001: Accesses from an untrusted master are not allowed. If an access is attempted by an untrusted master, the access is terminated with an error response and no peripheral access is initiated on the IPS bus.
+            pub const TP1: u32 = 0b0001;
         }
     }
 

--- a/src/imxrt102/imxrt1021/can.rs
+++ b/src/imxrt102/imxrt1021/can.rs
@@ -923,8 +923,8 @@ pub mod ESR1 {
             /// 0b01: Error Passive
             pub const FLTCONF_1: u32 = 0b01;
 
-            /// 0b00: Bus off
-            pub const FLTCONF_2: u32 = 0b00;
+            /// 0b10: Bus off
+            pub const FLTCONF_2: u32 = 0b10;
         }
     }
 

--- a/src/imxrt102/imxrt1021/ccm.rs
+++ b/src/imxrt102/imxrt1021/ccm.rs
@@ -3492,8 +3492,8 @@ pub mod CGPR {
             /// 0b01: Enable memory (outside ARM platform) DS mode when system STOP and PLL are disabled
             pub const SYS_MEM_DS_CTRL_1: u32 = 0b01;
 
-            /// 0b00: enable memory (outside ARM platform) DS mode when system is in STOP mode
-            pub const SYS_MEM_DS_CTRL_2: u32 = 0b00;
+            /// 0b10: enable memory (outside ARM platform) DS mode when system is in STOP mode
+            pub const SYS_MEM_DS_CTRL_2: u32 = 0b10;
         }
     }
 

--- a/src/imxrt102/imxrt1021/enet.rs
+++ b/src/imxrt102/imxrt1021/enet.rs
@@ -2762,8 +2762,8 @@ pub mod TCSR0 {
             /// 0b0111: Timer Channel is configured for Output Compare - set output on compare.
             pub const TMODE_7: u32 = 0b0111;
 
-            /// 0b0000: Timer Channel is configured for Output Compare - set output on compare, clear output on overflow.
-            pub const TMODE_9: u32 = 0b0000;
+            /// 0b1001: Timer Channel is configured for Output Compare - set output on compare, clear output on overflow.
+            pub const TMODE_9: u32 = 0b1001;
 
             /// 0b1010: Timer Channel is configured for Output Compare - clear output on compare, set output on overflow.
             pub const TMODE_10: u32 = 0b1010;

--- a/src/imxrt102/imxrt1021/gpt.rs
+++ b/src/imxrt102/imxrt1021/gpt.rs
@@ -325,8 +325,8 @@ pub mod CR {
             /// 0b011: Set output pin
             pub const OM3_3: u32 = 0b011;
 
-            /// 0b000: Generate an active low pulse (that is one input clock wide) on the output pin.
-            pub const OM3_4: u32 = 0b000;
+            /// 0b100: Generate an active low pulse (that is one input clock wide) on the output pin.
+            pub const OM3_4: u32 = 0b100;
         }
     }
 

--- a/src/imxrt102/imxrt1021/snvs.rs
+++ b/src/imxrt102/imxrt1021/snvs.rs
@@ -1077,8 +1077,8 @@ pub mod HPSVCR {
             /// 0b01: Security Violation 5 is a non-fatal violation
             pub const SV5_CFG_1: u32 = 0b01;
 
-            /// 0b00: Security Violation 5 is a fatal violation
-            pub const SV5_CFG_2: u32 = 0b00;
+            /// 0b10: Security Violation 5 is a fatal violation
+            pub const SV5_CFG_2: u32 = 0b10;
         }
     }
 
@@ -1101,8 +1101,8 @@ pub mod HPSVCR {
             /// 0b01: LP security violation is a non-fatal violation
             pub const LPSV_CFG_1: u32 = 0b01;
 
-            /// 0b00: LP security violation is a fatal violation
-            pub const LPSV_CFG_2: u32 = 0b00;
+            /// 0b10: LP security violation is a fatal violation
+            pub const LPSV_CFG_2: u32 = 0b10;
         }
     }
 }

--- a/src/imxrt102/imxrt1021/usdhc.rs
+++ b/src/imxrt102/imxrt1021/usdhc.rs
@@ -1087,8 +1087,8 @@ pub mod PROT_CTRL {
         /// Read-write values
         pub mod RW {
 
-            /// 0b000: Burst length is enabled for INCR
-            pub const BURST_LEN_EN_1: u32 = 0b000;
+            /// 0b001: Burst length is enabled for INCR
+            pub const BURST_LEN_EN_1: u32 = 0b001;
         }
     }
 

--- a/src/imxrt105/imxrt1052/csi.rs
+++ b/src/imxrt105/imxrt1052/csi.rs
@@ -676,8 +676,8 @@ pub mod CSICR2 {
             /// 0b01: Abs Diff on every third green pixels
             pub const AFS_1: u32 = 0b01;
 
-            /// 0b00: Abs Diff on every four green pixels
-            pub const AFS_2: u32 = 0b00;
+            /// 0b10: Abs Diff on every four green pixels
+            pub const AFS_2: u32 = 0b10;
         }
     }
 

--- a/src/imxrt105/peripherals/aipstz.rs
+++ b/src/imxrt105/peripherals/aipstz.rs
@@ -25,8 +25,8 @@ pub mod MPR {
             /// 0b0000: Accesses from this master are forced to user-mode (ips_supervisor_access is forced to zero) regardless of the hprot\[1\] access attribute.
             pub const MPL0: u32 = 0b0000;
 
-            /// 0b0000: Accesses from this master are not forced to user-mode. The hprot\[1\] access attribute is used directly to determine ips_supervisor_access.
-            pub const MPL1: u32 = 0b0000;
+            /// 0b0001: Accesses from this master are not forced to user-mode. The hprot\[1\] access attribute is used directly to determine ips_supervisor_access.
+            pub const MPL1: u32 = 0b0001;
         }
     }
 
@@ -102,8 +102,8 @@ pub mod OPACR {
             /// 0b0000: Accesses from an untrusted master are allowed.
             pub const TP0: u32 = 0b0000;
 
-            /// 0b0000: Accesses from an untrusted master are not allowed. If an access is attempted by an untrusted master, the access is terminated with an error response and no peripheral access is initiated on the IPS bus.
-            pub const TP1: u32 = 0b0000;
+            /// 0b0001: Accesses from an untrusted master are not allowed. If an access is attempted by an untrusted master, the access is terminated with an error response and no peripheral access is initiated on the IPS bus.
+            pub const TP1: u32 = 0b0001;
         }
     }
 
@@ -218,8 +218,8 @@ pub mod OPACR1 {
             /// 0b0000: Accesses from an untrusted master are allowed.
             pub const TP0: u32 = 0b0000;
 
-            /// 0b0000: Accesses from an untrusted master are not allowed. If an access is attempted by an untrusted master, the access is terminated with an error response and no peripheral access is initiated on the IPS bus.
-            pub const TP1: u32 = 0b0000;
+            /// 0b0001: Accesses from an untrusted master are not allowed. If an access is attempted by an untrusted master, the access is terminated with an error response and no peripheral access is initiated on the IPS bus.
+            pub const TP1: u32 = 0b0001;
         }
     }
 
@@ -334,8 +334,8 @@ pub mod OPACR2 {
             /// 0b0000: Accesses from an untrusted master are allowed.
             pub const TP0: u32 = 0b0000;
 
-            /// 0b0000: Accesses from an untrusted master are not allowed. If an access is attempted by an untrusted master, the access is terminated with an error response and no peripheral access is initiated on the IPS bus.
-            pub const TP1: u32 = 0b0000;
+            /// 0b0001: Accesses from an untrusted master are not allowed. If an access is attempted by an untrusted master, the access is terminated with an error response and no peripheral access is initiated on the IPS bus.
+            pub const TP1: u32 = 0b0001;
         }
     }
 
@@ -450,8 +450,8 @@ pub mod OPACR3 {
             /// 0b0000: Accesses from an untrusted master are allowed.
             pub const TP0: u32 = 0b0000;
 
-            /// 0b0000: Accesses from an untrusted master are not allowed. If an access is attempted by an untrusted master, the access is terminated with an error response and no peripheral access is initiated on the IPS bus.
-            pub const TP1: u32 = 0b0000;
+            /// 0b0001: Accesses from an untrusted master are not allowed. If an access is attempted by an untrusted master, the access is terminated with an error response and no peripheral access is initiated on the IPS bus.
+            pub const TP1: u32 = 0b0001;
         }
     }
 
@@ -566,8 +566,8 @@ pub mod OPACR4 {
             /// 0b0000: Accesses from an untrusted master are allowed.
             pub const TP0: u32 = 0b0000;
 
-            /// 0b0000: Accesses from an untrusted master are not allowed. If an access is attempted by an untrusted master, the access is terminated with an error response and no peripheral access is initiated on the IPS bus.
-            pub const TP1: u32 = 0b0000;
+            /// 0b0001: Accesses from an untrusted master are not allowed. If an access is attempted by an untrusted master, the access is terminated with an error response and no peripheral access is initiated on the IPS bus.
+            pub const TP1: u32 = 0b0001;
         }
     }
 

--- a/src/imxrt105/peripherals/can.rs
+++ b/src/imxrt105/peripherals/can.rs
@@ -923,8 +923,8 @@ pub mod ESR1 {
             /// 0b01: Error Passive
             pub const FLTCONF_1: u32 = 0b01;
 
-            /// 0b00: Bus off
-            pub const FLTCONF_2: u32 = 0b00;
+            /// 0b10: Bus off
+            pub const FLTCONF_2: u32 = 0b10;
         }
     }
 

--- a/src/imxrt105/peripherals/ccm.rs
+++ b/src/imxrt105/peripherals/ccm.rs
@@ -3747,8 +3747,8 @@ pub mod CGPR {
             /// 0b01: Enable memory (outside ARM platform) DS mode when system STOP and PLL are disabled
             pub const SYS_MEM_DS_CTRL_1: u32 = 0b01;
 
-            /// 0b00: enable memory (outside ARM platform) DS mode when system is in STOP mode
-            pub const SYS_MEM_DS_CTRL_2: u32 = 0b00;
+            /// 0b10: enable memory (outside ARM platform) DS mode when system is in STOP mode
+            pub const SYS_MEM_DS_CTRL_2: u32 = 0b10;
         }
     }
 

--- a/src/imxrt105/peripherals/enet.rs
+++ b/src/imxrt105/peripherals/enet.rs
@@ -2762,8 +2762,8 @@ pub mod TCSR0 {
             /// 0b0111: Timer Channel is configured for Output Compare - set output on compare.
             pub const TMODE_7: u32 = 0b0111;
 
-            /// 0b0000: Timer Channel is configured for Output Compare - set output on compare, clear output on overflow.
-            pub const TMODE_9: u32 = 0b0000;
+            /// 0b1001: Timer Channel is configured for Output Compare - set output on compare, clear output on overflow.
+            pub const TMODE_9: u32 = 0b1001;
 
             /// 0b1010: Timer Channel is configured for Output Compare - clear output on compare, set output on overflow.
             pub const TMODE_10: u32 = 0b1010;

--- a/src/imxrt105/peripherals/gpt.rs
+++ b/src/imxrt105/peripherals/gpt.rs
@@ -325,8 +325,8 @@ pub mod CR {
             /// 0b011: Set output pin
             pub const OM3_3: u32 = 0b011;
 
-            /// 0b000: Generate an active low pulse (that is one input clock wide) on the output pin.
-            pub const OM3_4: u32 = 0b000;
+            /// 0b100: Generate an active low pulse (that is one input clock wide) on the output pin.
+            pub const OM3_4: u32 = 0b100;
         }
     }
 

--- a/src/imxrt105/peripherals/snvs.rs
+++ b/src/imxrt105/peripherals/snvs.rs
@@ -1077,8 +1077,8 @@ pub mod HPSVCR {
             /// 0b01: Security Violation 5 is a non-fatal violation
             pub const SV5_CFG_1: u32 = 0b01;
 
-            /// 0b00: Security Violation 5 is a fatal violation
-            pub const SV5_CFG_2: u32 = 0b00;
+            /// 0b10: Security Violation 5 is a fatal violation
+            pub const SV5_CFG_2: u32 = 0b10;
         }
     }
 
@@ -1101,8 +1101,8 @@ pub mod HPSVCR {
             /// 0b01: LP security violation is a non-fatal violation
             pub const LPSV_CFG_1: u32 = 0b01;
 
-            /// 0b00: LP security violation is a fatal violation
-            pub const LPSV_CFG_2: u32 = 0b00;
+            /// 0b10: LP security violation is a fatal violation
+            pub const LPSV_CFG_2: u32 = 0b10;
         }
     }
 }

--- a/src/imxrt105/peripherals/usdhc.rs
+++ b/src/imxrt105/peripherals/usdhc.rs
@@ -1087,8 +1087,8 @@ pub mod PROT_CTRL {
         /// Read-write values
         pub mod RW {
 
-            /// 0b000: Burst length is enabled for INCR
-            pub const BURST_LEN_EN_1: u32 = 0b000;
+            /// 0b001: Burst length is enabled for INCR
+            pub const BURST_LEN_EN_1: u32 = 0b001;
         }
     }
 

--- a/src/imxrt106/peripherals/aipstz.rs
+++ b/src/imxrt106/peripherals/aipstz.rs
@@ -25,8 +25,8 @@ pub mod MPR {
             /// 0b0000: Accesses from this master are forced to user-mode (ips_supervisor_access is forced to zero) regardless of the hprot\[1\] access attribute.
             pub const MPL0: u32 = 0b0000;
 
-            /// 0b0000: Accesses from this master are not forced to user-mode. The hprot\[1\] access attribute is used directly to determine ips_supervisor_access.
-            pub const MPL1: u32 = 0b0000;
+            /// 0b0001: Accesses from this master are not forced to user-mode. The hprot\[1\] access attribute is used directly to determine ips_supervisor_access.
+            pub const MPL1: u32 = 0b0001;
         }
     }
 
@@ -102,8 +102,8 @@ pub mod OPACR {
             /// 0b0000: Accesses from an untrusted master are allowed.
             pub const TP0: u32 = 0b0000;
 
-            /// 0b0000: Accesses from an untrusted master are not allowed. If an access is attempted by an untrusted master, the access is terminated with an error response and no peripheral access is initiated on the IPS bus.
-            pub const TP1: u32 = 0b0000;
+            /// 0b0001: Accesses from an untrusted master are not allowed. If an access is attempted by an untrusted master, the access is terminated with an error response and no peripheral access is initiated on the IPS bus.
+            pub const TP1: u32 = 0b0001;
         }
     }
 
@@ -218,8 +218,8 @@ pub mod OPACR1 {
             /// 0b0000: Accesses from an untrusted master are allowed.
             pub const TP0: u32 = 0b0000;
 
-            /// 0b0000: Accesses from an untrusted master are not allowed. If an access is attempted by an untrusted master, the access is terminated with an error response and no peripheral access is initiated on the IPS bus.
-            pub const TP1: u32 = 0b0000;
+            /// 0b0001: Accesses from an untrusted master are not allowed. If an access is attempted by an untrusted master, the access is terminated with an error response and no peripheral access is initiated on the IPS bus.
+            pub const TP1: u32 = 0b0001;
         }
     }
 
@@ -334,8 +334,8 @@ pub mod OPACR2 {
             /// 0b0000: Accesses from an untrusted master are allowed.
             pub const TP0: u32 = 0b0000;
 
-            /// 0b0000: Accesses from an untrusted master are not allowed. If an access is attempted by an untrusted master, the access is terminated with an error response and no peripheral access is initiated on the IPS bus.
-            pub const TP1: u32 = 0b0000;
+            /// 0b0001: Accesses from an untrusted master are not allowed. If an access is attempted by an untrusted master, the access is terminated with an error response and no peripheral access is initiated on the IPS bus.
+            pub const TP1: u32 = 0b0001;
         }
     }
 
@@ -450,8 +450,8 @@ pub mod OPACR3 {
             /// 0b0000: Accesses from an untrusted master are allowed.
             pub const TP0: u32 = 0b0000;
 
-            /// 0b0000: Accesses from an untrusted master are not allowed. If an access is attempted by an untrusted master, the access is terminated with an error response and no peripheral access is initiated on the IPS bus.
-            pub const TP1: u32 = 0b0000;
+            /// 0b0001: Accesses from an untrusted master are not allowed. If an access is attempted by an untrusted master, the access is terminated with an error response and no peripheral access is initiated on the IPS bus.
+            pub const TP1: u32 = 0b0001;
         }
     }
 
@@ -566,8 +566,8 @@ pub mod OPACR4 {
             /// 0b0000: Accesses from an untrusted master are allowed.
             pub const TP0: u32 = 0b0000;
 
-            /// 0b0000: Accesses from an untrusted master are not allowed. If an access is attempted by an untrusted master, the access is terminated with an error response and no peripheral access is initiated on the IPS bus.
-            pub const TP1: u32 = 0b0000;
+            /// 0b0001: Accesses from an untrusted master are not allowed. If an access is attempted by an untrusted master, the access is terminated with an error response and no peripheral access is initiated on the IPS bus.
+            pub const TP1: u32 = 0b0001;
         }
     }
 

--- a/src/imxrt106/peripherals/can.rs
+++ b/src/imxrt106/peripherals/can.rs
@@ -923,8 +923,8 @@ pub mod ESR1 {
             /// 0b01: Error Passive
             pub const FLTCONF_1: u32 = 0b01;
 
-            /// 0b00: Bus off
-            pub const FLTCONF_2: u32 = 0b00;
+            /// 0b10: Bus off
+            pub const FLTCONF_2: u32 = 0b10;
         }
     }
 

--- a/src/imxrt106/peripherals/can3.rs
+++ b/src/imxrt106/peripherals/can3.rs
@@ -1014,8 +1014,8 @@ pub mod ESR1 {
             /// 0b01: Error Passive
             pub const FLTCONF_1: u32 = 0b01;
 
-            /// 0b00: Bus Off
-            pub const FLTCONF_2: u32 = 0b00;
+            /// 0b10: Bus Off
+            pub const FLTCONF_2: u32 = 0b10;
         }
     }
 

--- a/src/imxrt106/peripherals/ccm.rs
+++ b/src/imxrt106/peripherals/ccm.rs
@@ -3810,8 +3810,8 @@ pub mod CGPR {
             /// 0b01: Enable memory (outside ARM platform) DS mode when system STOP and PLL are disabled
             pub const SYS_MEM_DS_CTRL_1: u32 = 0b01;
 
-            /// 0b00: enable memory (outside ARM platform) DS mode when system is in STOP mode
-            pub const SYS_MEM_DS_CTRL_2: u32 = 0b00;
+            /// 0b10: enable memory (outside ARM platform) DS mode when system is in STOP mode
+            pub const SYS_MEM_DS_CTRL_2: u32 = 0b10;
         }
     }
 

--- a/src/imxrt106/peripherals/csi.rs
+++ b/src/imxrt106/peripherals/csi.rs
@@ -676,8 +676,8 @@ pub mod CSICR2 {
             /// 0b01: Abs Diff on every third green pixels
             pub const AFS_1: u32 = 0b01;
 
-            /// 0b00: Abs Diff on every four green pixels
-            pub const AFS_2: u32 = 0b00;
+            /// 0b10: Abs Diff on every four green pixels
+            pub const AFS_2: u32 = 0b10;
         }
     }
 

--- a/src/imxrt106/peripherals/enet.rs
+++ b/src/imxrt106/peripherals/enet.rs
@@ -2762,8 +2762,8 @@ pub mod TCSR0 {
             /// 0b0111: Timer Channel is configured for Output Compare - set output on compare.
             pub const TMODE_7: u32 = 0b0111;
 
-            /// 0b0000: Timer Channel is configured for Output Compare - set output on compare, clear output on overflow.
-            pub const TMODE_9: u32 = 0b0000;
+            /// 0b1001: Timer Channel is configured for Output Compare - set output on compare, clear output on overflow.
+            pub const TMODE_9: u32 = 0b1001;
 
             /// 0b1010: Timer Channel is configured for Output Compare - clear output on compare, set output on overflow.
             pub const TMODE_10: u32 = 0b1010;

--- a/src/imxrt106/peripherals/gpt.rs
+++ b/src/imxrt106/peripherals/gpt.rs
@@ -325,8 +325,8 @@ pub mod CR {
             /// 0b011: Set output pin
             pub const OM3_3: u32 = 0b011;
 
-            /// 0b000: Generate an active low pulse (that is one input clock wide) on the output pin.
-            pub const OM3_4: u32 = 0b000;
+            /// 0b100: Generate an active low pulse (that is one input clock wide) on the output pin.
+            pub const OM3_4: u32 = 0b100;
         }
     }
 

--- a/src/imxrt106/peripherals/snvs.rs
+++ b/src/imxrt106/peripherals/snvs.rs
@@ -1077,8 +1077,8 @@ pub mod HPSVCR {
             /// 0b01: Security Violation 5 is a non-fatal violation
             pub const SV5_CFG_1: u32 = 0b01;
 
-            /// 0b00: Security Violation 5 is a fatal violation
-            pub const SV5_CFG_2: u32 = 0b00;
+            /// 0b10: Security Violation 5 is a fatal violation
+            pub const SV5_CFG_2: u32 = 0b10;
         }
     }
 
@@ -1101,8 +1101,8 @@ pub mod HPSVCR {
             /// 0b01: LP security violation is a non-fatal violation
             pub const LPSV_CFG_1: u32 = 0b01;
 
-            /// 0b00: LP security violation is a fatal violation
-            pub const LPSV_CFG_2: u32 = 0b00;
+            /// 0b10: LP security violation is a fatal violation
+            pub const LPSV_CFG_2: u32 = 0b10;
         }
     }
 }

--- a/src/imxrt106/peripherals/usdhc.rs
+++ b/src/imxrt106/peripherals/usdhc.rs
@@ -1087,8 +1087,8 @@ pub mod PROT_CTRL {
         /// Read-write values
         pub mod RW {
 
-            /// 0b000: Burst length is enabled for INCR
-            pub const BURST_LEN_EN_1: u32 = 0b000;
+            /// 0b001: Burst length is enabled for INCR
+            pub const BURST_LEN_EN_1: u32 = 0b001;
         }
     }
 


### PR DESCRIPTION
Binary values have two different representations in the SVD world, and
they can express don't-care bits. This commit updates the code generator
and crate to acount for the alternate binary value representation. It
handles don't-care bits by setting them to zero.

This commit corrects incorrect enumerated values that were set to zero.
The code generator was warning about this, so those warnings should be
gone.