### PR TITLE
Equate fieldset names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ to all available components.
 
 **BREAKING** Rename LPI2C.SIER field "AM1F" to "AM1IE".
 
+**BREAKING** Rename SRC.SRSR field "LOCKUP" to "LOCKUP_SYSRESETREQ" for 1011,
+1015, and 1051 MCUs.
+
 ## [0.5.0] 2022-12-27
 
 Add support for NXP's i.MX RT 1176 dual-core MCUs. An `"imxrt1176_cm7"` feature

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ such fields.
 Fix the FlexIO timer and shifter counts from four to eight, permitting access
 to all available components.
 
+**BREAKING** Rename LPI2C.SIER field "AM1F" to "AM1IE".
+
 ## [0.5.0] 2022-12-27
 
 Add support for NXP's i.MX RT 1176 dual-core MCUs. An `"imxrt1176_cm7"` feature

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,17 @@ to all available components.
 **BREAKING** Rename SRC.SRSR field "LOCKUP" to "LOCKUP_SYSRESETREQ" for 1011,
 1015, and 1051 MCUs.
 
+**BREAKING** Rename CCM.CS1CDR field "FLEXIO1" to "FLEXIO2" for the 1050 and
+1060 families.
+
+**BREAKING** Expose the "TRNG_ACC" field in TRNG.MCTL on the 1015, 1021 MCUs.
+
+**BREAKING** Rename IOMUXC_GPR.GPR26 field "GPIO_SEL" to "GPIO_MUX1_GPIO_SEL,"
+and correct the documentation.
+
+**BREAKING** Correct the name, documentation of the SNVS.LPCR field "LVD_EN" on
+the 1176.
+
 ## [0.5.0] 2022-12-27
 
 Add support for NXP's i.MX RT 1176 dual-core MCUs. An `"imxrt1176_cm7"` feature

--- a/raltool-cfg.yaml
+++ b/raltool-cfg.yaml
@@ -150,3 +150,11 @@ transforms:
       block: ocotp::Ocotp
       from: HW_OCOTP_(.*)
       to: $1
+  # Field is needlessly named 'AM1F' on the 1176.
+  # All 1000-series use AM1IE. The field meaning
+  # is the same regardless, and this lets us combine
+  # the LPI2C blocks.
+  - RenameFields:
+      fieldset: lpi2c::regs::Sier
+      from: AM1F
+      to: AM1IE

--- a/raltool-cfg.yaml
+++ b/raltool-cfg.yaml
@@ -158,3 +158,7 @@ transforms:
       fieldset: lpi2c::regs::Sier
       from: AM1F
       to: AM1IE
+  - RenameFields:
+      fieldset: src::regs::Srsr
+      from: LOCKUP
+      to: LOCKUP_SYSRESETREQ

--- a/raltool/src/combine.rs
+++ b/raltool/src/combine.rs
@@ -126,7 +126,8 @@ fn equivalent_fieldsets(
 
     a.bit_size == b.bit_size
         && equivalent_slices(&a.fields, &b.fields, |q, r| {
-            q.bit_offset == r.bit_offset
+            q.name == r.name
+                && q.bit_offset == r.bit_offset
                 && q.array == r.array
                 && q.bit_size == r.bit_size
                 && try_equivalent_enum(&q.enum_read, &r.enum_read)

--- a/src/blocks/imxrt1011/lpi2c.rs
+++ b/src/blocks/imxrt1011/lpi2c.rs
@@ -1291,7 +1291,7 @@ pub mod SIER {
         }
     }
     #[doc = "Address Match 1 Interrupt Enable"]
-    pub mod AM1F {
+    pub mod AM1IE {
         pub const offset: u32 = 13;
         pub const mask: u32 = 0x01 << offset;
         pub mod R {}

--- a/src/blocks/imxrt1011/src.rs
+++ b/src/blocks/imxrt1011/src.rs
@@ -163,7 +163,7 @@ pub mod SRSR {
         }
     }
     #[doc = "Indicates a reset has been caused by CPU lockup."]
-    pub mod LOCKUP {
+    pub mod LOCKUP_SYSRESETREQ {
         pub const offset: u32 = 1;
         pub const mask: u32 = 0x01 << offset;
         pub mod R {}

--- a/src/blocks/imxrt1015/src.rs
+++ b/src/blocks/imxrt1015/src.rs
@@ -163,7 +163,7 @@ pub mod SRSR {
         }
     }
     #[doc = "Indicates a reset has been caused by CPU lockup."]
-    pub mod LOCKUP {
+    pub mod LOCKUP_SYSRESETREQ {
         pub const offset: u32 = 1;
         pub const mask: u32 = 0x01 << offset;
         pub mod R {}

--- a/src/blocks/imxrt1015/trng.rs
+++ b/src/blocks/imxrt1015/trng.rs
@@ -1,0 +1,969 @@
+#[doc = "TRNG"]
+#[repr(C)]
+pub struct RegisterBlock {
+    #[doc = "Miscellaneous Control Register"]
+    pub MCTL: crate::RWRegister<u32>,
+    #[doc = "Statistical Check Miscellaneous Register"]
+    pub SCMISC: crate::RWRegister<u32>,
+    #[doc = "Poker Range Register"]
+    pub PKRRNG: crate::RWRegister<u32>,
+    #[doc = "Poker Maximum Limit Register"]
+    pub PKRMAX: crate::RWRegister<u32>,
+    #[doc = "Seed Control Register"]
+    pub SDCTL: crate::RWRegister<u32>,
+    #[doc = "Sparse Bit Limit Register"]
+    pub SBLIM: crate::RWRegister<u32>,
+    #[doc = "Frequency Count Minimum Limit Register"]
+    pub FRQMIN: crate::RWRegister<u32>,
+    #[doc = "Frequency Count Maximum Limit Register"]
+    pub FRQMAX: crate::RWRegister<u32>,
+    #[doc = "Statistical Check Monobit Limit Register"]
+    pub SCML: crate::RWRegister<u32>,
+    #[doc = "Statistical Check Run Length 1 Limit Register"]
+    pub SCR1L: crate::RWRegister<u32>,
+    #[doc = "Statistical Check Run Length 2 Limit Register"]
+    pub SCR2L: crate::RWRegister<u32>,
+    #[doc = "Statistical Check Run Length 3 Limit Register"]
+    pub SCR3L: crate::RWRegister<u32>,
+    #[doc = "Statistical Check Run Length 4 Limit Register"]
+    pub SCR4L: crate::RWRegister<u32>,
+    #[doc = "Statistical Check Run Length 5 Limit Register"]
+    pub SCR5L: crate::RWRegister<u32>,
+    #[doc = "Statistical Check Run Length 6+ Limit Register"]
+    pub SCR6PL: crate::RWRegister<u32>,
+    #[doc = "Status Register"]
+    pub STATUS: crate::RORegister<u32>,
+    #[doc = "Entropy Read Register"]
+    pub ENT: [crate::RORegister<u32>; 16usize],
+    #[doc = "Statistical Check Poker Count 1 and 0 Register"]
+    pub PKRCNT10: crate::RORegister<u32>,
+    #[doc = "Statistical Check Poker Count 3 and 2 Register"]
+    pub PKRCNT32: crate::RORegister<u32>,
+    #[doc = "Statistical Check Poker Count 5 and 4 Register"]
+    pub PKRCNT54: crate::RORegister<u32>,
+    #[doc = "Statistical Check Poker Count 7 and 6 Register"]
+    pub PKRCNT76: crate::RORegister<u32>,
+    #[doc = "Statistical Check Poker Count 9 and 8 Register"]
+    pub PKRCNT98: crate::RORegister<u32>,
+    #[doc = "Statistical Check Poker Count B and A Register"]
+    pub PKRCNTBA: crate::RORegister<u32>,
+    #[doc = "Statistical Check Poker Count D and C Register"]
+    pub PKRCNTDC: crate::RORegister<u32>,
+    #[doc = "Statistical Check Poker Count F and E Register"]
+    pub PKRCNTFE: crate::RORegister<u32>,
+    #[doc = "Security Configuration Register"]
+    pub SEC_CFG: crate::RWRegister<u32>,
+    #[doc = "Interrupt Control Register"]
+    pub INT_CTRL: crate::RWRegister<u32>,
+    #[doc = "Mask Register"]
+    pub INT_MASK: crate::RWRegister<u32>,
+    #[doc = "Interrupt Status Register"]
+    pub INT_STATUS: crate::RORegister<u32>,
+    _reserved0: [u8; 0x40],
+    #[doc = "Version ID Register (MS)"]
+    pub VID1: crate::RORegister<u32>,
+    #[doc = "Version ID Register (LS)"]
+    pub VID2: crate::RORegister<u32>,
+}
+#[doc = "Miscellaneous Control Register"]
+pub mod MCTL {
+    #[doc = "Sample Mode"]
+    pub mod SAMP_MODE {
+        pub const offset: u32 = 0;
+        pub const mask: u32 = 0x03 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {
+            #[doc = "use Von Neumann data into both Entropy shifter and Statistical Checker"]
+            pub const SAMP_MODE_0: u32 = 0;
+            #[doc = "use raw data into both Entropy shifter and Statistical Checker"]
+            pub const SAMP_MODE_1: u32 = 0x01;
+            #[doc = "use Von Neumann data into Entropy shifter. Use raw data into Statistical Checker"]
+            pub const SAMP_MODE_2: u32 = 0x02;
+            #[doc = "undefined/reserved."]
+            pub const SAMP_MODE_3: u32 = 0x03;
+        }
+    }
+    #[doc = "Oscillator Divide"]
+    pub mod OSC_DIV {
+        pub const offset: u32 = 2;
+        pub const mask: u32 = 0x03 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {
+            #[doc = "use ring oscillator with no divide"]
+            pub const OSC_DIV_0: u32 = 0;
+            #[doc = "use ring oscillator divided-by-2"]
+            pub const OSC_DIV_1: u32 = 0x01;
+            #[doc = "use ring oscillator divided-by-4"]
+            pub const OSC_DIV_2: u32 = 0x02;
+            #[doc = "use ring oscillator divided-by-8"]
+            pub const OSC_DIV_3: u32 = 0x03;
+        }
+    }
+    #[doc = "This bit is unused. Always reads zero."]
+    pub mod UNUSED4 {
+        pub const offset: u32 = 4;
+        pub const mask: u32 = 0x01 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "TRNG Access Mode"]
+    pub mod TRNG_ACC {
+        pub const offset: u32 = 5;
+        pub const mask: u32 = 0x01 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "Reset Defaults"]
+    pub mod RST_DEF {
+        pub const offset: u32 = 6;
+        pub const mask: u32 = 0x01 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "Force System Clock"]
+    pub mod FOR_SCLK {
+        pub const offset: u32 = 7;
+        pub const mask: u32 = 0x01 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "Read only: Frequency Count Fail"]
+    pub mod FCT_FAIL {
+        pub const offset: u32 = 8;
+        pub const mask: u32 = 0x01 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "Read only: Frequency Count Valid. Indicates that a valid frequency count may be read from FRQCNT."]
+    pub mod FCT_VAL {
+        pub const offset: u32 = 9;
+        pub const mask: u32 = 0x01 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "Read only: Entropy Valid"]
+    pub mod ENT_VAL {
+        pub const offset: u32 = 10;
+        pub const mask: u32 = 0x01 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "Read only: Test point inside ring oscillator."]
+    pub mod TST_OUT {
+        pub const offset: u32 = 11;
+        pub const mask: u32 = 0x01 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "Read: Error status"]
+    pub mod ERR {
+        pub const offset: u32 = 12;
+        pub const mask: u32 = 0x01 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "TRNG_OK_TO_STOP"]
+    pub mod TSTOP_OK {
+        pub const offset: u32 = 13;
+        pub const mask: u32 = 0x01 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "Long run count continues between entropy generations"]
+    pub mod LRUN_CONT {
+        pub const offset: u32 = 14;
+        pub const mask: u32 = 0x01 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "Programming Mode Select"]
+    pub mod PRGM {
+        pub const offset: u32 = 16;
+        pub const mask: u32 = 0x01 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+}
+#[doc = "Statistical Check Miscellaneous Register"]
+pub mod SCMISC {
+    #[doc = "LONG RUN MAX LIMIT"]
+    pub mod LRUN_MAX {
+        pub const offset: u32 = 0;
+        pub const mask: u32 = 0xff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "RETRY COUNT"]
+    pub mod RTY_CT {
+        pub const offset: u32 = 16;
+        pub const mask: u32 = 0x0f << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+}
+#[doc = "Poker Range Register"]
+pub mod PKRRNG {
+    #[doc = "Poker Range"]
+    pub mod PKR_RNG {
+        pub const offset: u32 = 0;
+        pub const mask: u32 = 0xffff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+}
+#[doc = "Poker Maximum Limit Register"]
+pub mod PKRMAX {
+    #[doc = "Poker Maximum Limit."]
+    pub mod PKR_MAX {
+        pub const offset: u32 = 0;
+        pub const mask: u32 = 0x00ff_ffff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+}
+#[doc = "Seed Control Register"]
+pub mod SDCTL {
+    #[doc = "Sample Size"]
+    pub mod SAMP_SIZE {
+        pub const offset: u32 = 0;
+        pub const mask: u32 = 0xffff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "Entropy Delay"]
+    pub mod ENT_DLY {
+        pub const offset: u32 = 16;
+        pub const mask: u32 = 0xffff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+}
+#[doc = "Sparse Bit Limit Register"]
+pub mod SBLIM {
+    #[doc = "Sparse Bit Limit"]
+    pub mod SB_LIM {
+        pub const offset: u32 = 0;
+        pub const mask: u32 = 0x03ff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+}
+#[doc = "Frequency Count Minimum Limit Register"]
+pub mod FRQMIN {
+    #[doc = "Frequency Count Minimum Limit"]
+    pub mod FRQ_MIN {
+        pub const offset: u32 = 0;
+        pub const mask: u32 = 0x003f_ffff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+}
+#[doc = "Frequency Count Maximum Limit Register"]
+pub mod FRQMAX {
+    #[doc = "Frequency Counter Maximum Limit"]
+    pub mod FRQ_MAX {
+        pub const offset: u32 = 0;
+        pub const mask: u32 = 0x003f_ffff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+}
+#[doc = "Statistical Check Monobit Limit Register"]
+pub mod SCML {
+    #[doc = "Monobit Maximum Limit"]
+    pub mod MONO_MAX {
+        pub const offset: u32 = 0;
+        pub const mask: u32 = 0xffff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "Monobit Range"]
+    pub mod MONO_RNG {
+        pub const offset: u32 = 16;
+        pub const mask: u32 = 0xffff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+}
+#[doc = "Statistical Check Run Length 1 Limit Register"]
+pub mod SCR1L {
+    #[doc = "Run Length 1 Maximum Limit"]
+    pub mod RUN1_MAX {
+        pub const offset: u32 = 0;
+        pub const mask: u32 = 0x7fff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "Run Length 1 Range"]
+    pub mod RUN1_RNG {
+        pub const offset: u32 = 16;
+        pub const mask: u32 = 0x7fff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+}
+#[doc = "Statistical Check Run Length 2 Limit Register"]
+pub mod SCR2L {
+    #[doc = "Run Length 2 Maximum Limit"]
+    pub mod RUN2_MAX {
+        pub const offset: u32 = 0;
+        pub const mask: u32 = 0x3fff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "Run Length 2 Range"]
+    pub mod RUN2_RNG {
+        pub const offset: u32 = 16;
+        pub const mask: u32 = 0x3fff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+}
+#[doc = "Statistical Check Run Length 3 Limit Register"]
+pub mod SCR3L {
+    #[doc = "Run Length 3 Maximum Limit"]
+    pub mod RUN3_MAX {
+        pub const offset: u32 = 0;
+        pub const mask: u32 = 0x1fff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "Run Length 3 Range"]
+    pub mod RUN3_RNG {
+        pub const offset: u32 = 16;
+        pub const mask: u32 = 0x1fff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+}
+#[doc = "Statistical Check Run Length 4 Limit Register"]
+pub mod SCR4L {
+    #[doc = "Run Length 4 Maximum Limit"]
+    pub mod RUN4_MAX {
+        pub const offset: u32 = 0;
+        pub const mask: u32 = 0x0fff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "Run Length 4 Range"]
+    pub mod RUN4_RNG {
+        pub const offset: u32 = 16;
+        pub const mask: u32 = 0x0fff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+}
+#[doc = "Statistical Check Run Length 5 Limit Register"]
+pub mod SCR5L {
+    #[doc = "Run Length 5 Maximum Limit"]
+    pub mod RUN5_MAX {
+        pub const offset: u32 = 0;
+        pub const mask: u32 = 0x07ff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "Run Length 5 Range"]
+    pub mod RUN5_RNG {
+        pub const offset: u32 = 16;
+        pub const mask: u32 = 0x07ff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+}
+#[doc = "Statistical Check Run Length 6+ Limit Register"]
+pub mod SCR6PL {
+    #[doc = "Run Length 6+ Maximum Limit"]
+    pub mod RUN6P_MAX {
+        pub const offset: u32 = 0;
+        pub const mask: u32 = 0x07ff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "Run Length 6+ Range"]
+    pub mod RUN6P_RNG {
+        pub const offset: u32 = 16;
+        pub const mask: u32 = 0x07ff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+}
+#[doc = "Status Register"]
+pub mod STATUS {
+    #[doc = "Test Fail, 1-Bit Run, Sampling 0s. If TF1BR0=1, the 1-Bit Run, Sampling 0s Test has failed."]
+    pub mod TF1BR0 {
+        pub const offset: u32 = 0;
+        pub const mask: u32 = 0x01 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "Test Fail, 1-Bit Run, Sampling 1s. If TF1BR1=1, the 1-Bit Run, Sampling 1s Test has failed."]
+    pub mod TF1BR1 {
+        pub const offset: u32 = 1;
+        pub const mask: u32 = 0x01 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "Test Fail, 2-Bit Run, Sampling 0s. If TF2BR0=1, the 2-Bit Run, Sampling 0s Test has failed."]
+    pub mod TF2BR0 {
+        pub const offset: u32 = 2;
+        pub const mask: u32 = 0x01 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "Test Fail, 2-Bit Run, Sampling 1s. If TF2BR1=1, the 2-Bit Run, Sampling 1s Test has failed."]
+    pub mod TF2BR1 {
+        pub const offset: u32 = 3;
+        pub const mask: u32 = 0x01 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "Test Fail, 3-Bit Run, Sampling 0s. If TF3BR0=1, the 3-Bit Run, Sampling 0s Test has failed."]
+    pub mod TF3BR0 {
+        pub const offset: u32 = 4;
+        pub const mask: u32 = 0x01 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "Test Fail, 3-Bit Run, Sampling 1s. If TF3BR1=1, the 3-Bit Run, Sampling 1s Test has failed."]
+    pub mod TF3BR1 {
+        pub const offset: u32 = 5;
+        pub const mask: u32 = 0x01 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "Test Fail, 4-Bit Run, Sampling 0s. If TF4BR0=1, the 4-Bit Run, Sampling 0s Test has failed."]
+    pub mod TF4BR0 {
+        pub const offset: u32 = 6;
+        pub const mask: u32 = 0x01 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "Test Fail, 4-Bit Run, Sampling 1s. If TF4BR1=1, the 4-Bit Run, Sampling 1s Test has failed."]
+    pub mod TF4BR1 {
+        pub const offset: u32 = 7;
+        pub const mask: u32 = 0x01 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "Test Fail, 5-Bit Run, Sampling 0s. If TF5BR0=1, the 5-Bit Run, Sampling 0s Test has failed."]
+    pub mod TF5BR0 {
+        pub const offset: u32 = 8;
+        pub const mask: u32 = 0x01 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "Test Fail, 5-Bit Run, Sampling 1s. If TF5BR1=1, the 5-Bit Run, Sampling 1s Test has failed."]
+    pub mod TF5BR1 {
+        pub const offset: u32 = 9;
+        pub const mask: u32 = 0x01 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "Test Fail, 6 Plus Bit Run, Sampling 0s"]
+    pub mod TF6PBR0 {
+        pub const offset: u32 = 10;
+        pub const mask: u32 = 0x01 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "Test Fail, 6 Plus Bit Run, Sampling 1s"]
+    pub mod TF6PBR1 {
+        pub const offset: u32 = 11;
+        pub const mask: u32 = 0x01 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "Test Fail, Sparse Bit. If TFSB=1, the Sparse Bit Test has failed."]
+    pub mod TFSB {
+        pub const offset: u32 = 12;
+        pub const mask: u32 = 0x01 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "Test Fail, Long Run. If TFLR=1, the Long Run Test has failed."]
+    pub mod TFLR {
+        pub const offset: u32 = 13;
+        pub const mask: u32 = 0x01 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "Test Fail, Poker. If TFP=1, the Poker Test has failed."]
+    pub mod TFP {
+        pub const offset: u32 = 14;
+        pub const mask: u32 = 0x01 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "Test Fail, Mono Bit. If TFMB=1, the Mono Bit Test has failed."]
+    pub mod TFMB {
+        pub const offset: u32 = 15;
+        pub const mask: u32 = 0x01 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "RETRY COUNT"]
+    pub mod RETRY_CT {
+        pub const offset: u32 = 16;
+        pub const mask: u32 = 0x0f << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+}
+#[doc = "Entropy Read Register"]
+pub mod ENT {
+    #[doc = "Entropy Value"]
+    pub mod ENT {
+        pub const offset: u32 = 0;
+        pub const mask: u32 = 0xffff_ffff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+}
+#[doc = "Statistical Check Poker Count 1 and 0 Register"]
+pub mod PKRCNT10 {
+    #[doc = "Poker 0h Count"]
+    pub mod PKR_0_CT {
+        pub const offset: u32 = 0;
+        pub const mask: u32 = 0xffff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "Poker 1h Count"]
+    pub mod PKR_1_CT {
+        pub const offset: u32 = 16;
+        pub const mask: u32 = 0xffff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+}
+#[doc = "Statistical Check Poker Count 3 and 2 Register"]
+pub mod PKRCNT32 {
+    #[doc = "Poker 2h Count"]
+    pub mod PKR_2_CT {
+        pub const offset: u32 = 0;
+        pub const mask: u32 = 0xffff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "Poker 3h Count"]
+    pub mod PKR_3_CT {
+        pub const offset: u32 = 16;
+        pub const mask: u32 = 0xffff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+}
+#[doc = "Statistical Check Poker Count 5 and 4 Register"]
+pub mod PKRCNT54 {
+    #[doc = "Poker 4h Count"]
+    pub mod PKR_4_CT {
+        pub const offset: u32 = 0;
+        pub const mask: u32 = 0xffff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "Poker 5h Count"]
+    pub mod PKR_5_CT {
+        pub const offset: u32 = 16;
+        pub const mask: u32 = 0xffff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+}
+#[doc = "Statistical Check Poker Count 7 and 6 Register"]
+pub mod PKRCNT76 {
+    #[doc = "Poker 6h Count"]
+    pub mod PKR_6_CT {
+        pub const offset: u32 = 0;
+        pub const mask: u32 = 0xffff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "Poker 7h Count"]
+    pub mod PKR_7_CT {
+        pub const offset: u32 = 16;
+        pub const mask: u32 = 0xffff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+}
+#[doc = "Statistical Check Poker Count 9 and 8 Register"]
+pub mod PKRCNT98 {
+    #[doc = "Poker 8h Count"]
+    pub mod PKR_8_CT {
+        pub const offset: u32 = 0;
+        pub const mask: u32 = 0xffff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "Poker 9h Count"]
+    pub mod PKR_9_CT {
+        pub const offset: u32 = 16;
+        pub const mask: u32 = 0xffff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+}
+#[doc = "Statistical Check Poker Count B and A Register"]
+pub mod PKRCNTBA {
+    #[doc = "Poker Ah Count"]
+    pub mod PKR_A_CT {
+        pub const offset: u32 = 0;
+        pub const mask: u32 = 0xffff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "Poker Bh Count"]
+    pub mod PKR_B_CT {
+        pub const offset: u32 = 16;
+        pub const mask: u32 = 0xffff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+}
+#[doc = "Statistical Check Poker Count D and C Register"]
+pub mod PKRCNTDC {
+    #[doc = "Poker Ch Count"]
+    pub mod PKR_C_CT {
+        pub const offset: u32 = 0;
+        pub const mask: u32 = 0xffff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "Poker Dh Count"]
+    pub mod PKR_D_CT {
+        pub const offset: u32 = 16;
+        pub const mask: u32 = 0xffff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+}
+#[doc = "Statistical Check Poker Count F and E Register"]
+pub mod PKRCNTFE {
+    #[doc = "Poker Eh Count"]
+    pub mod PKR_E_CT {
+        pub const offset: u32 = 0;
+        pub const mask: u32 = 0xffff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "Poker Fh Count"]
+    pub mod PKR_F_CT {
+        pub const offset: u32 = 16;
+        pub const mask: u32 = 0xffff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+}
+#[doc = "Security Configuration Register"]
+pub mod SEC_CFG {
+    #[doc = "This bit is unused. Ignore."]
+    pub mod UNUSED0 {
+        pub const offset: u32 = 0;
+        pub const mask: u32 = 0x01 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "If set, the TRNG registers cannot be programmed"]
+    pub mod NO_PRGM {
+        pub const offset: u32 = 1;
+        pub const mask: u32 = 0x01 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {
+            #[doc = "Programability of registers controlled only by the Miscellaneous Control Register's access mode bit."]
+            pub const NO_PRGM_0: u32 = 0;
+            #[doc = "Overides Miscellaneous Control Register access mode and prevents TRNG register programming."]
+            pub const NO_PRGM_1: u32 = 0x01;
+        }
+    }
+    #[doc = "This bit is unused. Ignore."]
+    pub mod UNUSED2 {
+        pub const offset: u32 = 2;
+        pub const mask: u32 = 0x01 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+}
+#[doc = "Interrupt Control Register"]
+pub mod INT_CTRL {
+    #[doc = "Bit position that can be cleared if corresponding bit of INT_STATUS register has been asserted."]
+    pub mod HW_ERR {
+        pub const offset: u32 = 0;
+        pub const mask: u32 = 0x01 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {
+            #[doc = "Corresponding bit of INT_STATUS register cleared."]
+            pub const HW_ERR_0: u32 = 0;
+            #[doc = "Corresponding bit of INT_STATUS register active."]
+            pub const HW_ERR_1: u32 = 0x01;
+        }
+    }
+    #[doc = "Same behavior as bit 0 of this register."]
+    pub mod ENT_VAL {
+        pub const offset: u32 = 1;
+        pub const mask: u32 = 0x01 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {
+            #[doc = "Same behavior as bit 0 of this register."]
+            pub const ENT_VAL_0: u32 = 0;
+            #[doc = "Same behavior as bit 0 of this register."]
+            pub const ENT_VAL_1: u32 = 0x01;
+        }
+    }
+    #[doc = "Same behavior as bit 0 of this register."]
+    pub mod FRQ_CT_FAIL {
+        pub const offset: u32 = 2;
+        pub const mask: u32 = 0x01 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {
+            #[doc = "Same behavior as bit 0 of this register."]
+            pub const FRQ_CT_FAIL_0: u32 = 0;
+            #[doc = "Same behavior as bit 0 of this register."]
+            pub const FRQ_CT_FAIL_1: u32 = 0x01;
+        }
+    }
+}
+#[doc = "Mask Register"]
+pub mod INT_MASK {
+    #[doc = "Bit position that can be cleared if corresponding bit of INT_STATUS has been asserted."]
+    pub mod HW_ERR {
+        pub const offset: u32 = 0;
+        pub const mask: u32 = 0x01 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {
+            #[doc = "Corresponding interrupt of INT_STATUS is masked."]
+            pub const HW_ERR_0: u32 = 0;
+            #[doc = "Corresponding bit of INT_STATUS is active."]
+            pub const HW_ERR_1: u32 = 0x01;
+        }
+    }
+    #[doc = "Same behavior as bit 0 of this register."]
+    pub mod ENT_VAL {
+        pub const offset: u32 = 1;
+        pub const mask: u32 = 0x01 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {
+            #[doc = "Same behavior as bit 0 of this register."]
+            pub const ENT_VAL_0: u32 = 0;
+            #[doc = "Same behavior as bit 0 of this register."]
+            pub const ENT_VAL_1: u32 = 0x01;
+        }
+    }
+    #[doc = "Same behavior as bit 0 of this register."]
+    pub mod FRQ_CT_FAIL {
+        pub const offset: u32 = 2;
+        pub const mask: u32 = 0x01 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {
+            #[doc = "Same behavior as bit 0 of this register."]
+            pub const FRQ_CT_FAIL_0: u32 = 0;
+            #[doc = "Same behavior as bit 0 of this register."]
+            pub const FRQ_CT_FAIL_1: u32 = 0x01;
+        }
+    }
+}
+#[doc = "Interrupt Status Register"]
+pub mod INT_STATUS {
+    #[doc = "Read: Error status"]
+    pub mod HW_ERR {
+        pub const offset: u32 = 0;
+        pub const mask: u32 = 0x01 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {
+            #[doc = "no error"]
+            pub const HW_ERR_0: u32 = 0;
+            #[doc = "error detected."]
+            pub const HW_ERR_1: u32 = 0x01;
+        }
+    }
+    #[doc = "Read only: Entropy Valid"]
+    pub mod ENT_VAL {
+        pub const offset: u32 = 1;
+        pub const mask: u32 = 0x01 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {
+            #[doc = "Busy generation entropy. Any value read is invalid."]
+            pub const ENT_VAL_0: u32 = 0;
+            #[doc = "TRNG can be stopped and entropy is valid if read."]
+            pub const ENT_VAL_1: u32 = 0x01;
+        }
+    }
+    #[doc = "Read only: Frequency Count Fail"]
+    pub mod FRQ_CT_FAIL {
+        pub const offset: u32 = 2;
+        pub const mask: u32 = 0x01 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {
+            #[doc = "No hardware nor self test frequency errors."]
+            pub const FRQ_CT_FAIL_0: u32 = 0;
+            #[doc = "The frequency counter has detected a failure."]
+            pub const FRQ_CT_FAIL_1: u32 = 0x01;
+        }
+    }
+}
+#[doc = "Version ID Register (MS)"]
+pub mod VID1 {
+    #[doc = "Shows the IP's Minor revision of the TRNG."]
+    pub mod MIN_REV {
+        pub const offset: u32 = 0;
+        pub const mask: u32 = 0xff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {
+            #[doc = "Minor revision number for TRNG."]
+            pub const MIN_REV_0: u32 = 0;
+        }
+    }
+    #[doc = "Shows the IP's Major revision of the TRNG."]
+    pub mod MAJ_REV {
+        pub const offset: u32 = 8;
+        pub const mask: u32 = 0xff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {
+            #[doc = "Major revision number for TRNG."]
+            pub const MAJ_REV_1: u32 = 0x01;
+        }
+    }
+    #[doc = "Shows the IP ID."]
+    pub mod IP_ID {
+        pub const offset: u32 = 16;
+        pub const mask: u32 = 0xffff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {
+            #[doc = "ID for TRNG."]
+            pub const IP_ID_48: u32 = 0x30;
+        }
+    }
+}
+#[doc = "Version ID Register (LS)"]
+pub mod VID2 {
+    #[doc = "Shows the IP's Configuaration options for the TRNG."]
+    pub mod CONFIG_OPT {
+        pub const offset: u32 = 0;
+        pub const mask: u32 = 0xff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {
+            #[doc = "TRNG_CONFIG_OPT for TRNG."]
+            pub const CONFIG_OPT_0: u32 = 0;
+        }
+    }
+    #[doc = "Shows the IP's ECO revision of the TRNG."]
+    pub mod ECO_REV {
+        pub const offset: u32 = 8;
+        pub const mask: u32 = 0xff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {
+            #[doc = "TRNG_ECO_REV for TRNG."]
+            pub const ECO_REV_0: u32 = 0;
+        }
+    }
+    #[doc = "Shows the integration options for the TRNG."]
+    pub mod INTG_OPT {
+        pub const offset: u32 = 16;
+        pub const mask: u32 = 0xff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {
+            #[doc = "INTG_OPT for TRNG."]
+            pub const INTG_OPT_0: u32 = 0;
+        }
+    }
+    #[doc = "Shows the compile options for the TRNG."]
+    pub mod ERA {
+        pub const offset: u32 = 24;
+        pub const mask: u32 = 0xff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {
+            #[doc = "COMPILE_OPT for TRNG."]
+            pub const ERA_0: u32 = 0;
+        }
+    }
+}

--- a/src/blocks/imxrt1051/ccm.rs
+++ b/src/blocks/imxrt1051/ccm.rs
@@ -1278,29 +1278,29 @@ pub mod CS1CDR {
             pub const SAI1_CLK_PRED_7: u32 = 0x07;
         }
     }
-    #[doc = "Divider for flexio1 clock."]
-    pub mod FLEXIO1_CLK_PRED {
+    #[doc = "Divider for flexio2 clock."]
+    pub mod FLEXIO2_CLK_PRED {
         pub const offset: u32 = 9;
         pub const mask: u32 = 0x07 << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {
             #[doc = "divide by 1"]
-            pub const FLEXIO1_CLK_PRED_0: u32 = 0;
+            pub const FLEXIO2_CLK_PRED_0: u32 = 0;
             #[doc = "divide by 2"]
-            pub const FLEXIO1_CLK_PRED_1: u32 = 0x01;
+            pub const FLEXIO2_CLK_PRED_1: u32 = 0x01;
             #[doc = "divide by 3"]
-            pub const FLEXIO1_CLK_PRED_2: u32 = 0x02;
+            pub const FLEXIO2_CLK_PRED_2: u32 = 0x02;
             #[doc = "divide by 4"]
-            pub const FLEXIO1_CLK_PRED_3: u32 = 0x03;
+            pub const FLEXIO2_CLK_PRED_3: u32 = 0x03;
             #[doc = "divide by 5"]
-            pub const FLEXIO1_CLK_PRED_4: u32 = 0x04;
+            pub const FLEXIO2_CLK_PRED_4: u32 = 0x04;
             #[doc = "divide by 6"]
-            pub const FLEXIO1_CLK_PRED_5: u32 = 0x05;
+            pub const FLEXIO2_CLK_PRED_5: u32 = 0x05;
             #[doc = "divide by 7"]
-            pub const FLEXIO1_CLK_PRED_6: u32 = 0x06;
+            pub const FLEXIO2_CLK_PRED_6: u32 = 0x06;
             #[doc = "divide by 8"]
-            pub const FLEXIO1_CLK_PRED_7: u32 = 0x07;
+            pub const FLEXIO2_CLK_PRED_7: u32 = 0x07;
         }
     }
     #[doc = "Divider for sai3 clock podf. The input clock to this divider should be lower than 300Mhz, the predivider can be used to achieve this."]
@@ -1465,8 +1465,8 @@ pub mod CS1CDR {
             pub const SAI3_CLK_PRED_7: u32 = 0x07;
         }
     }
-    #[doc = "Divider for flexio1 clock. Divider should be updated when output clock is gated."]
-    pub mod FLEXIO1_CLK_PODF {
+    #[doc = "Divider for flexio2 clock. Divider should be updated when output clock is gated."]
+    pub mod FLEXIO2_CLK_PODF {
         pub const offset: u32 = 25;
         pub const mask: u32 = 0x07 << offset;
         pub mod R {}

--- a/src/blocks/imxrt1051/src.rs
+++ b/src/blocks/imxrt1051/src.rs
@@ -150,7 +150,7 @@ pub mod SRSR {
         }
     }
     #[doc = "Indicates a reset has been caused by CPU lockup."]
-    pub mod LOCKUP {
+    pub mod LOCKUP_SYSRESETREQ {
         pub const offset: u32 = 1;
         pub const mask: u32 = 0x01 << offset;
         pub mod R {}

--- a/src/blocks/imxrt1061/ccm.rs
+++ b/src/blocks/imxrt1061/ccm.rs
@@ -1321,29 +1321,29 @@ pub mod CS1CDR {
             pub const SAI1_CLK_PRED_7: u32 = 0x07;
         }
     }
-    #[doc = "Divider for flexio1 clock."]
-    pub mod FLEXIO1_CLK_PRED {
+    #[doc = "Divider for flexio2 clock."]
+    pub mod FLEXIO2_CLK_PRED {
         pub const offset: u32 = 9;
         pub const mask: u32 = 0x07 << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {
             #[doc = "divide by 1"]
-            pub const FLEXIO1_CLK_PRED_0: u32 = 0;
+            pub const FLEXIO2_CLK_PRED_0: u32 = 0;
             #[doc = "divide by 2"]
-            pub const FLEXIO1_CLK_PRED_1: u32 = 0x01;
+            pub const FLEXIO2_CLK_PRED_1: u32 = 0x01;
             #[doc = "divide by 3"]
-            pub const FLEXIO1_CLK_PRED_2: u32 = 0x02;
+            pub const FLEXIO2_CLK_PRED_2: u32 = 0x02;
             #[doc = "divide by 4"]
-            pub const FLEXIO1_CLK_PRED_3: u32 = 0x03;
+            pub const FLEXIO2_CLK_PRED_3: u32 = 0x03;
             #[doc = "divide by 5"]
-            pub const FLEXIO1_CLK_PRED_4: u32 = 0x04;
+            pub const FLEXIO2_CLK_PRED_4: u32 = 0x04;
             #[doc = "divide by 6"]
-            pub const FLEXIO1_CLK_PRED_5: u32 = 0x05;
+            pub const FLEXIO2_CLK_PRED_5: u32 = 0x05;
             #[doc = "divide by 7"]
-            pub const FLEXIO1_CLK_PRED_6: u32 = 0x06;
+            pub const FLEXIO2_CLK_PRED_6: u32 = 0x06;
             #[doc = "divide by 8"]
-            pub const FLEXIO1_CLK_PRED_7: u32 = 0x07;
+            pub const FLEXIO2_CLK_PRED_7: u32 = 0x07;
         }
     }
     #[doc = "Divider for sai3 clock podf. The input clock to this divider should be lower than 300Mhz, the predivider can be used to achieve this."]
@@ -1508,8 +1508,8 @@ pub mod CS1CDR {
             pub const SAI3_CLK_PRED_7: u32 = 0x07;
         }
     }
-    #[doc = "Divider for flexio1 clock. Divider should be updated when output clock is gated."]
-    pub mod FLEXIO1_CLK_PODF {
+    #[doc = "Divider for flexio2 clock. Divider should be updated when output clock is gated."]
+    pub mod FLEXIO2_CLK_PODF {
         pub const offset: u32 = 25;
         pub const mask: u32 = 0x07 << offset;
         pub mod R {}

--- a/src/blocks/imxrt1061/iomuxc_gpr.rs
+++ b/src/blocks/imxrt1061/iomuxc_gpr.rs
@@ -3794,8 +3794,8 @@ pub mod GPR25 {
 }
 #[doc = "GPR26 General Purpose Register"]
 pub mod GPR26 {
-    #[doc = "Select GPIO1 or GPIO2"]
-    pub mod GPIO_SEL {
+    #[doc = "GPIO1 and GPIO6 share same IO MUX function, GPIO_MUX1 selects one GPIO function."]
+    pub mod GPIO_MUX1_GPIO_SEL {
         pub const offset: u32 = 0;
         pub const mask: u32 = 0xffff_ffff << offset;
         pub mod R {}

--- a/src/blocks/imxrt1176_cm4/snvs.rs
+++ b/src/blocks/imxrt1176_cm4/snvs.rs
@@ -1433,8 +1433,8 @@ pub mod LPCR {
             pub const TOP_1: u32 = 0x01;
         }
     }
-    #[doc = "Power Glitch Enable By default the detection of a power glitch does not cause the pmic_en_b signal to be asserted"]
-    pub mod PWR_GLITCH_EN {
+    #[doc = "Digital Low-Voltage Event Enable By default the detection of a low-voltage event does not cause the pmic_en_b signal to be asserted"]
+    pub mod LVD_EN {
         pub const offset: u32 = 7;
         pub const mask: u32 = 0x01 << offset;
         pub mod R {}

--- a/src/imxrt1015.rs
+++ b/src/imxrt1015.rs
@@ -1871,7 +1871,7 @@ pub mod tmr1 {
 pub mod trng {
     #[doc = "TRNG"]
     pub const TRNG: *const RegisterBlock = 0x400c_c000 as *const RegisterBlock;
-    #[path = "blocks/imxrt1011/trng.rs"]
+    #[path = "blocks/imxrt1015/trng.rs"]
     mod blocks;
     pub use blocks::*;
     pub type Instance<const N: u8> = crate::Instance<RegisterBlock, N>;

--- a/src/imxrt1021.rs
+++ b/src/imxrt1021.rs
@@ -2355,7 +2355,7 @@ pub mod tmr {
 pub mod trng {
     #[doc = "TRNG"]
     pub const TRNG: *const RegisterBlock = 0x400c_c000 as *const RegisterBlock;
-    #[path = "blocks/imxrt1011/trng.rs"]
+    #[path = "blocks/imxrt1015/trng.rs"]
     mod blocks;
     pub use blocks::*;
     pub type Instance<const N: u8> = crate::Instance<RegisterBlock, N>;


### PR DESCRIPTION
Omitting checks for fieldset names allowed the combine pass to eagerly merge fieldsets it believed were equivalent. Consider the LPI2C.SIER register. On the 1000 series, the "address match 1 interrupt enable" field is called "AM1IE." And on the 1100 series, the same field is called "AM1F." Same meaning, but a different name. By eagerly combining, we have no need to generate another `lpi2c.rs` file, and we have 1675 fewer lines of code.

The assumption fails when that name difference is meaningful, like when NXP changes the CCM.CS1CDR field at offset 25 from FLEXIO1_CLK_PODF to FLEXIO2_CLK_PODF. Those aren't equivalent fields, but we don't know that because we're not checking the field name.

It's always correct to not combine. And turns out it's not adding too much code; we can patch the small name corrections like the LPI2C example.

This PR ensures the combiner always equates fieldset names. It also adds raltool patches to rename specific fieldsets that truly should have the same name. The PR corrects the concrete case identified in #32, but it does not fully address the greediness problem. See individual commits for more information and to simplify review.