### PR TITLE
Add combiner configurations, strict enum checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ and correct the documentation.
 **BREAKING** Correct the name, documentation of the SNVS.LPCR field "LVD_EN" on
 the 1176.
 
+**BREAKING** Correct the symbols for most IOMUXC `*SELECT_INPUT*` enum variants.
+As a result of this change, symbols for IOMUXC `SW_MUX_CTL*` and `*SW_PAD_CTL*`
+enum variants may have also changed.
+
 Add missing register fields:
 
 - SERCLKDIV in FlexSPI MCR0.

--- a/raltool-cfg.yaml
+++ b/raltool-cfg.yaml
@@ -162,3 +162,28 @@ transforms:
       fieldset: src::regs::Srsr
       from: LOCKUP
       to: LOCKUP_SYSRESETREQ
+
+# Settings for the combine pass.
+combines:
+  # By default, the combiner will claim that field's enums are equivalent if their
+  # plurality, bit size, and values are the same. It does not consider the enum name.
+  # Once they're deemed equivalent, the combiner is allowed to consolidate these enums
+  # across all fields and devices. This default behavior lets us consolidate enum variants
+  # that are written like "OFF / ON" in one SVD, and "DISABLED / ENABLED" in another SVD.
+  # Those variants have the same meaning, so it makes sense to combine these differences.
+  #
+  # This behavior isn't always appropriate. For example, an IOMUXC field LPSPI1_SCK_SELECT_INPUT
+  # on the 1021 might have enum variants named GPIO_SD_B0_02_ALT4 and GPIO_AD_B0_10_ALT1.
+  # The same field on the 1011 might have enum variants named GPIO_AD_06_ALT0 and
+  # GPIO_SD_08_ALT2 with the same respective values. If the combiner does not check
+  # the names, its allowed to replace the 1021 enum variants with the 1011 names. That's
+  # confusing and misleading. So in cases where this behavior shouldn't happen, we add
+  # those peripherals to this list, and we force the combiner to consider the enum variant
+  # names.
+  #
+  # It's always safe to add to this list. By adding peripherals to this list, you make it harder
+  # to develop drivers that work across all MCUs.
+  - StrictEnumNames:
+    - iomuxc
+    - iomuxc_gpr
+    - iomuxc_snvs

--- a/raltool/src/main.rs
+++ b/raltool/src/main.rs
@@ -202,7 +202,7 @@ fn gen(mut args: Generate) -> Result<()> {
         weak_syms: true,
     };
 
-    let combination = combine::combine(&irs);
+    let combination = combine::combine(&irs, &config.combines.into());
     generate::render(&combination, &generate_opts)?;
 
     Ok(())
@@ -343,6 +343,7 @@ fn gen_block(args: GenBlock) -> Result<()> {
 #[derive(serde::Serialize, serde::Deserialize, Default)]
 struct Config {
     transforms: Vec<raltool::transform::Transform>,
+    combines: Vec<raltool::combine::Combine>,
 }
 
 // ==============

--- a/src/blocks/imxrt1015/iomuxc_snvs.rs
+++ b/src/blocks/imxrt1015/iomuxc_snvs.rs
@@ -68,8 +68,8 @@ pub mod SW_PAD_CTL_PAD_TEST_MODE {
         pub mod RW {
             #[doc = "output driver disabled;"]
             pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
-            #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            #[doc = "R0(260 Ohm @ 3.3V, 150 Ohm@1.8V, 240 Ohm for DDR)"]
+            pub const DSE_1_R0_260_OHM___3_3V__150_OHM_1_8V__240_OHM_FOR_DDR_: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -189,8 +189,8 @@ pub mod SW_PAD_CTL_PAD_POR_B {
         pub mod RW {
             #[doc = "output driver disabled;"]
             pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
-            #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            #[doc = "R0(260 Ohm @ 3.3V, 150 Ohm@1.8V, 240 Ohm for DDR)"]
+            pub const DSE_1_R0_260_OHM___3_3V__150_OHM_1_8V__240_OHM_FOR_DDR_: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -310,8 +310,8 @@ pub mod SW_PAD_CTL_PAD_ONOFF {
         pub mod RW {
             #[doc = "output driver disabled;"]
             pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
-            #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            #[doc = "R0(260 Ohm @ 3.3V, 150 Ohm@1.8V, 240 Ohm for DDR)"]
+            pub const DSE_1_R0_260_OHM___3_3V__150_OHM_1_8V__240_OHM_FOR_DDR_: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -431,8 +431,8 @@ pub mod SW_PAD_CTL_PAD_PMIC_ON_REQ {
         pub mod RW {
             #[doc = "output driver disabled;"]
             pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
-            #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            #[doc = "R0(260 Ohm @ 3.3V, 150 Ohm@1.8V, 240 Ohm for DDR)"]
+            pub const DSE_1_R0_260_OHM___3_3V__150_OHM_1_8V__240_OHM_FOR_DDR_: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]

--- a/src/blocks/imxrt1021/iomuxc.rs
+++ b/src/blocks/imxrt1021/iomuxc.rs
@@ -16720,10 +16720,10 @@ pub mod LPSPI1_SCK_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_06 for Mode: ALT0"]
-            pub const GPIO_AD_06_ALT0: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_SD_08 for Mode: ALT2"]
-            pub const GPIO_SD_08_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B0_02 for Mode: ALT4"]
+            pub const GPIO_SD_B0_02_ALT4: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_10 for Mode: ALT1"]
+            pub const GPIO_AD_B0_10_ALT1: u32 = 0x01;
         }
     }
 }
@@ -16736,10 +16736,10 @@ pub mod LPSPI1_SDI_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_03 for Mode: ALT0"]
-            pub const GPIO_AD_03_ALT0: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_SD_05 for Mode: ALT2"]
-            pub const GPIO_SD_05_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B0_05 for Mode: ALT4"]
+            pub const GPIO_SD_B0_05_ALT4: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_13 for Mode: ALT1"]
+            pub const GPIO_AD_B0_13_ALT1: u32 = 0x01;
         }
     }
 }
@@ -16752,10 +16752,10 @@ pub mod LPSPI1_SDO_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_04 for Mode: ALT0"]
-            pub const GPIO_AD_04_ALT0: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_SD_06 for Mode: ALT2"]
-            pub const GPIO_SD_06_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B0_04 for Mode: ALT4"]
+            pub const GPIO_SD_B0_04_ALT4: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_12 for Mode: ALT1"]
+            pub const GPIO_AD_B0_12_ALT1: u32 = 0x01;
         }
     }
 }

--- a/src/blocks/imxrt1021/iomuxc_snvs.rs
+++ b/src/blocks/imxrt1021/iomuxc_snvs.rs
@@ -131,8 +131,8 @@ pub mod SW_PAD_CTL_PAD_TEST_MODE {
         pub mod RW {
             #[doc = "output driver disabled;"]
             pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
-            #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            #[doc = "R0(260 Ohm @ 3.3V, 150 Ohm@1.8V, 240 Ohm for DDR)"]
+            pub const DSE_1_R0_260_OHM___3_3V__150_OHM_1_8V__240_OHM_FOR_DDR_: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -252,8 +252,8 @@ pub mod SW_PAD_CTL_PAD_POR_B {
         pub mod RW {
             #[doc = "output driver disabled;"]
             pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
-            #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            #[doc = "R0(260 Ohm @ 3.3V, 150 Ohm@1.8V, 240 Ohm for DDR)"]
+            pub const DSE_1_R0_260_OHM___3_3V__150_OHM_1_8V__240_OHM_FOR_DDR_: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -373,8 +373,8 @@ pub mod SW_PAD_CTL_PAD_ONOFF {
         pub mod RW {
             #[doc = "output driver disabled;"]
             pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
-            #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            #[doc = "R0(260 Ohm @ 3.3V, 150 Ohm@1.8V, 240 Ohm for DDR)"]
+            pub const DSE_1_R0_260_OHM___3_3V__150_OHM_1_8V__240_OHM_FOR_DDR_: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -615,8 +615,8 @@ pub mod SW_PAD_CTL_PAD_PMIC_ON_REQ {
         pub mod RW {
             #[doc = "output driver disabled;"]
             pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
-            #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            #[doc = "R0(260 Ohm @ 3.3V, 150 Ohm@1.8V, 240 Ohm for DDR)"]
+            pub const DSE_1_R0_260_OHM___3_3V__150_OHM_1_8V__240_OHM_FOR_DDR_: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]

--- a/src/blocks/imxrt1051/iomuxc.rs
+++ b/src/blocks/imxrt1051/iomuxc.rs
@@ -5632,9 +5632,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_00 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -5657,13 +5657,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_00 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -5759,9 +5759,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_01 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -5784,13 +5784,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_01 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -5886,9 +5886,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_02 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -5911,13 +5911,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_02 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -6013,9 +6013,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_03 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -6038,13 +6038,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_03 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -6140,9 +6140,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_04 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -6165,13 +6165,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_04 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -6267,9 +6267,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_05 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -6292,13 +6292,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_05 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -6394,9 +6394,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_06 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -6419,13 +6419,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_06 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -6521,9 +6521,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_07 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -6546,13 +6546,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_07 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -6648,9 +6648,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_08 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -6673,13 +6673,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_08 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -6775,9 +6775,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_09 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -6800,13 +6800,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_09 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -6902,9 +6902,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_10 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -6927,13 +6927,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_10 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -7029,9 +7029,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_11 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -7054,13 +7054,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_11 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -7156,9 +7156,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_12 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -7181,13 +7181,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_12 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -7283,9 +7283,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_13 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -7308,13 +7308,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_13 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -7410,9 +7410,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_14 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -7435,13 +7435,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_14 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -7537,9 +7537,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_15 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -7562,13 +7562,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_15 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -7664,9 +7664,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_16 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -7689,13 +7689,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_16 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -7791,9 +7791,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_17 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -7816,13 +7816,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_17 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -7918,9 +7918,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_18 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -7943,13 +7943,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_18 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -8045,9 +8045,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_19 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -8070,13 +8070,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_19 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -8172,9 +8172,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_20 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -8197,13 +8197,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_20 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -8299,9 +8299,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_21 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -8324,13 +8324,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_21 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -8426,9 +8426,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_22 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -8451,13 +8451,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_22 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -8553,9 +8553,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_23 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -8578,13 +8578,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_23 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -8680,9 +8680,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_24 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -8705,13 +8705,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_24 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -8807,9 +8807,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_25 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -8832,13 +8832,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_25 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -8934,9 +8934,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_26 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -8959,13 +8959,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_26 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -9061,9 +9061,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_27 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -9086,13 +9086,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_27 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -9188,9 +9188,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_28 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -9213,13 +9213,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_28 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -9315,9 +9315,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_29 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -9340,13 +9340,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_29 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -9442,9 +9442,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_30 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -9467,13 +9467,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_30 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -9569,9 +9569,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_31 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -9594,13 +9594,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_31 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -9696,9 +9696,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_32 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -9721,13 +9721,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_32 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -9823,9 +9823,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_33 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -9848,13 +9848,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_33 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -9950,9 +9950,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_34 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -9975,13 +9975,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_34 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -10077,9 +10077,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_35 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -10102,13 +10102,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_35 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -10204,9 +10204,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_36 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -10229,13 +10229,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_36 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -10331,9 +10331,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_37 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -10356,13 +10356,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_37 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -10458,9 +10458,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_38 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -10483,13 +10483,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_38 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -10585,9 +10585,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_39 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -10610,13 +10610,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_39 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -10712,9 +10712,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_40 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -10737,13 +10737,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_40 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -10839,9 +10839,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_41 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -10864,13 +10864,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_41 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -10966,9 +10966,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_00 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -10991,13 +10991,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_00 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -11093,9 +11093,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_01 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -11118,13 +11118,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_01 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -11220,9 +11220,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_02 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -11245,13 +11245,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_02 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -11347,9 +11347,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_03 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -11372,13 +11372,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_03 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -11474,9 +11474,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_04 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -11499,13 +11499,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_04 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -11601,9 +11601,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_05 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -11626,13 +11626,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_05 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -11728,9 +11728,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_06 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -11753,13 +11753,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_06 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -11855,9 +11855,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_07 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -11880,13 +11880,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_07 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -11982,9 +11982,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_08 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -12007,13 +12007,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_08 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -12109,9 +12109,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_09 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -12134,13 +12134,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_09 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -12236,9 +12236,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_10 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -12261,13 +12261,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_10 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -12363,9 +12363,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_11 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -12388,13 +12388,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_11 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -12490,9 +12490,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_12 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -12515,13 +12515,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_12 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -12617,9 +12617,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_13 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -12642,13 +12642,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_13 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -12744,9 +12744,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_14 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -12769,13 +12769,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_14 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -12871,9 +12871,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_15 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -12896,13 +12896,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_15 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -12998,9 +12998,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_00 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -13023,13 +13023,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_00 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -13125,9 +13125,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_01 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -13150,13 +13150,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_01 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -13252,9 +13252,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_02 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -13277,13 +13277,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_02 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -13379,9 +13379,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_03 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -13404,13 +13404,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_03 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -13506,9 +13506,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_04 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -13531,13 +13531,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_04 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -13633,9 +13633,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_05 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -13658,13 +13658,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_05 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -13760,9 +13760,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_06 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -13785,13 +13785,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_06 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -13887,9 +13887,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_07 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -13912,13 +13912,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_07 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -14014,9 +14014,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_08 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -14039,13 +14039,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_08 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -14141,9 +14141,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_09 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -14166,13 +14166,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_09 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -14268,9 +14268,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_10 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -14293,13 +14293,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_10 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -14395,9 +14395,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_11 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -14420,13 +14420,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_11 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -14522,9 +14522,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_12 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -14547,13 +14547,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_12 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -14649,9 +14649,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_13 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -14674,13 +14674,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_13 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -14776,9 +14776,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_14 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -14801,13 +14801,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_14 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -14903,9 +14903,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_15 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -14928,13 +14928,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_15 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -19094,9 +19094,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B0_00 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -19119,13 +19119,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B0_00 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -19221,9 +19221,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B0_01 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -19246,13 +19246,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B0_01 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -19348,9 +19348,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B0_02 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -19373,13 +19373,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B0_02 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -19475,9 +19475,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B0_03 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -19500,13 +19500,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B0_03 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -19602,9 +19602,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B0_04 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -19627,13 +19627,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B0_04 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -19729,9 +19729,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B0_05 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -19754,13 +19754,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B0_05 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -19856,9 +19856,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_00 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -19881,13 +19881,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_00 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -19983,9 +19983,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_01 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -20008,13 +20008,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_01 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -20110,9 +20110,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_02 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -20135,13 +20135,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_02 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -20237,9 +20237,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_03 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -20262,13 +20262,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_03 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -20364,9 +20364,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_04 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -20389,13 +20389,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_04 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -20491,9 +20491,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_05 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -20516,13 +20516,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_05 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -20618,9 +20618,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_06 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -20643,13 +20643,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_06 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -20745,9 +20745,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_07 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -20770,13 +20770,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_07 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -20872,9 +20872,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_08 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -20897,13 +20897,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_08 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -20999,9 +20999,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_09 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -21024,13 +21024,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_09 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -21126,9 +21126,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_10 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -21151,13 +21151,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_10 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -21253,9 +21253,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_11 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -21278,13 +21278,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_11 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -21616,12 +21616,12 @@ pub mod ENET_MDIO_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B0_02 for Mode: ALT6"]
-            pub const GPIO_SD_B0_02_ALT6: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_AD_B0_04 for Mode: ALT4"]
-            pub const GPIO_AD_B0_04_ALT4: u32 = 0x01;
-            #[doc = "Selecting Pad: GPIO_EMC_40 for Mode: ALT4"]
-            pub const GPIO_EMC_40_ALT4: u32 = 0x02;
+            #[doc = "Selecting Pad: GPIO_AD_B1_05 for Mode: ALT1"]
+            pub const GPIO_AD_B1_05_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_EMC_41 for Mode: ALT4"]
+            pub const GPIO_EMC_41_ALT4: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_B1_15 for Mode: ALT0"]
+            pub const GPIO_B1_15_ALT0: u32 = 0x02;
         }
     }
 }
@@ -21732,14 +21732,14 @@ pub mod FLEXCAN1_RX_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_01 for Mode: ALT6"]
-            pub const GPIO_EMC_01_ALT6: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_SD_B1_01 for Mode: ALT4"]
-            pub const GPIO_SD_B1_01_ALT4: u32 = 0x01;
-            #[doc = "Selecting Pad: GPIO_AD_B0_05 for Mode: ALT1"]
-            pub const GPIO_AD_B0_05_ALT1: u32 = 0x02;
-            #[doc = "Selecting Pad: GPIO_EMC_15 for Mode: ALT6"]
-            pub const GPIO_EMC_15_ALT6: u32 = 0x03;
+            #[doc = "Selecting Pad: GPIO_SD_B1_03 for Mode: ALT4"]
+            pub const GPIO_SD_B1_03_ALT4: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_EMC_18 for Mode: ALT3"]
+            pub const GPIO_EMC_18_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_AD_B1_09 for Mode: ALT2"]
+            pub const GPIO_AD_B1_09_ALT2: u32 = 0x02;
+            #[doc = "Selecting Pad: GPIO_B0_03 for Mode: ALT2"]
+            pub const GPIO_B0_03_ALT2: u32 = 0x03;
         }
     }
 }
@@ -21752,14 +21752,14 @@ pub mod FLEXCAN2_RX_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B0_05 for Mode: ALT1"]
-            pub const GPIO_SD_B0_05_ALT1: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_09 for Mode: ALT2"]
-            pub const GPIO_EMC_09_ALT2: u32 = 0x01;
-            #[doc = "Selecting Pad: GPIO_AD_B0_15 for Mode: ALT1"]
-            pub const GPIO_AD_B0_15_ALT1: u32 = 0x02;
-            #[doc = "Selecting Pad: GPIO_AD_B1_01 for Mode: ALT2"]
-            pub const GPIO_AD_B1_01_ALT2: u32 = 0x03;
+            #[doc = "Selecting Pad: GPIO_EMC_10 for Mode: ALT3"]
+            pub const GPIO_EMC_10_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_03 for Mode: ALT0"]
+            pub const GPIO_AD_B0_03_ALT0: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_AD_B0_15 for Mode: ALT6"]
+            pub const GPIO_AD_B0_15_ALT6: u32 = 0x02;
+            #[doc = "Selecting Pad: GPIO_B1_09 for Mode: ALT6"]
+            pub const GPIO_B1_09_ALT6: u32 = 0x03;
         }
     }
 }
@@ -21794,10 +21794,10 @@ pub mod FLEXPWM1_PWMA0_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_06 for Mode: ALT1"]
-            pub const GPIO_AD_B1_06_ALT1: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_26 for Mode: ALT1"]
-            pub const GPIO_EMC_26_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_23 for Mode: ALT1"]
+            pub const GPIO_EMC_23_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_SD_B0_00 for Mode: ALT1"]
+            pub const GPIO_SD_B0_00_ALT1: u32 = 0x01;
         }
     }
 }
@@ -21810,10 +21810,10 @@ pub mod FLEXPWM1_PWMA1_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_08 for Mode: ALT1"]
-            pub const GPIO_AD_B1_08_ALT1: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_24 for Mode: ALT1"]
-            pub const GPIO_EMC_24_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_25 for Mode: ALT1"]
+            pub const GPIO_EMC_25_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_SD_B0_02 for Mode: ALT1"]
+            pub const GPIO_SD_B0_02_ALT1: u32 = 0x01;
         }
     }
 }
@@ -21826,10 +21826,10 @@ pub mod FLEXPWM1_PWMA2_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_10 for Mode: ALT1"]
-            pub const GPIO_AD_B1_10_ALT1: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_22 for Mode: ALT1"]
-            pub const GPIO_EMC_22_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_27 for Mode: ALT1"]
+            pub const GPIO_EMC_27_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_SD_B0_04 for Mode: ALT1"]
+            pub const GPIO_SD_B0_04_ALT1: u32 = 0x01;
         }
     }
 }
@@ -21864,10 +21864,10 @@ pub mod FLEXPWM1_PWMB0_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_07 for Mode: ALT1"]
-            pub const GPIO_AD_B1_07_ALT1: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_27 for Mode: ALT1"]
-            pub const GPIO_EMC_27_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_24 for Mode: ALT1"]
+            pub const GPIO_EMC_24_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_SD_B0_01 for Mode: ALT1"]
+            pub const GPIO_SD_B0_01_ALT1: u32 = 0x01;
         }
     }
 }
@@ -21880,10 +21880,10 @@ pub mod FLEXPWM1_PWMB1_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_09 for Mode: ALT1"]
-            pub const GPIO_AD_B1_09_ALT1: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_25 for Mode: ALT1"]
-            pub const GPIO_EMC_25_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_26 for Mode: ALT1"]
+            pub const GPIO_EMC_26_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_SD_B0_03 for Mode: ALT1"]
+            pub const GPIO_SD_B0_03_ALT1: u32 = 0x01;
         }
     }
 }
@@ -21896,10 +21896,10 @@ pub mod FLEXPWM1_PWMB2_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_11 for Mode: ALT1"]
-            pub const GPIO_AD_B1_11_ALT1: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_23 for Mode: ALT1"]
-            pub const GPIO_EMC_23_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_28 for Mode: ALT1"]
+            pub const GPIO_EMC_28_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_SD_B0_05 for Mode: ALT1"]
+            pub const GPIO_SD_B0_05_ALT1: u32 = 0x01;
         }
     }
 }
@@ -21934,10 +21934,10 @@ pub mod FLEXPWM2_PWMA0_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B0_14 for Mode: ALT4"]
-            pub const GPIO_AD_B0_14_ALT4: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_38 for Mode: ALT1"]
-            pub const GPIO_EMC_38_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_06 for Mode: ALT1"]
+            pub const GPIO_EMC_06_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B0_06 for Mode: ALT2"]
+            pub const GPIO_B0_06_ALT2: u32 = 0x01;
         }
     }
 }
@@ -21950,10 +21950,10 @@ pub mod FLEXPWM2_PWMA1_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B0_12 for Mode: ALT4"]
-            pub const GPIO_AD_B0_12_ALT4: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_36 for Mode: ALT1"]
-            pub const GPIO_EMC_36_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_08 for Mode: ALT1"]
+            pub const GPIO_EMC_08_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B0_08 for Mode: ALT2"]
+            pub const GPIO_B0_08_ALT2: u32 = 0x01;
         }
     }
 }
@@ -21966,10 +21966,10 @@ pub mod FLEXPWM2_PWMA2_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B0_10 for Mode: ALT4"]
-            pub const GPIO_AD_B0_10_ALT4: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_30 for Mode: ALT1"]
-            pub const GPIO_EMC_30_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_10 for Mode: ALT1"]
+            pub const GPIO_EMC_10_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B0_10 for Mode: ALT2"]
+            pub const GPIO_B0_10_ALT2: u32 = 0x01;
         }
     }
 }
@@ -22002,10 +22002,10 @@ pub mod FLEXPWM2_PWMB0_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B0_15 for Mode: ALT4"]
-            pub const GPIO_AD_B0_15_ALT4: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_39 for Mode: ALT1"]
-            pub const GPIO_EMC_39_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_07 for Mode: ALT1"]
+            pub const GPIO_EMC_07_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B0_07 for Mode: ALT2"]
+            pub const GPIO_B0_07_ALT2: u32 = 0x01;
         }
     }
 }
@@ -22018,10 +22018,10 @@ pub mod FLEXPWM2_PWMB1_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B0_13 for Mode: ALT4"]
-            pub const GPIO_AD_B0_13_ALT4: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_37 for Mode: ALT1"]
-            pub const GPIO_EMC_37_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_09 for Mode: ALT1"]
+            pub const GPIO_EMC_09_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B0_09 for Mode: ALT2"]
+            pub const GPIO_B0_09_ALT2: u32 = 0x01;
         }
     }
 }
@@ -22034,10 +22034,10 @@ pub mod FLEXPWM2_PWMB2_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B0_11 for Mode: ALT4"]
-            pub const GPIO_AD_B0_11_ALT4: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_31 for Mode: ALT1"]
-            pub const GPIO_EMC_31_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_11 for Mode: ALT1"]
+            pub const GPIO_EMC_11_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B0_11 for Mode: ALT2"]
+            pub const GPIO_B0_11_ALT2: u32 = 0x01;
         }
     }
 }
@@ -22274,10 +22274,10 @@ pub mod LPI2C1_SCL_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_02 for Mode: ALT6"]
-            pub const GPIO_EMC_02_ALT6: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_AD_B1_14 for Mode: ALT0"]
-            pub const GPIO_AD_B1_14_ALT0: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B1_04 for Mode: ALT2"]
+            pub const GPIO_SD_B1_04_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B1_00 for Mode: ALT3"]
+            pub const GPIO_AD_B1_00_ALT3: u32 = 0x01;
         }
     }
 }
@@ -22290,10 +22290,10 @@ pub mod LPI2C1_SDA_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_03 for Mode: ALT6"]
-            pub const GPIO_EMC_03_ALT6: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_AD_B1_15 for Mode: ALT0"]
-            pub const GPIO_AD_B1_15_ALT0: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B1_05 for Mode: ALT2"]
+            pub const GPIO_SD_B1_05_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B1_01 for Mode: ALT3"]
+            pub const GPIO_AD_B1_01_ALT3: u32 = 0x01;
         }
     }
 }
@@ -22306,10 +22306,10 @@ pub mod LPI2C2_SCL_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_08 for Mode: ALT0"]
-            pub const GPIO_AD_B1_08_ALT0: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_19 for Mode: ALT2"]
-            pub const GPIO_EMC_19_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B1_11 for Mode: ALT3"]
+            pub const GPIO_SD_B1_11_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B0_04 for Mode: ALT2"]
+            pub const GPIO_B0_04_ALT2: u32 = 0x01;
         }
     }
 }
@@ -22322,10 +22322,10 @@ pub mod LPI2C2_SDA_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_09 for Mode: ALT0"]
-            pub const GPIO_AD_B1_09_ALT0: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_18 for Mode: ALT2"]
-            pub const GPIO_EMC_18_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B1_10 for Mode: ALT3"]
+            pub const GPIO_SD_B1_10_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B0_05 for Mode: ALT2"]
+            pub const GPIO_B0_05_ALT2: u32 = 0x01;
         }
     }
 }
@@ -22374,10 +22374,10 @@ pub mod LPI2C4_SCL_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_11 for Mode: ALT2"]
-            pub const GPIO_EMC_11_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_SD_B1_02 for Mode: ALT3"]
-            pub const GPIO_SD_B1_02_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_12 for Mode: ALT2"]
+            pub const GPIO_EMC_12_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_12 for Mode: ALT0"]
+            pub const GPIO_AD_B0_12_ALT0: u32 = 0x01;
         }
     }
 }
@@ -22390,10 +22390,10 @@ pub mod LPI2C4_SDA_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_10 for Mode: ALT2"]
-            pub const GPIO_EMC_10_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_SD_B1_03 for Mode: ALT3"]
-            pub const GPIO_SD_B1_03_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_11 for Mode: ALT2"]
+            pub const GPIO_EMC_11_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_13 for Mode: ALT0"]
+            pub const GPIO_AD_B0_13_ALT0: u32 = 0x01;
         }
     }
 }
@@ -22406,10 +22406,10 @@ pub mod LPSPI1_PCS0_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B0_03 for Mode: ALT4"]
-            pub const GPIO_SD_B0_03_ALT4: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_AD_B0_11 for Mode: ALT1"]
-            pub const GPIO_AD_B0_11_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B0_01 for Mode: ALT4"]
+            pub const GPIO_SD_B0_01_ALT4: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_EMC_30 for Mode: ALT3"]
+            pub const GPIO_EMC_30_ALT3: u32 = 0x01;
         }
     }
 }
@@ -22422,10 +22422,10 @@ pub mod LPSPI1_SCK_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_06 for Mode: ALT0"]
-            pub const GPIO_AD_06_ALT0: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_SD_08 for Mode: ALT2"]
-            pub const GPIO_SD_08_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_27 for Mode: ALT3"]
+            pub const GPIO_EMC_27_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_SD_B0_00 for Mode: ALT4"]
+            pub const GPIO_SD_B0_00_ALT4: u32 = 0x01;
         }
     }
 }
@@ -22438,10 +22438,10 @@ pub mod LPSPI1_SDI_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_03 for Mode: ALT0"]
-            pub const GPIO_AD_03_ALT0: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_SD_05 for Mode: ALT2"]
-            pub const GPIO_SD_05_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_29 for Mode: ALT3"]
+            pub const GPIO_EMC_29_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_03 for Mode: ALT4"]
+            pub const GPIO_SD_B0_03_ALT4: u32 = 0x01;
         }
     }
 }
@@ -22454,10 +22454,10 @@ pub mod LPSPI1_SDO_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_04 for Mode: ALT0"]
-            pub const GPIO_AD_04_ALT0: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_SD_06 for Mode: ALT2"]
-            pub const GPIO_SD_06_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_28 for Mode: ALT3"]
+            pub const GPIO_EMC_28_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_SD_B0_02 for Mode: ALT4"]
+            pub const GPIO_SD_B0_02_ALT4: u32 = 0x01;
         }
     }
 }
@@ -22486,10 +22486,10 @@ pub mod LPSPI2_SCK_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_12 for Mode: ALT0"]
-            pub const GPIO_AD_12_ALT0: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_SD_11 for Mode: ALT1"]
-            pub const GPIO_SD_11_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B1_07 for Mode: ALT4"]
+            pub const GPIO_SD_B1_07_ALT4: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_EMC_00 for Mode: ALT2"]
+            pub const GPIO_EMC_00_ALT2: u32 = 0x01;
         }
     }
 }
@@ -22502,10 +22502,10 @@ pub mod LPSPI2_SDI_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_09 for Mode: ALT0"]
-            pub const GPIO_AD_09_ALT0: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_SD_09 for Mode: ALT1"]
-            pub const GPIO_SD_09_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B1_09 for Mode: ALT4"]
+            pub const GPIO_SD_B1_09_ALT4: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_EMC_03 for Mode: ALT2"]
+            pub const GPIO_EMC_03_ALT2: u32 = 0x01;
         }
     }
 }
@@ -22518,10 +22518,10 @@ pub mod LPSPI2_SDO_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_10 for Mode: ALT0"]
-            pub const GPIO_AD_10_ALT0: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_SD_10 for Mode: ALT1"]
-            pub const GPIO_SD_10_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B1_08 for Mode: ALT4"]
+            pub const GPIO_SD_B1_08_ALT4: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_EMC_02 for Mode: ALT2"]
+            pub const GPIO_EMC_02_ALT2: u32 = 0x01;
         }
     }
 }
@@ -22598,10 +22598,10 @@ pub mod LPSPI4_PCS0_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_03 for Mode: ALT2"]
-            pub const GPIO_AD_B1_03_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_33 for Mode: ALT4"]
-            pub const GPIO_EMC_33_ALT4: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_B0_00 for Mode: ALT3"]
+            pub const GPIO_B0_00_ALT3: u32 = 0;
+            #[doc = "Selecting Pad:GPIO_B1_04 for Mode: ALT1"]
+            pub const GPIO_B1_04_ALT1: u32 = 0x01;
         }
     }
 }
@@ -22614,10 +22614,10 @@ pub mod LPSPI4_SCK_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_02 for Mode: ALT2"]
-            pub const GPIO_AD_B1_02_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_32 for Mode: ALT4"]
-            pub const GPIO_EMC_32_ALT4: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_B0_03 for Mode: ALT3"]
+            pub const GPIO_B0_03_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B1_07 for Mode: ALT1"]
+            pub const GPIO_B1_07_ALT1: u32 = 0x01;
         }
     }
 }
@@ -22630,10 +22630,10 @@ pub mod LPSPI4_SDI_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_05 for Mode: ALT2"]
-            pub const GPIO_AD_B1_05_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_35 for Mode: ALT4"]
-            pub const GPIO_EMC_35_ALT4: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_B0_01 for Mode: ALT3"]
+            pub const GPIO_B0_01_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B1_05 for Mode: ALT1"]
+            pub const GPIO_B1_05_ALT1: u32 = 0x01;
         }
     }
 }
@@ -22646,10 +22646,10 @@ pub mod LPSPI4_SDO_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_04 for Mode: ALT2"]
-            pub const GPIO_AD_B1_04_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_34 for Mode: ALT4"]
-            pub const GPIO_EMC_34_ALT4: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_B0_02 for Mode: ALT3"]
+            pub const GPIO_B0_02_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B1_06 for Mode: ALT1"]
+            pub const GPIO_B1_06_ALT1: u32 = 0x01;
         }
     }
 }
@@ -22662,10 +22662,10 @@ pub mod LPUART2_RX_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_09 for Mode: ALT2"]
-            pub const GPIO_AD_B1_09_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_23 for Mode: ALT2"]
-            pub const GPIO_EMC_23_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B1_10 for Mode: ALT2"]
+            pub const GPIO_SD_B1_10_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B1_03 for Mode: ALT2"]
+            pub const GPIO_AD_B1_03_ALT2: u32 = 0x01;
         }
     }
 }
@@ -22678,10 +22678,10 @@ pub mod LPUART2_TX_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_08 for Mode: ALT2"]
-            pub const GPIO_AD_B1_08_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_22 for Mode: ALT2"]
-            pub const GPIO_EMC_22_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B1_11 for Mode: ALT2"]
+            pub const GPIO_SD_B1_11_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B1_02 for Mode: ALT2"]
+            pub const GPIO_AD_B1_02_ALT2: u32 = 0x01;
         }
     }
 }
@@ -22746,12 +22746,12 @@ pub mod LPUART4_RX_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_03 for Mode: ALT2"]
-            pub const GPIO_EMC_03_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_AD_B1_11 for Mode: ALT2"]
-            pub const GPIO_AD_B1_11_ALT2: u32 = 0x01;
-            #[doc = "Selecting Pad: GPIO_EMC_33 for Mode: ALT2"]
-            pub const GPIO_EMC_33_ALT2: u32 = 0x02;
+            #[doc = "Selecting Pad: GPIO_SD_B1_01 for Mode: ALT4"]
+            pub const GPIO_SD_B1_01_ALT4: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_EMC_20 for Mode: ALT2"]
+            pub const GPIO_EMC_20_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_B1_01 for Mode: ALT2"]
+            pub const GPIO_B1_01_ALT2: u32 = 0x02;
         }
     }
 }
@@ -22764,12 +22764,12 @@ pub mod LPUART4_TX_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_02 for Mode: ALT2"]
-            pub const GPIO_EMC_02_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_AD_B1_10 for Mode: ALT2"]
-            pub const GPIO_AD_B1_10_ALT2: u32 = 0x01;
-            #[doc = "Selecting Pad: GPIO_EMC_32 for Mode: ALT2"]
-            pub const GPIO_EMC_32_ALT2: u32 = 0x02;
+            #[doc = "Selecting Pad: GPIO_SD_B1_00 for Mode: ALT4"]
+            pub const GPIO_SD_B1_00_ALT4: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_EMC_19 for Mode: ALT2"]
+            pub const GPIO_EMC_19_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_B1_00 for Mode: ALT2"]
+            pub const GPIO_B1_00_ALT2: u32 = 0x02;
         }
     }
 }
@@ -22782,10 +22782,10 @@ pub mod LPUART5_RX_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B0_11 for Mode: ALT2"]
-            pub const GPIO_AD_B0_11_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_39 for Mode: ALT2"]
-            pub const GPIO_EMC_39_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_24 for Mode: ALT2"]
+            pub const GPIO_EMC_24_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B1_13 for Mode: ALT1"]
+            pub const GPIO_B1_13_ALT1: u32 = 0x01;
         }
     }
 }
@@ -22798,10 +22798,10 @@ pub mod LPUART5_TX_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B0_10 for Mode: ALT2"]
-            pub const GPIO_AD_B0_10_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_38 for Mode: ALT2"]
-            pub const GPIO_EMC_38_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_23 for Mode: ALT2"]
+            pub const GPIO_EMC_23_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B1_12 for Mode: ALT1"]
+            pub const GPIO_B1_12_ALT1: u32 = 0x01;
         }
     }
 }
@@ -22814,10 +22814,10 @@ pub mod LPUART6_RX_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_13 for Mode: ALT2"]
-            pub const GPIO_EMC_13_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_SD_B1_01 for Mode: ALT2"]
-            pub const GPIO_SD_B1_01_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_26 for Mode: ALT2"]
+            pub const GPIO_EMC_26_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_03 for Mode: ALT2"]
+            pub const GPIO_AD_B0_03_ALT2: u32 = 0x01;
         }
     }
 }
@@ -22830,10 +22830,10 @@ pub mod LPUART6_TX_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_12 for Mode: ALT2"]
-            pub const GPIO_EMC_12_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_SD_B1_00 for Mode: ALT2"]
-            pub const GPIO_SD_B1_00_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_25 for Mode: ALT2"]
+            pub const GPIO_EMC_25_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_02 for Mode: ALT2"]
+            pub const GPIO_AD_B0_02_ALT2: u32 = 0x01;
         }
     }
 }
@@ -22846,10 +22846,10 @@ pub mod LPUART7_RX_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B0_05 for Mode: ALT2"]
-            pub const GPIO_SD_B0_05_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_35 for Mode: ALT2"]
-            pub const GPIO_EMC_35_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B1_09 for Mode: ALT2"]
+            pub const GPIO_SD_B1_09_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_EMC_32 for Mode: ALT2"]
+            pub const GPIO_EMC_32_ALT2: u32 = 0x01;
         }
     }
 }
@@ -22862,10 +22862,10 @@ pub mod LPUART7_TX_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B0_04 for Mode: ALT2"]
-            pub const GPIO_SD_B0_04_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_34 for Mode: ALT2"]
-            pub const GPIO_EMC_34_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B1_08 for Mode: ALT2"]
+            pub const GPIO_SD_B1_08_ALT2: u32 = 0;
+            #[doc = "Selecting Pad:GPIO_EMC_31 for Mode: ALT2"]
+            pub const GPIO_EMC_31_ALT2: u32 = 0x01;
         }
     }
 }
@@ -22914,8 +22914,8 @@ pub mod NMI_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B0_05 for Mode: ALT7"]
-            pub const GPIO_AD_B0_05_ALT7: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_12 for Mode: ALT7"]
+            pub const GPIO_AD_B0_12_ALT7: u32 = 0;
             #[doc = "Selecting Pad: WAKEUP for Mode: ALT7"]
             pub const WAKEUP_ALT7: u32 = 0x01;
         }
@@ -23084,12 +23084,12 @@ pub mod SAI1_RX_BCLK_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_06 for Mode: ALT3"]
-            pub const GPIO_AD_B1_06_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_14 for Mode: ALT3"]
-            pub const GPIO_EMC_14_ALT3: u32 = 0x01;
-            #[doc = "Selecting Pad: GPIO_EMC_19 for Mode: ALT3"]
-            pub const GPIO_EMC_19_ALT3: u32 = 0x02;
+            #[doc = "Selecting Pad: GPIO_SD_B1_05 for Mode: ALT3"]
+            pub const GPIO_SD_B1_05_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B1_11 for Mode: ALT3"]
+            pub const GPIO_AD_B1_11_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_B0_15 for Mode: ALT3"]
+            pub const GPIO_B0_15_ALT3: u32 = 0x02;
         }
     }
 }
@@ -23102,12 +23102,12 @@ pub mod SAI1_RX_DATA0_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_13 for Mode: ALT3"]
-            pub const GPIO_EMC_13_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_AD_B1_05 for Mode: ALT3"]
-            pub const GPIO_AD_B1_05_ALT3: u32 = 0x01;
-            #[doc = "Selecting Pad: GPIO_EMC_21 for Mode: ALT3"]
-            pub const GPIO_EMC_21_ALT3: u32 = 0x02;
+            #[doc = "Selecting Pad: GPIO_SD_B1_06 for Mode: ALT3"]
+            pub const GPIO_SD_B1_06_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B1_12 for Mode: ALT3"]
+            pub const GPIO_AD_B1_12_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_B1_00 for Mode: ALT3"]
+            pub const GPIO_B1_00_ALT3: u32 = 0x02;
         }
     }
 }
@@ -23120,10 +23120,10 @@ pub mod SAI1_RX_DATA1_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_09 for Mode: ALT3"]
-            pub const GPIO_AD_B1_09_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_22 for Mode: ALT3"]
-            pub const GPIO_EMC_22_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B1_00 for Mode: ALT3"]
+            pub const GPIO_SD_B1_00_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B0_10 for Mode: ALT3"]
+            pub const GPIO_B0_10_ALT3: u32 = 0x01;
         }
     }
 }
@@ -23136,10 +23136,10 @@ pub mod SAI1_RX_DATA2_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_08 for Mode: ALT3"]
-            pub const GPIO_AD_B1_08_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_23 for Mode: ALT3"]
-            pub const GPIO_EMC_23_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B1_01 for Mode: ALT3"]
+            pub const GPIO_SD_B1_01_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B0_11 for Mode: ALT3"]
+            pub const GPIO_B0_11_ALT3: u32 = 0x01;
         }
     }
 }
@@ -23152,10 +23152,10 @@ pub mod SAI1_RX_DATA3_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_07 for Mode: ALT3"]
-            pub const GPIO_AD_B1_07_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_24 for Mode: ALT3"]
-            pub const GPIO_EMC_24_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B1_02 for Mode: ALT3"]
+            pub const GPIO_SD_B1_02_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B0_12 for Mode: ALT3"]
+            pub const GPIO_B0_12_ALT3: u32 = 0x01;
         }
     }
 }
@@ -23168,12 +23168,12 @@ pub mod SAI1_RX_SYNC_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_04 for Mode: ALT3"]
-            pub const GPIO_AD_B1_04_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_15 for Mode: ALT3"]
-            pub const GPIO_EMC_15_ALT3: u32 = 0x01;
-            #[doc = "Selecting Pad: GPIO_EMC_18 for Mode: ALT3"]
-            pub const GPIO_EMC_18_ALT3: u32 = 0x02;
+            #[doc = "Selecting Pad: GPIO_SD_B1_04 for Mode: ALT3"]
+            pub const GPIO_SD_B1_04_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B1_10 for Mode: ALT3"]
+            pub const GPIO_AD_B1_10_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_B0_14 for Mode: ALT3"]
+            pub const GPIO_B0_14_ALT3: u32 = 0x02;
         }
     }
 }
@@ -23186,12 +23186,12 @@ pub mod SAI1_TX_BCLK_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_11 for Mode: ALT3"]
-            pub const GPIO_EMC_11_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_AD_B1_01 for Mode: ALT3"]
-            pub const GPIO_AD_B1_01_ALT3: u32 = 0x01;
-            #[doc = "Selecting Pad: GPIO_EMC_26 for Mode: ALT3"]
-            pub const GPIO_EMC_26_ALT3: u32 = 0x02;
+            #[doc = "Selecting Pad: GPIO_SD_B1_08 for Mode: ALT3"]
+            pub const GPIO_SD_B1_08_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B1_14 for Mode: ALT3"]
+            pub const GPIO_AD_B1_14_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_B1_02 for Mode: ALT3"]
+            pub const GPIO_B1_02_ALT3: u32 = 0x02;
         }
     }
 }
@@ -23204,12 +23204,12 @@ pub mod SAI1_TX_SYNC_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_10 for Mode: ALT3"]
-            pub const GPIO_EMC_10_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_AD_B1_02 for Mode: ALT3"]
-            pub const GPIO_AD_B1_02_ALT3: u32 = 0x01;
-            #[doc = "Selecting Pad: GPIO_EMC_27 for Mode: ALT3"]
-            pub const GPIO_EMC_27_ALT3: u32 = 0x02;
+            #[doc = "Selecting Pad: GPIO_SD_B1_09 for Mode: ALT3"]
+            pub const GPIO_SD_B1_09_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B1_15 for Mode: ALT3"]
+            pub const GPIO_AD_B1_15_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_B1_03 for Mode: ALT3"]
+            pub const GPIO_B1_03_ALT3: u32 = 0x02;
         }
     }
 }
@@ -23238,10 +23238,10 @@ pub mod SAI2_RX_BCLK_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B0_02 for Mode: ALT3"]
-            pub const GPIO_SD_B0_02_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_09 for Mode: ALT3"]
-            pub const GPIO_EMC_09_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_10 for Mode: ALT2"]
+            pub const GPIO_EMC_10_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_06 for Mode: ALT3"]
+            pub const GPIO_AD_B0_06_ALT3: u32 = 0x01;
         }
     }
 }
@@ -23254,10 +23254,10 @@ pub mod SAI2_RX_DATA0_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B0_03 for Mode: ALT3"]
-            pub const GPIO_SD_B0_03_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_08 for Mode: ALT3"]
-            pub const GPIO_EMC_08_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_08 for Mode: ALT2"]
+            pub const GPIO_EMC_08_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_08 for Mode: ALT3"]
+            pub const GPIO_AD_B0_08_ALT3: u32 = 0x01;
         }
     }
 }
@@ -23270,10 +23270,10 @@ pub mod SAI2_RX_SYNC_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B0_01 for Mode: ALT3"]
-            pub const GPIO_SD_B0_01_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_07 for Mode: ALT3"]
-            pub const GPIO_EMC_07_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_09 for Mode: ALT2"]
+            pub const GPIO_EMC_09_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_07 for Mode: ALT3"]
+            pub const GPIO_AD_B0_07_ALT3: u32 = 0x01;
         }
     }
 }
@@ -23286,10 +23286,10 @@ pub mod SAI2_TX_BCLK_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B0_05 for Mode: ALT3"]
-            pub const GPIO_SD_B0_05_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_04 for Mode: ALT3"]
-            pub const GPIO_EMC_04_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_06 for Mode: ALT2"]
+            pub const GPIO_EMC_06_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_05 for Mode: ALT3"]
+            pub const GPIO_AD_B0_05_ALT3: u32 = 0x01;
         }
     }
 }
@@ -23302,10 +23302,10 @@ pub mod SAI2_TX_SYNC_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B0_06 for Mode: ALT3"]
-            pub const GPIO_SD_B0_06_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_05 for Mode: ALT3"]
-            pub const GPIO_EMC_05_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_05 for Mode: ALT2"]
+            pub const GPIO_EMC_05_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_04 for Mode: ALT3"]
+            pub const GPIO_AD_B0_04_ALT3: u32 = 0x01;
         }
     }
 }
@@ -23318,10 +23318,10 @@ pub mod SPDIF_IN_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_05 for Mode: ALT2"]
-            pub const GPIO_EMC_05_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_41 for Mode: ALT2"]
-            pub const GPIO_EMC_41_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_AD_B1_03 for Mode: ALT3"]
+            pub const GPIO_AD_B1_03_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_EMC_16 for Mode: ALT3"]
+            pub const GPIO_EMC_16_ALT3: u32 = 0x01;
         }
     }
 }
@@ -23580,10 +23580,10 @@ pub mod USDHC2_WP_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_13 for Mode: ALT3"]
-            pub const GPIO_AD_B1_13_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_35 for Mode: ALT3"]
-            pub const GPIO_EMC_35_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_37 for Mode: ALT6"]
+            pub const GPIO_EMC_37_ALT6: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B1_10 for Mode: ALT6"]
+            pub const GPIO_AD_B1_10_ALT6: u32 = 0x01;
         }
     }
 }
@@ -23744,10 +23744,10 @@ pub mod XBAR1_IN18_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_28 for Mode: ALT2"]
-            pub const GPIO_EMC_28_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_40 for Mode: ALT1"]
-            pub const GPIO_EMC_40_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_35 for Mode: ALT1"]
+            pub const GPIO_EMC_35_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_06 for Mode: ALT6"]
+            pub const GPIO_AD_B0_06_ALT6: u32 = 0x01;
         }
     }
 }
@@ -23824,10 +23824,10 @@ pub mod XBAR1_IN14_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B0_00 for Mode: ALT7"]
-            pub const GPIO_SD_B0_00_ALT7: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_14 for Mode: ALT1"]
-            pub const GPIO_EMC_14_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_AD_B0_00 for Mode: ALT1"]
+            pub const GPIO_AD_B0_00_ALT1: u32 = 0;
+            #[doc = "Selecting Pad:GPIO_B1_00 for Mode: ALT1"]
+            pub const GPIO_B1_00_ALT1: u32 = 0x01;
         }
     }
 }
@@ -23840,10 +23840,10 @@ pub mod XBAR1_IN15_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B0_01 for Mode: ALT7"]
-            pub const GPIO_SD_B0_01_ALT7: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_15 for Mode: ALT1"]
-            pub const GPIO_EMC_15_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_AD_B0_01 for Mode: ALT1"]
+            pub const GPIO_AD_B0_01_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B1_01 for Mode: ALT1"]
+            pub const GPIO_B1_01_ALT1: u32 = 0x01;
         }
     }
 }
@@ -23856,10 +23856,10 @@ pub mod XBAR1_IN16_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B0_02 for Mode: ALT7"]
-            pub const GPIO_SD_B0_02_ALT7: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_18 for Mode: ALT1"]
-            pub const GPIO_EMC_18_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_AD_B0_02 for Mode: ALT1"]
+            pub const GPIO_AD_B0_02_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B1_02 for Mode: ALT1"]
+            pub const GPIO_B1_02_ALT1: u32 = 0x01;
         }
     }
 }
@@ -23888,10 +23888,10 @@ pub mod XBAR1_IN19_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_29 for Mode: ALT2"]
-            pub const GPIO_EMC_29_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_41 for Mode: ALT1"]
-            pub const GPIO_EMC_41_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_14 for Mode: ALT1"]
+            pub const GPIO_EMC_14_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_07 for Mode: ALT6"]
+            pub const GPIO_AD_B0_07_ALT6: u32 = 0x01;
         }
     }
 }

--- a/src/blocks/imxrt1061/iomuxc.rs
+++ b/src/blocks/imxrt1061/iomuxc.rs
@@ -6048,9 +6048,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_00 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -6073,13 +6073,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_00 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -6175,9 +6175,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_01 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -6200,13 +6200,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_01 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -6302,9 +6302,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_02 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -6327,13 +6327,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_02 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -6429,9 +6429,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_03 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -6454,13 +6454,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_03 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -6556,9 +6556,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_04 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -6581,13 +6581,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_04 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -6683,9 +6683,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_05 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -6708,13 +6708,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_05 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -6810,9 +6810,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_06 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -6835,13 +6835,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_06 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -6937,9 +6937,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_07 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -6962,13 +6962,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_07 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -7064,9 +7064,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_08 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -7089,13 +7089,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_08 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -7191,9 +7191,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_09 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -7216,13 +7216,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_09 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -7318,9 +7318,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_10 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -7343,13 +7343,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_10 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -7445,9 +7445,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_11 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -7470,13 +7470,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_11 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -7572,9 +7572,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_12 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -7597,13 +7597,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_12 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -7699,9 +7699,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_13 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -7724,13 +7724,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_13 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -7826,9 +7826,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_14 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -7851,13 +7851,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_14 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -7953,9 +7953,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_15 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -7978,13 +7978,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_15 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -8080,9 +8080,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_16 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -8105,13 +8105,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_16 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -8207,9 +8207,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_17 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -8232,13 +8232,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_17 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -8334,9 +8334,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_18 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -8359,13 +8359,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_18 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -8461,9 +8461,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_19 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -8486,13 +8486,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_19 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -8588,9 +8588,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_20 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -8613,13 +8613,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_20 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -8715,9 +8715,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_21 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -8740,13 +8740,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_21 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -8842,9 +8842,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_22 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -8867,13 +8867,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_22 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -8969,9 +8969,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_23 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -8994,13 +8994,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_23 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -9096,9 +9096,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_24 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -9121,13 +9121,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_24 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -9223,9 +9223,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_25 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -9248,13 +9248,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_25 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -9350,9 +9350,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_26 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -9375,13 +9375,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_26 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -9477,9 +9477,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_27 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -9502,13 +9502,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_27 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -9604,9 +9604,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_28 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -9629,13 +9629,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_28 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -9731,9 +9731,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_29 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -9756,13 +9756,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_29 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -9858,9 +9858,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_30 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -9883,13 +9883,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_30 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -9985,9 +9985,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_31 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -10010,13 +10010,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_31 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -10112,9 +10112,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_32 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -10137,13 +10137,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_32 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -10239,9 +10239,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_33 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -10264,13 +10264,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_33 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -10366,9 +10366,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_34 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -10391,13 +10391,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_34 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -10493,9 +10493,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_35 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -10518,13 +10518,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_35 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -10620,9 +10620,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_36 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -10645,13 +10645,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_36 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -10747,9 +10747,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_37 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -10772,13 +10772,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_37 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -10874,9 +10874,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_38 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -10899,13 +10899,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_38 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -11001,9 +11001,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_39 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -11026,13 +11026,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_39 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -11128,9 +11128,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_40 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -11153,13 +11153,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_40 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -11255,9 +11255,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_41 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -11280,13 +11280,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_41 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -11382,9 +11382,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_00 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -11407,13 +11407,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_00 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -11509,9 +11509,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_01 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -11534,13 +11534,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_01 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -11636,9 +11636,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_02 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -11661,13 +11661,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_02 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -11763,9 +11763,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_03 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -11788,13 +11788,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_03 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -11890,9 +11890,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_04 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -11915,13 +11915,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_04 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -12017,9 +12017,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_05 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -12042,13 +12042,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_05 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -12144,9 +12144,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_06 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -12169,13 +12169,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_06 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -12271,9 +12271,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_07 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -12296,13 +12296,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_07 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -12398,9 +12398,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_08 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -12423,13 +12423,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_08 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -12525,9 +12525,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_09 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -12550,13 +12550,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_09 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -12652,9 +12652,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_10 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -12677,13 +12677,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_10 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -12779,9 +12779,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_11 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -12804,13 +12804,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_11 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -12906,9 +12906,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_12 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -12931,13 +12931,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_12 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -13033,9 +13033,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_13 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -13058,13 +13058,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_13 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -13160,9 +13160,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_14 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -13185,13 +13185,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_14 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -13287,9 +13287,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_15 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -13312,13 +13312,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_15 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -13414,9 +13414,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_00 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -13439,13 +13439,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_00 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -13541,9 +13541,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_01 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -13566,13 +13566,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_01 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -13668,9 +13668,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_02 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -13693,13 +13693,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_02 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -13795,9 +13795,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_03 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -13820,13 +13820,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_03 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -13922,9 +13922,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_04 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -13947,13 +13947,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_04 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -14049,9 +14049,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_05 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -14074,13 +14074,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_05 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -14176,9 +14176,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_06 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -14201,13 +14201,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_06 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -14303,9 +14303,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_07 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -14328,13 +14328,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_07 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -14430,9 +14430,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_08 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -14455,13 +14455,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_08 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -14557,9 +14557,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_09 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -14582,13 +14582,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_09 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -14684,9 +14684,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_10 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -14709,13 +14709,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_10 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -14811,9 +14811,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_11 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -14836,13 +14836,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_11 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -14938,9 +14938,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_12 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -14963,13 +14963,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_12 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -15065,9 +15065,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_13 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -15090,13 +15090,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_13 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -15192,9 +15192,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_14 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -15217,13 +15217,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_14 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -15319,9 +15319,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_15 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -15344,13 +15344,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_15 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -19510,9 +19510,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B0_00 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -19535,13 +19535,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B0_00 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -19637,9 +19637,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B0_01 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -19662,13 +19662,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B0_01 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -19764,9 +19764,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B0_02 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -19789,13 +19789,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B0_02 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -19891,9 +19891,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B0_03 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -19916,13 +19916,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B0_03 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -20018,9 +20018,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B0_04 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -20043,13 +20043,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B0_04 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -20145,9 +20145,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B0_05 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -20170,13 +20170,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B0_05 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -20272,9 +20272,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_00 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -20297,13 +20297,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_00 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -20399,9 +20399,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_01 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -20424,13 +20424,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_01 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -20526,9 +20526,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_02 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -20551,13 +20551,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_02 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -20653,9 +20653,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_03 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -20678,13 +20678,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_03 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -20780,9 +20780,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_04 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -20805,13 +20805,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_04 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -20907,9 +20907,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_05 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -20932,13 +20932,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_05 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -21034,9 +21034,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_06 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -21059,13 +21059,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_06 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -21161,9 +21161,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_07 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -21186,13 +21186,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_07 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -21288,9 +21288,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_08 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -21313,13 +21313,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_08 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -21415,9 +21415,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_09 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -21440,13 +21440,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_09 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -21542,9 +21542,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_10 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -21567,13 +21567,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_10 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -21669,9 +21669,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_11 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -21694,13 +21694,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_11 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -22032,12 +22032,12 @@ pub mod ENET_MDIO_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B0_02 for Mode: ALT6"]
-            pub const GPIO_SD_B0_02_ALT6: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_AD_B0_04 for Mode: ALT4"]
-            pub const GPIO_AD_B0_04_ALT4: u32 = 0x01;
-            #[doc = "Selecting Pad: GPIO_EMC_40 for Mode: ALT4"]
-            pub const GPIO_EMC_40_ALT4: u32 = 0x02;
+            #[doc = "Selecting Pad: GPIO_AD_B1_05 for Mode: ALT1"]
+            pub const GPIO_AD_B1_05_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_EMC_41 for Mode: ALT4"]
+            pub const GPIO_EMC_41_ALT4: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_B1_15 for Mode: ALT0"]
+            pub const GPIO_B1_15_ALT0: u32 = 0x02;
         }
     }
 }
@@ -22148,14 +22148,14 @@ pub mod FLEXCAN1_RX_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_01 for Mode: ALT6"]
-            pub const GPIO_EMC_01_ALT6: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_SD_B1_01 for Mode: ALT4"]
-            pub const GPIO_SD_B1_01_ALT4: u32 = 0x01;
-            #[doc = "Selecting Pad: GPIO_AD_B0_05 for Mode: ALT1"]
-            pub const GPIO_AD_B0_05_ALT1: u32 = 0x02;
-            #[doc = "Selecting Pad: GPIO_EMC_15 for Mode: ALT6"]
-            pub const GPIO_EMC_15_ALT6: u32 = 0x03;
+            #[doc = "Selecting Pad: GPIO_SD_B1_03 for Mode: ALT4"]
+            pub const GPIO_SD_B1_03_ALT4: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_EMC_18 for Mode: ALT3"]
+            pub const GPIO_EMC_18_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_AD_B1_09 for Mode: ALT2"]
+            pub const GPIO_AD_B1_09_ALT2: u32 = 0x02;
+            #[doc = "Selecting Pad: GPIO_B0_03 for Mode: ALT2"]
+            pub const GPIO_B0_03_ALT2: u32 = 0x03;
         }
     }
 }
@@ -22168,14 +22168,14 @@ pub mod FLEXCAN2_RX_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B0_05 for Mode: ALT1"]
-            pub const GPIO_SD_B0_05_ALT1: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_09 for Mode: ALT2"]
-            pub const GPIO_EMC_09_ALT2: u32 = 0x01;
-            #[doc = "Selecting Pad: GPIO_AD_B0_15 for Mode: ALT1"]
-            pub const GPIO_AD_B0_15_ALT1: u32 = 0x02;
-            #[doc = "Selecting Pad: GPIO_AD_B1_01 for Mode: ALT2"]
-            pub const GPIO_AD_B1_01_ALT2: u32 = 0x03;
+            #[doc = "Selecting Pad: GPIO_EMC_10 for Mode: ALT3"]
+            pub const GPIO_EMC_10_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_03 for Mode: ALT0"]
+            pub const GPIO_AD_B0_03_ALT0: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_AD_B0_15 for Mode: ALT6"]
+            pub const GPIO_AD_B0_15_ALT6: u32 = 0x02;
+            #[doc = "Selecting Pad: GPIO_B1_09 for Mode: ALT6"]
+            pub const GPIO_B1_09_ALT6: u32 = 0x03;
         }
     }
 }
@@ -22210,10 +22210,10 @@ pub mod FLEXPWM1_PWMA0_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_06 for Mode: ALT1"]
-            pub const GPIO_AD_B1_06_ALT1: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_26 for Mode: ALT1"]
-            pub const GPIO_EMC_26_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_23 for Mode: ALT1"]
+            pub const GPIO_EMC_23_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_SD_B0_00 for Mode: ALT1"]
+            pub const GPIO_SD_B0_00_ALT1: u32 = 0x01;
         }
     }
 }
@@ -22226,10 +22226,10 @@ pub mod FLEXPWM1_PWMA1_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_08 for Mode: ALT1"]
-            pub const GPIO_AD_B1_08_ALT1: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_24 for Mode: ALT1"]
-            pub const GPIO_EMC_24_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_25 for Mode: ALT1"]
+            pub const GPIO_EMC_25_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_SD_B0_02 for Mode: ALT1"]
+            pub const GPIO_SD_B0_02_ALT1: u32 = 0x01;
         }
     }
 }
@@ -22242,10 +22242,10 @@ pub mod FLEXPWM1_PWMA2_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_10 for Mode: ALT1"]
-            pub const GPIO_AD_B1_10_ALT1: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_22 for Mode: ALT1"]
-            pub const GPIO_EMC_22_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_27 for Mode: ALT1"]
+            pub const GPIO_EMC_27_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_SD_B0_04 for Mode: ALT1"]
+            pub const GPIO_SD_B0_04_ALT1: u32 = 0x01;
         }
     }
 }
@@ -22280,10 +22280,10 @@ pub mod FLEXPWM1_PWMB0_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_07 for Mode: ALT1"]
-            pub const GPIO_AD_B1_07_ALT1: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_27 for Mode: ALT1"]
-            pub const GPIO_EMC_27_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_24 for Mode: ALT1"]
+            pub const GPIO_EMC_24_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_SD_B0_01 for Mode: ALT1"]
+            pub const GPIO_SD_B0_01_ALT1: u32 = 0x01;
         }
     }
 }
@@ -22296,10 +22296,10 @@ pub mod FLEXPWM1_PWMB1_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_09 for Mode: ALT1"]
-            pub const GPIO_AD_B1_09_ALT1: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_25 for Mode: ALT1"]
-            pub const GPIO_EMC_25_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_26 for Mode: ALT1"]
+            pub const GPIO_EMC_26_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_SD_B0_03 for Mode: ALT1"]
+            pub const GPIO_SD_B0_03_ALT1: u32 = 0x01;
         }
     }
 }
@@ -22312,10 +22312,10 @@ pub mod FLEXPWM1_PWMB2_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_11 for Mode: ALT1"]
-            pub const GPIO_AD_B1_11_ALT1: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_23 for Mode: ALT1"]
-            pub const GPIO_EMC_23_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_28 for Mode: ALT1"]
+            pub const GPIO_EMC_28_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_SD_B0_05 for Mode: ALT1"]
+            pub const GPIO_SD_B0_05_ALT1: u32 = 0x01;
         }
     }
 }
@@ -22350,10 +22350,10 @@ pub mod FLEXPWM2_PWMA0_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B0_14 for Mode: ALT4"]
-            pub const GPIO_AD_B0_14_ALT4: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_38 for Mode: ALT1"]
-            pub const GPIO_EMC_38_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_06 for Mode: ALT1"]
+            pub const GPIO_EMC_06_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B0_06 for Mode: ALT2"]
+            pub const GPIO_B0_06_ALT2: u32 = 0x01;
         }
     }
 }
@@ -22366,10 +22366,10 @@ pub mod FLEXPWM2_PWMA1_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B0_12 for Mode: ALT4"]
-            pub const GPIO_AD_B0_12_ALT4: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_36 for Mode: ALT1"]
-            pub const GPIO_EMC_36_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_08 for Mode: ALT1"]
+            pub const GPIO_EMC_08_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B0_08 for Mode: ALT2"]
+            pub const GPIO_B0_08_ALT2: u32 = 0x01;
         }
     }
 }
@@ -22382,10 +22382,10 @@ pub mod FLEXPWM2_PWMA2_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B0_10 for Mode: ALT4"]
-            pub const GPIO_AD_B0_10_ALT4: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_30 for Mode: ALT1"]
-            pub const GPIO_EMC_30_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_10 for Mode: ALT1"]
+            pub const GPIO_EMC_10_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B0_10 for Mode: ALT2"]
+            pub const GPIO_B0_10_ALT2: u32 = 0x01;
         }
     }
 }
@@ -22418,10 +22418,10 @@ pub mod FLEXPWM2_PWMB0_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B0_15 for Mode: ALT4"]
-            pub const GPIO_AD_B0_15_ALT4: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_39 for Mode: ALT1"]
-            pub const GPIO_EMC_39_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_07 for Mode: ALT1"]
+            pub const GPIO_EMC_07_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B0_07 for Mode: ALT2"]
+            pub const GPIO_B0_07_ALT2: u32 = 0x01;
         }
     }
 }
@@ -22434,10 +22434,10 @@ pub mod FLEXPWM2_PWMB1_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B0_13 for Mode: ALT4"]
-            pub const GPIO_AD_B0_13_ALT4: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_37 for Mode: ALT1"]
-            pub const GPIO_EMC_37_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_09 for Mode: ALT1"]
+            pub const GPIO_EMC_09_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B0_09 for Mode: ALT2"]
+            pub const GPIO_B0_09_ALT2: u32 = 0x01;
         }
     }
 }
@@ -22450,10 +22450,10 @@ pub mod FLEXPWM2_PWMB2_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B0_11 for Mode: ALT4"]
-            pub const GPIO_AD_B0_11_ALT4: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_31 for Mode: ALT1"]
-            pub const GPIO_EMC_31_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_11 for Mode: ALT1"]
+            pub const GPIO_EMC_11_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B0_11 for Mode: ALT2"]
+            pub const GPIO_B0_11_ALT2: u32 = 0x01;
         }
     }
 }
@@ -22690,10 +22690,10 @@ pub mod LPI2C1_SCL_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_02 for Mode: ALT6"]
-            pub const GPIO_EMC_02_ALT6: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_AD_B1_14 for Mode: ALT0"]
-            pub const GPIO_AD_B1_14_ALT0: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B1_04 for Mode: ALT2"]
+            pub const GPIO_SD_B1_04_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B1_00 for Mode: ALT3"]
+            pub const GPIO_AD_B1_00_ALT3: u32 = 0x01;
         }
     }
 }
@@ -22706,10 +22706,10 @@ pub mod LPI2C1_SDA_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_03 for Mode: ALT6"]
-            pub const GPIO_EMC_03_ALT6: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_AD_B1_15 for Mode: ALT0"]
-            pub const GPIO_AD_B1_15_ALT0: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B1_05 for Mode: ALT2"]
+            pub const GPIO_SD_B1_05_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B1_01 for Mode: ALT3"]
+            pub const GPIO_AD_B1_01_ALT3: u32 = 0x01;
         }
     }
 }
@@ -22722,10 +22722,10 @@ pub mod LPI2C2_SCL_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_08 for Mode: ALT0"]
-            pub const GPIO_AD_B1_08_ALT0: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_19 for Mode: ALT2"]
-            pub const GPIO_EMC_19_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B1_11 for Mode: ALT3"]
+            pub const GPIO_SD_B1_11_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B0_04 for Mode: ALT2"]
+            pub const GPIO_B0_04_ALT2: u32 = 0x01;
         }
     }
 }
@@ -22738,10 +22738,10 @@ pub mod LPI2C2_SDA_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_09 for Mode: ALT0"]
-            pub const GPIO_AD_B1_09_ALT0: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_18 for Mode: ALT2"]
-            pub const GPIO_EMC_18_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B1_10 for Mode: ALT3"]
+            pub const GPIO_SD_B1_10_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B0_05 for Mode: ALT2"]
+            pub const GPIO_B0_05_ALT2: u32 = 0x01;
         }
     }
 }
@@ -22790,10 +22790,10 @@ pub mod LPI2C4_SCL_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_11 for Mode: ALT2"]
-            pub const GPIO_EMC_11_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_SD_B1_02 for Mode: ALT3"]
-            pub const GPIO_SD_B1_02_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_12 for Mode: ALT2"]
+            pub const GPIO_EMC_12_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_12 for Mode: ALT0"]
+            pub const GPIO_AD_B0_12_ALT0: u32 = 0x01;
         }
     }
 }
@@ -22806,10 +22806,10 @@ pub mod LPI2C4_SDA_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_10 for Mode: ALT2"]
-            pub const GPIO_EMC_10_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_SD_B1_03 for Mode: ALT3"]
-            pub const GPIO_SD_B1_03_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_11 for Mode: ALT2"]
+            pub const GPIO_EMC_11_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_13 for Mode: ALT0"]
+            pub const GPIO_AD_B0_13_ALT0: u32 = 0x01;
         }
     }
 }
@@ -22822,10 +22822,10 @@ pub mod LPSPI1_PCS0_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B0_03 for Mode: ALT4"]
-            pub const GPIO_SD_B0_03_ALT4: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_AD_B0_11 for Mode: ALT1"]
-            pub const GPIO_AD_B0_11_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B0_01 for Mode: ALT4"]
+            pub const GPIO_SD_B0_01_ALT4: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_EMC_30 for Mode: ALT3"]
+            pub const GPIO_EMC_30_ALT3: u32 = 0x01;
         }
     }
 }
@@ -22838,10 +22838,10 @@ pub mod LPSPI1_SCK_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_06 for Mode: ALT0"]
-            pub const GPIO_AD_06_ALT0: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_SD_08 for Mode: ALT2"]
-            pub const GPIO_SD_08_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_27 for Mode: ALT3"]
+            pub const GPIO_EMC_27_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_SD_B0_00 for Mode: ALT4"]
+            pub const GPIO_SD_B0_00_ALT4: u32 = 0x01;
         }
     }
 }
@@ -22854,10 +22854,10 @@ pub mod LPSPI1_SDI_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_03 for Mode: ALT0"]
-            pub const GPIO_AD_03_ALT0: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_SD_05 for Mode: ALT2"]
-            pub const GPIO_SD_05_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_29 for Mode: ALT3"]
+            pub const GPIO_EMC_29_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_03 for Mode: ALT4"]
+            pub const GPIO_SD_B0_03_ALT4: u32 = 0x01;
         }
     }
 }
@@ -22870,10 +22870,10 @@ pub mod LPSPI1_SDO_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_04 for Mode: ALT0"]
-            pub const GPIO_AD_04_ALT0: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_SD_06 for Mode: ALT2"]
-            pub const GPIO_SD_06_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_28 for Mode: ALT3"]
+            pub const GPIO_EMC_28_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_SD_B0_02 for Mode: ALT4"]
+            pub const GPIO_SD_B0_02_ALT4: u32 = 0x01;
         }
     }
 }
@@ -22902,10 +22902,10 @@ pub mod LPSPI2_SCK_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_12 for Mode: ALT0"]
-            pub const GPIO_AD_12_ALT0: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_SD_11 for Mode: ALT1"]
-            pub const GPIO_SD_11_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B1_07 for Mode: ALT4"]
+            pub const GPIO_SD_B1_07_ALT4: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_EMC_00 for Mode: ALT2"]
+            pub const GPIO_EMC_00_ALT2: u32 = 0x01;
         }
     }
 }
@@ -22918,10 +22918,10 @@ pub mod LPSPI2_SDI_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_09 for Mode: ALT0"]
-            pub const GPIO_AD_09_ALT0: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_SD_09 for Mode: ALT1"]
-            pub const GPIO_SD_09_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B1_09 for Mode: ALT4"]
+            pub const GPIO_SD_B1_09_ALT4: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_EMC_03 for Mode: ALT2"]
+            pub const GPIO_EMC_03_ALT2: u32 = 0x01;
         }
     }
 }
@@ -22934,10 +22934,10 @@ pub mod LPSPI2_SDO_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_10 for Mode: ALT0"]
-            pub const GPIO_AD_10_ALT0: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_SD_10 for Mode: ALT1"]
-            pub const GPIO_SD_10_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B1_08 for Mode: ALT4"]
+            pub const GPIO_SD_B1_08_ALT4: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_EMC_02 for Mode: ALT2"]
+            pub const GPIO_EMC_02_ALT2: u32 = 0x01;
         }
     }
 }
@@ -23014,10 +23014,10 @@ pub mod LPSPI4_PCS0_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_03 for Mode: ALT2"]
-            pub const GPIO_AD_B1_03_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_33 for Mode: ALT4"]
-            pub const GPIO_EMC_33_ALT4: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_B0_00 for Mode: ALT3"]
+            pub const GPIO_B0_00_ALT3: u32 = 0;
+            #[doc = "Selecting Pad:GPIO_B1_04 for Mode: ALT1"]
+            pub const GPIO_B1_04_ALT1: u32 = 0x01;
         }
     }
 }
@@ -23030,10 +23030,10 @@ pub mod LPSPI4_SCK_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_02 for Mode: ALT2"]
-            pub const GPIO_AD_B1_02_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_32 for Mode: ALT4"]
-            pub const GPIO_EMC_32_ALT4: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_B0_03 for Mode: ALT3"]
+            pub const GPIO_B0_03_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B1_07 for Mode: ALT1"]
+            pub const GPIO_B1_07_ALT1: u32 = 0x01;
         }
     }
 }
@@ -23046,10 +23046,10 @@ pub mod LPSPI4_SDI_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_05 for Mode: ALT2"]
-            pub const GPIO_AD_B1_05_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_35 for Mode: ALT4"]
-            pub const GPIO_EMC_35_ALT4: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_B0_01 for Mode: ALT3"]
+            pub const GPIO_B0_01_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B1_05 for Mode: ALT1"]
+            pub const GPIO_B1_05_ALT1: u32 = 0x01;
         }
     }
 }
@@ -23062,10 +23062,10 @@ pub mod LPSPI4_SDO_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_04 for Mode: ALT2"]
-            pub const GPIO_AD_B1_04_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_34 for Mode: ALT4"]
-            pub const GPIO_EMC_34_ALT4: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_B0_02 for Mode: ALT3"]
+            pub const GPIO_B0_02_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B1_06 for Mode: ALT1"]
+            pub const GPIO_B1_06_ALT1: u32 = 0x01;
         }
     }
 }
@@ -23078,10 +23078,10 @@ pub mod LPUART2_RX_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_09 for Mode: ALT2"]
-            pub const GPIO_AD_B1_09_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_23 for Mode: ALT2"]
-            pub const GPIO_EMC_23_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B1_10 for Mode: ALT2"]
+            pub const GPIO_SD_B1_10_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B1_03 for Mode: ALT2"]
+            pub const GPIO_AD_B1_03_ALT2: u32 = 0x01;
         }
     }
 }
@@ -23094,10 +23094,10 @@ pub mod LPUART2_TX_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_08 for Mode: ALT2"]
-            pub const GPIO_AD_B1_08_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_22 for Mode: ALT2"]
-            pub const GPIO_EMC_22_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B1_11 for Mode: ALT2"]
+            pub const GPIO_SD_B1_11_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B1_02 for Mode: ALT2"]
+            pub const GPIO_AD_B1_02_ALT2: u32 = 0x01;
         }
     }
 }
@@ -23162,12 +23162,12 @@ pub mod LPUART4_RX_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_03 for Mode: ALT2"]
-            pub const GPIO_EMC_03_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_AD_B1_11 for Mode: ALT2"]
-            pub const GPIO_AD_B1_11_ALT2: u32 = 0x01;
-            #[doc = "Selecting Pad: GPIO_EMC_33 for Mode: ALT2"]
-            pub const GPIO_EMC_33_ALT2: u32 = 0x02;
+            #[doc = "Selecting Pad: GPIO_SD_B1_01 for Mode: ALT4"]
+            pub const GPIO_SD_B1_01_ALT4: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_EMC_20 for Mode: ALT2"]
+            pub const GPIO_EMC_20_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_B1_01 for Mode: ALT2"]
+            pub const GPIO_B1_01_ALT2: u32 = 0x02;
         }
     }
 }
@@ -23180,12 +23180,12 @@ pub mod LPUART4_TX_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_02 for Mode: ALT2"]
-            pub const GPIO_EMC_02_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_AD_B1_10 for Mode: ALT2"]
-            pub const GPIO_AD_B1_10_ALT2: u32 = 0x01;
-            #[doc = "Selecting Pad: GPIO_EMC_32 for Mode: ALT2"]
-            pub const GPIO_EMC_32_ALT2: u32 = 0x02;
+            #[doc = "Selecting Pad: GPIO_SD_B1_00 for Mode: ALT4"]
+            pub const GPIO_SD_B1_00_ALT4: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_EMC_19 for Mode: ALT2"]
+            pub const GPIO_EMC_19_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_B1_00 for Mode: ALT2"]
+            pub const GPIO_B1_00_ALT2: u32 = 0x02;
         }
     }
 }
@@ -23198,10 +23198,10 @@ pub mod LPUART5_RX_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B0_11 for Mode: ALT2"]
-            pub const GPIO_AD_B0_11_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_39 for Mode: ALT2"]
-            pub const GPIO_EMC_39_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_24 for Mode: ALT2"]
+            pub const GPIO_EMC_24_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B1_13 for Mode: ALT1"]
+            pub const GPIO_B1_13_ALT1: u32 = 0x01;
         }
     }
 }
@@ -23214,10 +23214,10 @@ pub mod LPUART5_TX_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B0_10 for Mode: ALT2"]
-            pub const GPIO_AD_B0_10_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_38 for Mode: ALT2"]
-            pub const GPIO_EMC_38_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_23 for Mode: ALT2"]
+            pub const GPIO_EMC_23_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B1_12 for Mode: ALT1"]
+            pub const GPIO_B1_12_ALT1: u32 = 0x01;
         }
     }
 }
@@ -23230,10 +23230,10 @@ pub mod LPUART6_RX_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_13 for Mode: ALT2"]
-            pub const GPIO_EMC_13_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_SD_B1_01 for Mode: ALT2"]
-            pub const GPIO_SD_B1_01_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_26 for Mode: ALT2"]
+            pub const GPIO_EMC_26_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_03 for Mode: ALT2"]
+            pub const GPIO_AD_B0_03_ALT2: u32 = 0x01;
         }
     }
 }
@@ -23246,10 +23246,10 @@ pub mod LPUART6_TX_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_12 for Mode: ALT2"]
-            pub const GPIO_EMC_12_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_SD_B1_00 for Mode: ALT2"]
-            pub const GPIO_SD_B1_00_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_25 for Mode: ALT2"]
+            pub const GPIO_EMC_25_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_02 for Mode: ALT2"]
+            pub const GPIO_AD_B0_02_ALT2: u32 = 0x01;
         }
     }
 }
@@ -23262,10 +23262,10 @@ pub mod LPUART7_RX_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B0_05 for Mode: ALT2"]
-            pub const GPIO_SD_B0_05_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_35 for Mode: ALT2"]
-            pub const GPIO_EMC_35_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B1_09 for Mode: ALT2"]
+            pub const GPIO_SD_B1_09_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_EMC_32 for Mode: ALT2"]
+            pub const GPIO_EMC_32_ALT2: u32 = 0x01;
         }
     }
 }
@@ -23278,10 +23278,10 @@ pub mod LPUART7_TX_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B0_04 for Mode: ALT2"]
-            pub const GPIO_SD_B0_04_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_34 for Mode: ALT2"]
-            pub const GPIO_EMC_34_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B1_08 for Mode: ALT2"]
+            pub const GPIO_SD_B1_08_ALT2: u32 = 0;
+            #[doc = "Selecting Pad:GPIO_EMC_31 for Mode: ALT2"]
+            pub const GPIO_EMC_31_ALT2: u32 = 0x01;
         }
     }
 }
@@ -23330,8 +23330,8 @@ pub mod NMI_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B0_05 for Mode: ALT7"]
-            pub const GPIO_AD_B0_05_ALT7: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_12 for Mode: ALT7"]
+            pub const GPIO_AD_B0_12_ALT7: u32 = 0;
             #[doc = "Selecting Pad: WAKEUP for Mode: ALT7"]
             pub const WAKEUP_ALT7: u32 = 0x01;
         }
@@ -23500,12 +23500,12 @@ pub mod SAI1_RX_BCLK_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_06 for Mode: ALT3"]
-            pub const GPIO_AD_B1_06_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_14 for Mode: ALT3"]
-            pub const GPIO_EMC_14_ALT3: u32 = 0x01;
-            #[doc = "Selecting Pad: GPIO_EMC_19 for Mode: ALT3"]
-            pub const GPIO_EMC_19_ALT3: u32 = 0x02;
+            #[doc = "Selecting Pad: GPIO_SD_B1_05 for Mode: ALT3"]
+            pub const GPIO_SD_B1_05_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B1_11 for Mode: ALT3"]
+            pub const GPIO_AD_B1_11_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_B0_15 for Mode: ALT3"]
+            pub const GPIO_B0_15_ALT3: u32 = 0x02;
         }
     }
 }
@@ -23518,12 +23518,12 @@ pub mod SAI1_RX_DATA0_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_13 for Mode: ALT3"]
-            pub const GPIO_EMC_13_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_AD_B1_05 for Mode: ALT3"]
-            pub const GPIO_AD_B1_05_ALT3: u32 = 0x01;
-            #[doc = "Selecting Pad: GPIO_EMC_21 for Mode: ALT3"]
-            pub const GPIO_EMC_21_ALT3: u32 = 0x02;
+            #[doc = "Selecting Pad: GPIO_SD_B1_06 for Mode: ALT3"]
+            pub const GPIO_SD_B1_06_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B1_12 for Mode: ALT3"]
+            pub const GPIO_AD_B1_12_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_B1_00 for Mode: ALT3"]
+            pub const GPIO_B1_00_ALT3: u32 = 0x02;
         }
     }
 }
@@ -23536,10 +23536,10 @@ pub mod SAI1_RX_DATA1_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_09 for Mode: ALT3"]
-            pub const GPIO_AD_B1_09_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_22 for Mode: ALT3"]
-            pub const GPIO_EMC_22_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B1_00 for Mode: ALT3"]
+            pub const GPIO_SD_B1_00_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B0_10 for Mode: ALT3"]
+            pub const GPIO_B0_10_ALT3: u32 = 0x01;
         }
     }
 }
@@ -23552,10 +23552,10 @@ pub mod SAI1_RX_DATA2_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_08 for Mode: ALT3"]
-            pub const GPIO_AD_B1_08_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_23 for Mode: ALT3"]
-            pub const GPIO_EMC_23_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B1_01 for Mode: ALT3"]
+            pub const GPIO_SD_B1_01_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B0_11 for Mode: ALT3"]
+            pub const GPIO_B0_11_ALT3: u32 = 0x01;
         }
     }
 }
@@ -23568,10 +23568,10 @@ pub mod SAI1_RX_DATA3_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_07 for Mode: ALT3"]
-            pub const GPIO_AD_B1_07_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_24 for Mode: ALT3"]
-            pub const GPIO_EMC_24_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B1_02 for Mode: ALT3"]
+            pub const GPIO_SD_B1_02_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B0_12 for Mode: ALT3"]
+            pub const GPIO_B0_12_ALT3: u32 = 0x01;
         }
     }
 }
@@ -23584,12 +23584,12 @@ pub mod SAI1_RX_SYNC_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_04 for Mode: ALT3"]
-            pub const GPIO_AD_B1_04_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_15 for Mode: ALT3"]
-            pub const GPIO_EMC_15_ALT3: u32 = 0x01;
-            #[doc = "Selecting Pad: GPIO_EMC_18 for Mode: ALT3"]
-            pub const GPIO_EMC_18_ALT3: u32 = 0x02;
+            #[doc = "Selecting Pad: GPIO_SD_B1_04 for Mode: ALT3"]
+            pub const GPIO_SD_B1_04_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B1_10 for Mode: ALT3"]
+            pub const GPIO_AD_B1_10_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_B0_14 for Mode: ALT3"]
+            pub const GPIO_B0_14_ALT3: u32 = 0x02;
         }
     }
 }
@@ -23602,12 +23602,12 @@ pub mod SAI1_TX_BCLK_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_11 for Mode: ALT3"]
-            pub const GPIO_EMC_11_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_AD_B1_01 for Mode: ALT3"]
-            pub const GPIO_AD_B1_01_ALT3: u32 = 0x01;
-            #[doc = "Selecting Pad: GPIO_EMC_26 for Mode: ALT3"]
-            pub const GPIO_EMC_26_ALT3: u32 = 0x02;
+            #[doc = "Selecting Pad: GPIO_SD_B1_08 for Mode: ALT3"]
+            pub const GPIO_SD_B1_08_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B1_14 for Mode: ALT3"]
+            pub const GPIO_AD_B1_14_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_B1_02 for Mode: ALT3"]
+            pub const GPIO_B1_02_ALT3: u32 = 0x02;
         }
     }
 }
@@ -23620,12 +23620,12 @@ pub mod SAI1_TX_SYNC_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_10 for Mode: ALT3"]
-            pub const GPIO_EMC_10_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_AD_B1_02 for Mode: ALT3"]
-            pub const GPIO_AD_B1_02_ALT3: u32 = 0x01;
-            #[doc = "Selecting Pad: GPIO_EMC_27 for Mode: ALT3"]
-            pub const GPIO_EMC_27_ALT3: u32 = 0x02;
+            #[doc = "Selecting Pad: GPIO_SD_B1_09 for Mode: ALT3"]
+            pub const GPIO_SD_B1_09_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B1_15 for Mode: ALT3"]
+            pub const GPIO_AD_B1_15_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_B1_03 for Mode: ALT3"]
+            pub const GPIO_B1_03_ALT3: u32 = 0x02;
         }
     }
 }
@@ -23654,10 +23654,10 @@ pub mod SAI2_RX_BCLK_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B0_02 for Mode: ALT3"]
-            pub const GPIO_SD_B0_02_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_09 for Mode: ALT3"]
-            pub const GPIO_EMC_09_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_10 for Mode: ALT2"]
+            pub const GPIO_EMC_10_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_06 for Mode: ALT3"]
+            pub const GPIO_AD_B0_06_ALT3: u32 = 0x01;
         }
     }
 }
@@ -23670,10 +23670,10 @@ pub mod SAI2_RX_DATA0_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B0_03 for Mode: ALT3"]
-            pub const GPIO_SD_B0_03_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_08 for Mode: ALT3"]
-            pub const GPIO_EMC_08_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_08 for Mode: ALT2"]
+            pub const GPIO_EMC_08_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_08 for Mode: ALT3"]
+            pub const GPIO_AD_B0_08_ALT3: u32 = 0x01;
         }
     }
 }
@@ -23686,10 +23686,10 @@ pub mod SAI2_RX_SYNC_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B0_01 for Mode: ALT3"]
-            pub const GPIO_SD_B0_01_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_07 for Mode: ALT3"]
-            pub const GPIO_EMC_07_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_09 for Mode: ALT2"]
+            pub const GPIO_EMC_09_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_07 for Mode: ALT3"]
+            pub const GPIO_AD_B0_07_ALT3: u32 = 0x01;
         }
     }
 }
@@ -23702,10 +23702,10 @@ pub mod SAI2_TX_BCLK_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B0_05 for Mode: ALT3"]
-            pub const GPIO_SD_B0_05_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_04 for Mode: ALT3"]
-            pub const GPIO_EMC_04_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_06 for Mode: ALT2"]
+            pub const GPIO_EMC_06_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_05 for Mode: ALT3"]
+            pub const GPIO_AD_B0_05_ALT3: u32 = 0x01;
         }
     }
 }
@@ -23718,10 +23718,10 @@ pub mod SAI2_TX_SYNC_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B0_06 for Mode: ALT3"]
-            pub const GPIO_SD_B0_06_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_05 for Mode: ALT3"]
-            pub const GPIO_EMC_05_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_05 for Mode: ALT2"]
+            pub const GPIO_EMC_05_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_04 for Mode: ALT3"]
+            pub const GPIO_AD_B0_04_ALT3: u32 = 0x01;
         }
     }
 }
@@ -23734,10 +23734,10 @@ pub mod SPDIF_IN_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_05 for Mode: ALT2"]
-            pub const GPIO_EMC_05_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_41 for Mode: ALT2"]
-            pub const GPIO_EMC_41_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_AD_B1_03 for Mode: ALT3"]
+            pub const GPIO_AD_B1_03_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_EMC_16 for Mode: ALT3"]
+            pub const GPIO_EMC_16_ALT3: u32 = 0x01;
         }
     }
 }
@@ -23996,10 +23996,10 @@ pub mod USDHC2_WP_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_13 for Mode: ALT3"]
-            pub const GPIO_AD_B1_13_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_35 for Mode: ALT3"]
-            pub const GPIO_EMC_35_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_37 for Mode: ALT6"]
+            pub const GPIO_EMC_37_ALT6: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B1_10 for Mode: ALT6"]
+            pub const GPIO_AD_B1_10_ALT6: u32 = 0x01;
         }
     }
 }
@@ -24160,10 +24160,10 @@ pub mod XBAR1_IN18_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_28 for Mode: ALT2"]
-            pub const GPIO_EMC_28_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_40 for Mode: ALT1"]
-            pub const GPIO_EMC_40_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_35 for Mode: ALT1"]
+            pub const GPIO_EMC_35_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_06 for Mode: ALT6"]
+            pub const GPIO_AD_B0_06_ALT6: u32 = 0x01;
         }
     }
 }
@@ -24240,10 +24240,10 @@ pub mod XBAR1_IN14_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B0_00 for Mode: ALT7"]
-            pub const GPIO_SD_B0_00_ALT7: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_14 for Mode: ALT1"]
-            pub const GPIO_EMC_14_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_AD_B0_00 for Mode: ALT1"]
+            pub const GPIO_AD_B0_00_ALT1: u32 = 0;
+            #[doc = "Selecting Pad:GPIO_B1_00 for Mode: ALT1"]
+            pub const GPIO_B1_00_ALT1: u32 = 0x01;
         }
     }
 }
@@ -24256,10 +24256,10 @@ pub mod XBAR1_IN15_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B0_01 for Mode: ALT7"]
-            pub const GPIO_SD_B0_01_ALT7: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_15 for Mode: ALT1"]
-            pub const GPIO_EMC_15_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_AD_B0_01 for Mode: ALT1"]
+            pub const GPIO_AD_B0_01_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B1_01 for Mode: ALT1"]
+            pub const GPIO_B1_01_ALT1: u32 = 0x01;
         }
     }
 }
@@ -24272,10 +24272,10 @@ pub mod XBAR1_IN16_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B0_02 for Mode: ALT7"]
-            pub const GPIO_SD_B0_02_ALT7: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_18 for Mode: ALT1"]
-            pub const GPIO_EMC_18_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_AD_B0_02 for Mode: ALT1"]
+            pub const GPIO_AD_B0_02_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B1_02 for Mode: ALT1"]
+            pub const GPIO_B1_02_ALT1: u32 = 0x01;
         }
     }
 }
@@ -24304,10 +24304,10 @@ pub mod XBAR1_IN19_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_29 for Mode: ALT2"]
-            pub const GPIO_EMC_29_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_41 for Mode: ALT1"]
-            pub const GPIO_EMC_41_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_14 for Mode: ALT1"]
+            pub const GPIO_EMC_14_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_07 for Mode: ALT6"]
+            pub const GPIO_AD_B0_07_ALT6: u32 = 0x01;
         }
     }
 }
@@ -28115,10 +28115,10 @@ pub mod SAI3_IPG_CLK_SAI_MCLK_SELECT_INPUT_2 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B1_05 for Mode: ALT3"]
-            pub const GPIO_SD_B1_05_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_17 for Mode: ALT3"]
-            pub const GPIO_EMC_17_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_37 for Mode: ALT3"]
+            pub const GPIO_EMC_37_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_SD_B1_04 for Mode: ALT8"]
+            pub const GPIO_SD_B1_04_ALT8: u32 = 0x01;
         }
     }
 }
@@ -28179,10 +28179,10 @@ pub mod SAI3_IPP_IND_SAI_TXBCLK_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B1_06 for Mode: ALT3"]
-            pub const GPIO_SD_B1_06_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_33 for Mode: ALT3"]
-            pub const GPIO_EMC_33_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_38 for Mode: ALT3"]
+            pub const GPIO_EMC_38_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_SD_B1_03 for Mode: ALT8"]
+            pub const GPIO_SD_B1_03_ALT8: u32 = 0x01;
         }
     }
 }
@@ -28195,10 +28195,10 @@ pub mod SAI3_IPP_IND_SAI_TXSYNC_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B1_07 for Mode: ALT3"]
-            pub const GPIO_SD_B1_07_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_34 for Mode: ALT3"]
-            pub const GPIO_EMC_34_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_39 for Mode: ALT3"]
+            pub const GPIO_EMC_39_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_SD_B1_02 for Mode: ALT8"]
+            pub const GPIO_SD_B1_02_ALT8: u32 = 0x01;
         }
     }
 }

--- a/src/blocks/imxrt1064/iomuxc.rs
+++ b/src/blocks/imxrt1064/iomuxc.rs
@@ -5952,9 +5952,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_00 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -5977,13 +5977,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_00 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -6079,9 +6079,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_01 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -6104,13 +6104,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_01 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -6206,9 +6206,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_02 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -6231,13 +6231,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_02 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -6333,9 +6333,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_03 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -6358,13 +6358,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_03 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -6460,9 +6460,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_04 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -6485,13 +6485,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_04 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -6587,9 +6587,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_05 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -6612,13 +6612,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_05 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -6714,9 +6714,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_06 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -6739,13 +6739,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_06 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -6841,9 +6841,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_07 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -6866,13 +6866,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_07 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -6968,9 +6968,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_08 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -6993,13 +6993,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_08 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -7095,9 +7095,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_09 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -7120,13 +7120,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_09 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -7222,9 +7222,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_10 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -7247,13 +7247,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_10 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -7349,9 +7349,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_11 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -7374,13 +7374,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_11 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -7476,9 +7476,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_12 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -7501,13 +7501,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_12 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -7603,9 +7603,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_13 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -7628,13 +7628,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_13 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -7730,9 +7730,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_14 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -7755,13 +7755,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_14 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -7857,9 +7857,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_15 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -7882,13 +7882,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_15 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -7984,9 +7984,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_16 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -8009,13 +8009,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_16 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -8111,9 +8111,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_17 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -8136,13 +8136,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_17 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -8238,9 +8238,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_18 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -8263,13 +8263,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_18 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -8365,9 +8365,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_19 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -8390,13 +8390,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_19 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -8492,9 +8492,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_20 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -8517,13 +8517,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_20 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -8619,9 +8619,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_21 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -8644,13 +8644,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_21 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -8746,9 +8746,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_22 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -8771,13 +8771,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_22 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -8873,9 +8873,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_23 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -8898,13 +8898,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_23 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -9000,9 +9000,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_24 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -9025,13 +9025,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_24 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -9127,9 +9127,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_25 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -9152,13 +9152,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_25 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -9254,9 +9254,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_26 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -9279,13 +9279,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_26 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -9381,9 +9381,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_27 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -9406,13 +9406,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_27 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -9508,9 +9508,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_28 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -9533,13 +9533,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_28 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -9635,9 +9635,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_29 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -9660,13 +9660,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_29 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -9762,9 +9762,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_30 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -9787,13 +9787,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_30 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -9889,9 +9889,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_31 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -9914,13 +9914,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_31 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -10016,9 +10016,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_32 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -10041,13 +10041,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_32 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -10143,9 +10143,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_33 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -10168,13 +10168,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_33 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -10270,9 +10270,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_34 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -10295,13 +10295,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_34 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -10397,9 +10397,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_35 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -10422,13 +10422,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_35 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -10524,9 +10524,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_36 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -10549,13 +10549,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_36 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -10651,9 +10651,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_37 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -10676,13 +10676,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_37 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -10778,9 +10778,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_38 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -10803,13 +10803,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_38 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -10905,9 +10905,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_39 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -10930,13 +10930,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_39 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -11032,9 +11032,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_40 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -11057,13 +11057,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_40 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -11159,9 +11159,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_41 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -11184,13 +11184,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_EMC_41 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -11286,9 +11286,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_00 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -11311,13 +11311,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_00 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -11413,9 +11413,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_01 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -11438,13 +11438,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_01 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -11540,9 +11540,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_02 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -11565,13 +11565,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_02 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -11667,9 +11667,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_03 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -11692,13 +11692,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_03 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -11794,9 +11794,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_04 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -11819,13 +11819,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_04 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -11921,9 +11921,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_05 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -11946,13 +11946,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_05 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -12048,9 +12048,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_06 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -12073,13 +12073,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_06 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -12175,9 +12175,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_07 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -12200,13 +12200,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_07 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -12302,9 +12302,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_08 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -12327,13 +12327,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_08 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -12429,9 +12429,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_09 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -12454,13 +12454,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_09 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -12556,9 +12556,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_10 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -12581,13 +12581,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_10 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -12683,9 +12683,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_11 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -12708,13 +12708,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_11 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -12810,9 +12810,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_12 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -12835,13 +12835,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_12 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -12937,9 +12937,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_13 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -12962,13 +12962,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_13 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -13064,9 +13064,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_14 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -13089,13 +13089,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_14 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -13191,9 +13191,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_15 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -13216,13 +13216,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B0_15 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -13318,9 +13318,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_00 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -13343,13 +13343,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_00 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -13445,9 +13445,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_01 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -13470,13 +13470,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_01 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -13572,9 +13572,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_02 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -13597,13 +13597,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_02 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -13699,9 +13699,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_03 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -13724,13 +13724,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_03 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -13826,9 +13826,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_04 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -13851,13 +13851,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_04 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -13953,9 +13953,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_05 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -13978,13 +13978,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_05 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -14080,9 +14080,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_06 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -14105,13 +14105,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_06 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -14207,9 +14207,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_07 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -14232,13 +14232,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_07 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -14334,9 +14334,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_08 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -14359,13 +14359,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_08 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -14461,9 +14461,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_09 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -14486,13 +14486,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_09 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -14588,9 +14588,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_10 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -14613,13 +14613,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_10 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -14715,9 +14715,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_11 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -14740,13 +14740,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_11 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -14842,9 +14842,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_12 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -14867,13 +14867,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_12 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -14969,9 +14969,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_13 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -14994,13 +14994,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_13 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -15096,9 +15096,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_14 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -15121,13 +15121,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_14 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -15223,9 +15223,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_15 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -15248,13 +15248,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_B1_15 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -19414,9 +19414,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B0_00 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -19439,13 +19439,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B0_00 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -19541,9 +19541,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B0_01 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -19566,13 +19566,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B0_01 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -19668,9 +19668,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B0_02 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -19693,13 +19693,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B0_02 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -19795,9 +19795,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B0_03 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -19820,13 +19820,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B0_03 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -19922,9 +19922,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B0_04 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -19947,13 +19947,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B0_04 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -20049,9 +20049,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B0_05 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -20074,13 +20074,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B0_05 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -20176,9 +20176,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_00 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -20201,13 +20201,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_00 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -20303,9 +20303,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_01 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -20328,13 +20328,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_01 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -20430,9 +20430,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_02 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -20455,13 +20455,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_02 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -20557,9 +20557,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_03 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -20582,13 +20582,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_03 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -20684,9 +20684,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_04 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -20709,13 +20709,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_04 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -20811,9 +20811,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_05 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -20836,13 +20836,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_05 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -20938,9 +20938,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_06 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -20963,13 +20963,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_06 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -21065,9 +21065,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_07 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -21090,13 +21090,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_07 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -21192,9 +21192,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_08 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -21217,13 +21217,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_08 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -21319,9 +21319,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_09 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -21344,13 +21344,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_09 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -21446,9 +21446,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_10 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -21471,13 +21471,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_10 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -21573,9 +21573,9 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_11 {
         pub mod W {}
         pub mod RW {
             #[doc = "output driver disabled;"]
-            pub const DSE_0_OUTPUT_DRIVER_DISABLED_: u32 = 0;
+            pub const DSE_0_OUTPUT_DRIVER_DISABLED: u32 = 0;
             #[doc = "R0(150 Ohm @ 3.3V, 260 Ohm@1.8V)"]
-            pub const DSE_1_R0_150_OHM___3_3V__260_OHM_1_8V: u32 = 0x01;
+            pub const DSE_1_R0_150_OHM_3_3V_260_OHM_1_8V: u32 = 0x01;
             #[doc = "R0/2"]
             pub const DSE_2_R0_2: u32 = 0x02;
             #[doc = "R0/3"]
@@ -21598,13 +21598,13 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_11 {
         pub mod W {}
         pub mod RW {
             #[doc = "low(50MHz)"]
-            pub const SPEED_0_LOW_50MHZ_: u32 = 0;
+            pub const SPEED_0_LOW_50MHZ: u32 = 0;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_1_MEDIUM_100MHZ_: u32 = 0x01;
+            pub const SPEED_1_MEDIUM_100MHZ: u32 = 0x01;
             #[doc = "medium(100MHz)"]
-            pub const SPEED_2_MEDIUM_100MHZ_: u32 = 0x02;
+            pub const SPEED_2_MEDIUM_100MHZ: u32 = 0x02;
             #[doc = "max(200MHz)"]
-            pub const SPEED_3_MAX_200MHZ_: u32 = 0x03;
+            pub const SPEED_3_MAX_200MHZ: u32 = 0x03;
         }
     }
     #[doc = "Open Drain Enable Field"]
@@ -21936,12 +21936,12 @@ pub mod ENET_MDIO_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B0_02 for Mode: ALT6"]
-            pub const GPIO_SD_B0_02_ALT6: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_AD_B0_04 for Mode: ALT4"]
-            pub const GPIO_AD_B0_04_ALT4: u32 = 0x01;
-            #[doc = "Selecting Pad: GPIO_EMC_40 for Mode: ALT4"]
-            pub const GPIO_EMC_40_ALT4: u32 = 0x02;
+            #[doc = "Selecting Pad: GPIO_AD_B1_05 for Mode: ALT1"]
+            pub const GPIO_AD_B1_05_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_EMC_41 for Mode: ALT4"]
+            pub const GPIO_EMC_41_ALT4: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_B1_15 for Mode: ALT0"]
+            pub const GPIO_B1_15_ALT0: u32 = 0x02;
         }
     }
 }
@@ -22052,14 +22052,14 @@ pub mod FLEXCAN1_RX_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_01 for Mode: ALT6"]
-            pub const GPIO_EMC_01_ALT6: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_SD_B1_01 for Mode: ALT4"]
-            pub const GPIO_SD_B1_01_ALT4: u32 = 0x01;
-            #[doc = "Selecting Pad: GPIO_AD_B0_05 for Mode: ALT1"]
-            pub const GPIO_AD_B0_05_ALT1: u32 = 0x02;
-            #[doc = "Selecting Pad: GPIO_EMC_15 for Mode: ALT6"]
-            pub const GPIO_EMC_15_ALT6: u32 = 0x03;
+            #[doc = "Selecting Pad: GPIO_SD_B1_03 for Mode: ALT4"]
+            pub const GPIO_SD_B1_03_ALT4: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_EMC_18 for Mode: ALT3"]
+            pub const GPIO_EMC_18_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_AD_B1_09 for Mode: ALT2"]
+            pub const GPIO_AD_B1_09_ALT2: u32 = 0x02;
+            #[doc = "Selecting Pad: GPIO_B0_03 for Mode: ALT2"]
+            pub const GPIO_B0_03_ALT2: u32 = 0x03;
         }
     }
 }
@@ -22072,14 +22072,14 @@ pub mod FLEXCAN2_RX_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B0_05 for Mode: ALT1"]
-            pub const GPIO_SD_B0_05_ALT1: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_09 for Mode: ALT2"]
-            pub const GPIO_EMC_09_ALT2: u32 = 0x01;
-            #[doc = "Selecting Pad: GPIO_AD_B0_15 for Mode: ALT1"]
-            pub const GPIO_AD_B0_15_ALT1: u32 = 0x02;
-            #[doc = "Selecting Pad: GPIO_AD_B1_01 for Mode: ALT2"]
-            pub const GPIO_AD_B1_01_ALT2: u32 = 0x03;
+            #[doc = "Selecting Pad: GPIO_EMC_10 for Mode: ALT3"]
+            pub const GPIO_EMC_10_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_03 for Mode: ALT0"]
+            pub const GPIO_AD_B0_03_ALT0: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_AD_B0_15 for Mode: ALT6"]
+            pub const GPIO_AD_B0_15_ALT6: u32 = 0x02;
+            #[doc = "Selecting Pad: GPIO_B1_09 for Mode: ALT6"]
+            pub const GPIO_B1_09_ALT6: u32 = 0x03;
         }
     }
 }
@@ -22114,10 +22114,10 @@ pub mod FLEXPWM1_PWMA0_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_06 for Mode: ALT1"]
-            pub const GPIO_AD_B1_06_ALT1: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_26 for Mode: ALT1"]
-            pub const GPIO_EMC_26_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_23 for Mode: ALT1"]
+            pub const GPIO_EMC_23_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_SD_B0_00 for Mode: ALT1"]
+            pub const GPIO_SD_B0_00_ALT1: u32 = 0x01;
         }
     }
 }
@@ -22130,10 +22130,10 @@ pub mod FLEXPWM1_PWMA1_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_08 for Mode: ALT1"]
-            pub const GPIO_AD_B1_08_ALT1: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_24 for Mode: ALT1"]
-            pub const GPIO_EMC_24_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_25 for Mode: ALT1"]
+            pub const GPIO_EMC_25_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_SD_B0_02 for Mode: ALT1"]
+            pub const GPIO_SD_B0_02_ALT1: u32 = 0x01;
         }
     }
 }
@@ -22146,10 +22146,10 @@ pub mod FLEXPWM1_PWMA2_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_10 for Mode: ALT1"]
-            pub const GPIO_AD_B1_10_ALT1: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_22 for Mode: ALT1"]
-            pub const GPIO_EMC_22_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_27 for Mode: ALT1"]
+            pub const GPIO_EMC_27_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_SD_B0_04 for Mode: ALT1"]
+            pub const GPIO_SD_B0_04_ALT1: u32 = 0x01;
         }
     }
 }
@@ -22184,10 +22184,10 @@ pub mod FLEXPWM1_PWMB0_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_07 for Mode: ALT1"]
-            pub const GPIO_AD_B1_07_ALT1: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_27 for Mode: ALT1"]
-            pub const GPIO_EMC_27_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_24 for Mode: ALT1"]
+            pub const GPIO_EMC_24_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_SD_B0_01 for Mode: ALT1"]
+            pub const GPIO_SD_B0_01_ALT1: u32 = 0x01;
         }
     }
 }
@@ -22200,10 +22200,10 @@ pub mod FLEXPWM1_PWMB1_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_09 for Mode: ALT1"]
-            pub const GPIO_AD_B1_09_ALT1: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_25 for Mode: ALT1"]
-            pub const GPIO_EMC_25_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_26 for Mode: ALT1"]
+            pub const GPIO_EMC_26_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_SD_B0_03 for Mode: ALT1"]
+            pub const GPIO_SD_B0_03_ALT1: u32 = 0x01;
         }
     }
 }
@@ -22216,10 +22216,10 @@ pub mod FLEXPWM1_PWMB2_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_11 for Mode: ALT1"]
-            pub const GPIO_AD_B1_11_ALT1: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_23 for Mode: ALT1"]
-            pub const GPIO_EMC_23_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_28 for Mode: ALT1"]
+            pub const GPIO_EMC_28_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_SD_B0_05 for Mode: ALT1"]
+            pub const GPIO_SD_B0_05_ALT1: u32 = 0x01;
         }
     }
 }
@@ -22254,10 +22254,10 @@ pub mod FLEXPWM2_PWMA0_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B0_14 for Mode: ALT4"]
-            pub const GPIO_AD_B0_14_ALT4: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_38 for Mode: ALT1"]
-            pub const GPIO_EMC_38_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_06 for Mode: ALT1"]
+            pub const GPIO_EMC_06_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B0_06 for Mode: ALT2"]
+            pub const GPIO_B0_06_ALT2: u32 = 0x01;
         }
     }
 }
@@ -22270,10 +22270,10 @@ pub mod FLEXPWM2_PWMA1_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B0_12 for Mode: ALT4"]
-            pub const GPIO_AD_B0_12_ALT4: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_36 for Mode: ALT1"]
-            pub const GPIO_EMC_36_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_08 for Mode: ALT1"]
+            pub const GPIO_EMC_08_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B0_08 for Mode: ALT2"]
+            pub const GPIO_B0_08_ALT2: u32 = 0x01;
         }
     }
 }
@@ -22286,10 +22286,10 @@ pub mod FLEXPWM2_PWMA2_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B0_10 for Mode: ALT4"]
-            pub const GPIO_AD_B0_10_ALT4: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_30 for Mode: ALT1"]
-            pub const GPIO_EMC_30_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_10 for Mode: ALT1"]
+            pub const GPIO_EMC_10_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B0_10 for Mode: ALT2"]
+            pub const GPIO_B0_10_ALT2: u32 = 0x01;
         }
     }
 }
@@ -22322,10 +22322,10 @@ pub mod FLEXPWM2_PWMB0_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B0_15 for Mode: ALT4"]
-            pub const GPIO_AD_B0_15_ALT4: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_39 for Mode: ALT1"]
-            pub const GPIO_EMC_39_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_07 for Mode: ALT1"]
+            pub const GPIO_EMC_07_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B0_07 for Mode: ALT2"]
+            pub const GPIO_B0_07_ALT2: u32 = 0x01;
         }
     }
 }
@@ -22338,10 +22338,10 @@ pub mod FLEXPWM2_PWMB1_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B0_13 for Mode: ALT4"]
-            pub const GPIO_AD_B0_13_ALT4: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_37 for Mode: ALT1"]
-            pub const GPIO_EMC_37_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_09 for Mode: ALT1"]
+            pub const GPIO_EMC_09_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B0_09 for Mode: ALT2"]
+            pub const GPIO_B0_09_ALT2: u32 = 0x01;
         }
     }
 }
@@ -22354,10 +22354,10 @@ pub mod FLEXPWM2_PWMB2_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B0_11 for Mode: ALT4"]
-            pub const GPIO_AD_B0_11_ALT4: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_31 for Mode: ALT1"]
-            pub const GPIO_EMC_31_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_11 for Mode: ALT1"]
+            pub const GPIO_EMC_11_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B0_11 for Mode: ALT2"]
+            pub const GPIO_B0_11_ALT2: u32 = 0x01;
         }
     }
 }
@@ -22594,10 +22594,10 @@ pub mod LPI2C1_SCL_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_02 for Mode: ALT6"]
-            pub const GPIO_EMC_02_ALT6: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_AD_B1_14 for Mode: ALT0"]
-            pub const GPIO_AD_B1_14_ALT0: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B1_04 for Mode: ALT2"]
+            pub const GPIO_SD_B1_04_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B1_00 for Mode: ALT3"]
+            pub const GPIO_AD_B1_00_ALT3: u32 = 0x01;
         }
     }
 }
@@ -22610,10 +22610,10 @@ pub mod LPI2C1_SDA_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_03 for Mode: ALT6"]
-            pub const GPIO_EMC_03_ALT6: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_AD_B1_15 for Mode: ALT0"]
-            pub const GPIO_AD_B1_15_ALT0: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B1_05 for Mode: ALT2"]
+            pub const GPIO_SD_B1_05_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B1_01 for Mode: ALT3"]
+            pub const GPIO_AD_B1_01_ALT3: u32 = 0x01;
         }
     }
 }
@@ -22626,10 +22626,10 @@ pub mod LPI2C2_SCL_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_08 for Mode: ALT0"]
-            pub const GPIO_AD_B1_08_ALT0: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_19 for Mode: ALT2"]
-            pub const GPIO_EMC_19_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B1_11 for Mode: ALT3"]
+            pub const GPIO_SD_B1_11_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B0_04 for Mode: ALT2"]
+            pub const GPIO_B0_04_ALT2: u32 = 0x01;
         }
     }
 }
@@ -22642,10 +22642,10 @@ pub mod LPI2C2_SDA_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_09 for Mode: ALT0"]
-            pub const GPIO_AD_B1_09_ALT0: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_18 for Mode: ALT2"]
-            pub const GPIO_EMC_18_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B1_10 for Mode: ALT3"]
+            pub const GPIO_SD_B1_10_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B0_05 for Mode: ALT2"]
+            pub const GPIO_B0_05_ALT2: u32 = 0x01;
         }
     }
 }
@@ -22694,10 +22694,10 @@ pub mod LPI2C4_SCL_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_11 for Mode: ALT2"]
-            pub const GPIO_EMC_11_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_SD_B1_02 for Mode: ALT3"]
-            pub const GPIO_SD_B1_02_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_12 for Mode: ALT2"]
+            pub const GPIO_EMC_12_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_12 for Mode: ALT0"]
+            pub const GPIO_AD_B0_12_ALT0: u32 = 0x01;
         }
     }
 }
@@ -22710,10 +22710,10 @@ pub mod LPI2C4_SDA_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_10 for Mode: ALT2"]
-            pub const GPIO_EMC_10_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_SD_B1_03 for Mode: ALT3"]
-            pub const GPIO_SD_B1_03_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_11 for Mode: ALT2"]
+            pub const GPIO_EMC_11_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_13 for Mode: ALT0"]
+            pub const GPIO_AD_B0_13_ALT0: u32 = 0x01;
         }
     }
 }
@@ -22726,10 +22726,10 @@ pub mod LPSPI1_PCS0_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B0_03 for Mode: ALT4"]
-            pub const GPIO_SD_B0_03_ALT4: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_AD_B0_11 for Mode: ALT1"]
-            pub const GPIO_AD_B0_11_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B0_01 for Mode: ALT4"]
+            pub const GPIO_SD_B0_01_ALT4: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_EMC_30 for Mode: ALT3"]
+            pub const GPIO_EMC_30_ALT3: u32 = 0x01;
         }
     }
 }
@@ -22742,10 +22742,10 @@ pub mod LPSPI1_SCK_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_06 for Mode: ALT0"]
-            pub const GPIO_AD_06_ALT0: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_SD_08 for Mode: ALT2"]
-            pub const GPIO_SD_08_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_27 for Mode: ALT3"]
+            pub const GPIO_EMC_27_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_SD_B0_00 for Mode: ALT4"]
+            pub const GPIO_SD_B0_00_ALT4: u32 = 0x01;
         }
     }
 }
@@ -22758,10 +22758,10 @@ pub mod LPSPI1_SDI_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_03 for Mode: ALT0"]
-            pub const GPIO_AD_03_ALT0: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_SD_05 for Mode: ALT2"]
-            pub const GPIO_SD_05_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_29 for Mode: ALT3"]
+            pub const GPIO_EMC_29_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_03 for Mode: ALT4"]
+            pub const GPIO_SD_B0_03_ALT4: u32 = 0x01;
         }
     }
 }
@@ -22774,10 +22774,10 @@ pub mod LPSPI1_SDO_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_04 for Mode: ALT0"]
-            pub const GPIO_AD_04_ALT0: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_SD_06 for Mode: ALT2"]
-            pub const GPIO_SD_06_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_28 for Mode: ALT3"]
+            pub const GPIO_EMC_28_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_SD_B0_02 for Mode: ALT4"]
+            pub const GPIO_SD_B0_02_ALT4: u32 = 0x01;
         }
     }
 }
@@ -22806,10 +22806,10 @@ pub mod LPSPI2_SCK_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_12 for Mode: ALT0"]
-            pub const GPIO_AD_12_ALT0: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_SD_11 for Mode: ALT1"]
-            pub const GPIO_SD_11_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B1_07 for Mode: ALT4"]
+            pub const GPIO_SD_B1_07_ALT4: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_EMC_00 for Mode: ALT2"]
+            pub const GPIO_EMC_00_ALT2: u32 = 0x01;
         }
     }
 }
@@ -22822,10 +22822,10 @@ pub mod LPSPI2_SDI_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_09 for Mode: ALT0"]
-            pub const GPIO_AD_09_ALT0: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_SD_09 for Mode: ALT1"]
-            pub const GPIO_SD_09_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B1_09 for Mode: ALT4"]
+            pub const GPIO_SD_B1_09_ALT4: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_EMC_03 for Mode: ALT2"]
+            pub const GPIO_EMC_03_ALT2: u32 = 0x01;
         }
     }
 }
@@ -22838,10 +22838,10 @@ pub mod LPSPI2_SDO_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_10 for Mode: ALT0"]
-            pub const GPIO_AD_10_ALT0: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_SD_10 for Mode: ALT1"]
-            pub const GPIO_SD_10_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B1_08 for Mode: ALT4"]
+            pub const GPIO_SD_B1_08_ALT4: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_EMC_02 for Mode: ALT2"]
+            pub const GPIO_EMC_02_ALT2: u32 = 0x01;
         }
     }
 }
@@ -22918,10 +22918,10 @@ pub mod LPSPI4_PCS0_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_03 for Mode: ALT2"]
-            pub const GPIO_AD_B1_03_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_33 for Mode: ALT4"]
-            pub const GPIO_EMC_33_ALT4: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_B0_00 for Mode: ALT3"]
+            pub const GPIO_B0_00_ALT3: u32 = 0;
+            #[doc = "Selecting Pad:GPIO_B1_04 for Mode: ALT1"]
+            pub const GPIO_B1_04_ALT1: u32 = 0x01;
         }
     }
 }
@@ -22934,10 +22934,10 @@ pub mod LPSPI4_SCK_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_02 for Mode: ALT2"]
-            pub const GPIO_AD_B1_02_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_32 for Mode: ALT4"]
-            pub const GPIO_EMC_32_ALT4: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_B0_03 for Mode: ALT3"]
+            pub const GPIO_B0_03_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B1_07 for Mode: ALT1"]
+            pub const GPIO_B1_07_ALT1: u32 = 0x01;
         }
     }
 }
@@ -22950,10 +22950,10 @@ pub mod LPSPI4_SDI_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_05 for Mode: ALT2"]
-            pub const GPIO_AD_B1_05_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_35 for Mode: ALT4"]
-            pub const GPIO_EMC_35_ALT4: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_B0_01 for Mode: ALT3"]
+            pub const GPIO_B0_01_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B1_05 for Mode: ALT1"]
+            pub const GPIO_B1_05_ALT1: u32 = 0x01;
         }
     }
 }
@@ -22966,10 +22966,10 @@ pub mod LPSPI4_SDO_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_04 for Mode: ALT2"]
-            pub const GPIO_AD_B1_04_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_34 for Mode: ALT4"]
-            pub const GPIO_EMC_34_ALT4: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_B0_02 for Mode: ALT3"]
+            pub const GPIO_B0_02_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B1_06 for Mode: ALT1"]
+            pub const GPIO_B1_06_ALT1: u32 = 0x01;
         }
     }
 }
@@ -22982,10 +22982,10 @@ pub mod LPUART2_RX_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_09 for Mode: ALT2"]
-            pub const GPIO_AD_B1_09_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_23 for Mode: ALT2"]
-            pub const GPIO_EMC_23_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B1_10 for Mode: ALT2"]
+            pub const GPIO_SD_B1_10_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B1_03 for Mode: ALT2"]
+            pub const GPIO_AD_B1_03_ALT2: u32 = 0x01;
         }
     }
 }
@@ -22998,10 +22998,10 @@ pub mod LPUART2_TX_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_08 for Mode: ALT2"]
-            pub const GPIO_AD_B1_08_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_22 for Mode: ALT2"]
-            pub const GPIO_EMC_22_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B1_11 for Mode: ALT2"]
+            pub const GPIO_SD_B1_11_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B1_02 for Mode: ALT2"]
+            pub const GPIO_AD_B1_02_ALT2: u32 = 0x01;
         }
     }
 }
@@ -23066,12 +23066,12 @@ pub mod LPUART4_RX_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_03 for Mode: ALT2"]
-            pub const GPIO_EMC_03_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_AD_B1_11 for Mode: ALT2"]
-            pub const GPIO_AD_B1_11_ALT2: u32 = 0x01;
-            #[doc = "Selecting Pad: GPIO_EMC_33 for Mode: ALT2"]
-            pub const GPIO_EMC_33_ALT2: u32 = 0x02;
+            #[doc = "Selecting Pad: GPIO_SD_B1_01 for Mode: ALT4"]
+            pub const GPIO_SD_B1_01_ALT4: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_EMC_20 for Mode: ALT2"]
+            pub const GPIO_EMC_20_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_B1_01 for Mode: ALT2"]
+            pub const GPIO_B1_01_ALT2: u32 = 0x02;
         }
     }
 }
@@ -23084,12 +23084,12 @@ pub mod LPUART4_TX_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_02 for Mode: ALT2"]
-            pub const GPIO_EMC_02_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_AD_B1_10 for Mode: ALT2"]
-            pub const GPIO_AD_B1_10_ALT2: u32 = 0x01;
-            #[doc = "Selecting Pad: GPIO_EMC_32 for Mode: ALT2"]
-            pub const GPIO_EMC_32_ALT2: u32 = 0x02;
+            #[doc = "Selecting Pad: GPIO_SD_B1_00 for Mode: ALT4"]
+            pub const GPIO_SD_B1_00_ALT4: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_EMC_19 for Mode: ALT2"]
+            pub const GPIO_EMC_19_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_B1_00 for Mode: ALT2"]
+            pub const GPIO_B1_00_ALT2: u32 = 0x02;
         }
     }
 }
@@ -23102,10 +23102,10 @@ pub mod LPUART5_RX_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B0_11 for Mode: ALT2"]
-            pub const GPIO_AD_B0_11_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_39 for Mode: ALT2"]
-            pub const GPIO_EMC_39_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_24 for Mode: ALT2"]
+            pub const GPIO_EMC_24_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B1_13 for Mode: ALT1"]
+            pub const GPIO_B1_13_ALT1: u32 = 0x01;
         }
     }
 }
@@ -23118,10 +23118,10 @@ pub mod LPUART5_TX_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B0_10 for Mode: ALT2"]
-            pub const GPIO_AD_B0_10_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_38 for Mode: ALT2"]
-            pub const GPIO_EMC_38_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_23 for Mode: ALT2"]
+            pub const GPIO_EMC_23_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B1_12 for Mode: ALT1"]
+            pub const GPIO_B1_12_ALT1: u32 = 0x01;
         }
     }
 }
@@ -23134,10 +23134,10 @@ pub mod LPUART6_RX_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_13 for Mode: ALT2"]
-            pub const GPIO_EMC_13_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_SD_B1_01 for Mode: ALT2"]
-            pub const GPIO_SD_B1_01_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_26 for Mode: ALT2"]
+            pub const GPIO_EMC_26_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_03 for Mode: ALT2"]
+            pub const GPIO_AD_B0_03_ALT2: u32 = 0x01;
         }
     }
 }
@@ -23150,10 +23150,10 @@ pub mod LPUART6_TX_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_12 for Mode: ALT2"]
-            pub const GPIO_EMC_12_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_SD_B1_00 for Mode: ALT2"]
-            pub const GPIO_SD_B1_00_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_25 for Mode: ALT2"]
+            pub const GPIO_EMC_25_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_02 for Mode: ALT2"]
+            pub const GPIO_AD_B0_02_ALT2: u32 = 0x01;
         }
     }
 }
@@ -23166,10 +23166,10 @@ pub mod LPUART7_RX_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B0_05 for Mode: ALT2"]
-            pub const GPIO_SD_B0_05_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_35 for Mode: ALT2"]
-            pub const GPIO_EMC_35_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B1_09 for Mode: ALT2"]
+            pub const GPIO_SD_B1_09_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_EMC_32 for Mode: ALT2"]
+            pub const GPIO_EMC_32_ALT2: u32 = 0x01;
         }
     }
 }
@@ -23182,10 +23182,10 @@ pub mod LPUART7_TX_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B0_04 for Mode: ALT2"]
-            pub const GPIO_SD_B0_04_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_34 for Mode: ALT2"]
-            pub const GPIO_EMC_34_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B1_08 for Mode: ALT2"]
+            pub const GPIO_SD_B1_08_ALT2: u32 = 0;
+            #[doc = "Selecting Pad:GPIO_EMC_31 for Mode: ALT2"]
+            pub const GPIO_EMC_31_ALT2: u32 = 0x01;
         }
     }
 }
@@ -23234,8 +23234,8 @@ pub mod NMI_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B0_05 for Mode: ALT7"]
-            pub const GPIO_AD_B0_05_ALT7: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_12 for Mode: ALT7"]
+            pub const GPIO_AD_B0_12_ALT7: u32 = 0;
             #[doc = "Selecting Pad: WAKEUP for Mode: ALT7"]
             pub const WAKEUP_ALT7: u32 = 0x01;
         }
@@ -23404,12 +23404,12 @@ pub mod SAI1_RX_BCLK_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_06 for Mode: ALT3"]
-            pub const GPIO_AD_B1_06_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_14 for Mode: ALT3"]
-            pub const GPIO_EMC_14_ALT3: u32 = 0x01;
-            #[doc = "Selecting Pad: GPIO_EMC_19 for Mode: ALT3"]
-            pub const GPIO_EMC_19_ALT3: u32 = 0x02;
+            #[doc = "Selecting Pad: GPIO_SD_B1_05 for Mode: ALT3"]
+            pub const GPIO_SD_B1_05_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B1_11 for Mode: ALT3"]
+            pub const GPIO_AD_B1_11_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_B0_15 for Mode: ALT3"]
+            pub const GPIO_B0_15_ALT3: u32 = 0x02;
         }
     }
 }
@@ -23422,12 +23422,12 @@ pub mod SAI1_RX_DATA0_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_13 for Mode: ALT3"]
-            pub const GPIO_EMC_13_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_AD_B1_05 for Mode: ALT3"]
-            pub const GPIO_AD_B1_05_ALT3: u32 = 0x01;
-            #[doc = "Selecting Pad: GPIO_EMC_21 for Mode: ALT3"]
-            pub const GPIO_EMC_21_ALT3: u32 = 0x02;
+            #[doc = "Selecting Pad: GPIO_SD_B1_06 for Mode: ALT3"]
+            pub const GPIO_SD_B1_06_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B1_12 for Mode: ALT3"]
+            pub const GPIO_AD_B1_12_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_B1_00 for Mode: ALT3"]
+            pub const GPIO_B1_00_ALT3: u32 = 0x02;
         }
     }
 }
@@ -23440,10 +23440,10 @@ pub mod SAI1_RX_DATA1_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_09 for Mode: ALT3"]
-            pub const GPIO_AD_B1_09_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_22 for Mode: ALT3"]
-            pub const GPIO_EMC_22_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B1_00 for Mode: ALT3"]
+            pub const GPIO_SD_B1_00_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B0_10 for Mode: ALT3"]
+            pub const GPIO_B0_10_ALT3: u32 = 0x01;
         }
     }
 }
@@ -23456,10 +23456,10 @@ pub mod SAI1_RX_DATA2_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_08 for Mode: ALT3"]
-            pub const GPIO_AD_B1_08_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_23 for Mode: ALT3"]
-            pub const GPIO_EMC_23_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B1_01 for Mode: ALT3"]
+            pub const GPIO_SD_B1_01_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B0_11 for Mode: ALT3"]
+            pub const GPIO_B0_11_ALT3: u32 = 0x01;
         }
     }
 }
@@ -23472,10 +23472,10 @@ pub mod SAI1_RX_DATA3_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_07 for Mode: ALT3"]
-            pub const GPIO_AD_B1_07_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_24 for Mode: ALT3"]
-            pub const GPIO_EMC_24_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_SD_B1_02 for Mode: ALT3"]
+            pub const GPIO_SD_B1_02_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B0_12 for Mode: ALT3"]
+            pub const GPIO_B0_12_ALT3: u32 = 0x01;
         }
     }
 }
@@ -23488,12 +23488,12 @@ pub mod SAI1_RX_SYNC_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_04 for Mode: ALT3"]
-            pub const GPIO_AD_B1_04_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_15 for Mode: ALT3"]
-            pub const GPIO_EMC_15_ALT3: u32 = 0x01;
-            #[doc = "Selecting Pad: GPIO_EMC_18 for Mode: ALT3"]
-            pub const GPIO_EMC_18_ALT3: u32 = 0x02;
+            #[doc = "Selecting Pad: GPIO_SD_B1_04 for Mode: ALT3"]
+            pub const GPIO_SD_B1_04_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B1_10 for Mode: ALT3"]
+            pub const GPIO_AD_B1_10_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_B0_14 for Mode: ALT3"]
+            pub const GPIO_B0_14_ALT3: u32 = 0x02;
         }
     }
 }
@@ -23506,12 +23506,12 @@ pub mod SAI1_TX_BCLK_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_11 for Mode: ALT3"]
-            pub const GPIO_EMC_11_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_AD_B1_01 for Mode: ALT3"]
-            pub const GPIO_AD_B1_01_ALT3: u32 = 0x01;
-            #[doc = "Selecting Pad: GPIO_EMC_26 for Mode: ALT3"]
-            pub const GPIO_EMC_26_ALT3: u32 = 0x02;
+            #[doc = "Selecting Pad: GPIO_SD_B1_08 for Mode: ALT3"]
+            pub const GPIO_SD_B1_08_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B1_14 for Mode: ALT3"]
+            pub const GPIO_AD_B1_14_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_B1_02 for Mode: ALT3"]
+            pub const GPIO_B1_02_ALT3: u32 = 0x02;
         }
     }
 }
@@ -23524,12 +23524,12 @@ pub mod SAI1_TX_SYNC_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_10 for Mode: ALT3"]
-            pub const GPIO_EMC_10_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_AD_B1_02 for Mode: ALT3"]
-            pub const GPIO_AD_B1_02_ALT3: u32 = 0x01;
-            #[doc = "Selecting Pad: GPIO_EMC_27 for Mode: ALT3"]
-            pub const GPIO_EMC_27_ALT3: u32 = 0x02;
+            #[doc = "Selecting Pad: GPIO_SD_B1_09 for Mode: ALT3"]
+            pub const GPIO_SD_B1_09_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B1_15 for Mode: ALT3"]
+            pub const GPIO_AD_B1_15_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_B1_03 for Mode: ALT3"]
+            pub const GPIO_B1_03_ALT3: u32 = 0x02;
         }
     }
 }
@@ -23558,10 +23558,10 @@ pub mod SAI2_RX_BCLK_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B0_02 for Mode: ALT3"]
-            pub const GPIO_SD_B0_02_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_09 for Mode: ALT3"]
-            pub const GPIO_EMC_09_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_10 for Mode: ALT2"]
+            pub const GPIO_EMC_10_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_06 for Mode: ALT3"]
+            pub const GPIO_AD_B0_06_ALT3: u32 = 0x01;
         }
     }
 }
@@ -23574,10 +23574,10 @@ pub mod SAI2_RX_DATA0_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B0_03 for Mode: ALT3"]
-            pub const GPIO_SD_B0_03_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_08 for Mode: ALT3"]
-            pub const GPIO_EMC_08_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_08 for Mode: ALT2"]
+            pub const GPIO_EMC_08_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_08 for Mode: ALT3"]
+            pub const GPIO_AD_B0_08_ALT3: u32 = 0x01;
         }
     }
 }
@@ -23590,10 +23590,10 @@ pub mod SAI2_RX_SYNC_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B0_01 for Mode: ALT3"]
-            pub const GPIO_SD_B0_01_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_07 for Mode: ALT3"]
-            pub const GPIO_EMC_07_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_09 for Mode: ALT2"]
+            pub const GPIO_EMC_09_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_07 for Mode: ALT3"]
+            pub const GPIO_AD_B0_07_ALT3: u32 = 0x01;
         }
     }
 }
@@ -23606,10 +23606,10 @@ pub mod SAI2_TX_BCLK_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B0_05 for Mode: ALT3"]
-            pub const GPIO_SD_B0_05_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_04 for Mode: ALT3"]
-            pub const GPIO_EMC_04_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_06 for Mode: ALT2"]
+            pub const GPIO_EMC_06_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_05 for Mode: ALT3"]
+            pub const GPIO_AD_B0_05_ALT3: u32 = 0x01;
         }
     }
 }
@@ -23622,10 +23622,10 @@ pub mod SAI2_TX_SYNC_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B0_06 for Mode: ALT3"]
-            pub const GPIO_SD_B0_06_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_05 for Mode: ALT3"]
-            pub const GPIO_EMC_05_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_05 for Mode: ALT2"]
+            pub const GPIO_EMC_05_ALT2: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_04 for Mode: ALT3"]
+            pub const GPIO_AD_B0_04_ALT3: u32 = 0x01;
         }
     }
 }
@@ -23638,10 +23638,10 @@ pub mod SPDIF_IN_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_05 for Mode: ALT2"]
-            pub const GPIO_EMC_05_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_41 for Mode: ALT2"]
-            pub const GPIO_EMC_41_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_AD_B1_03 for Mode: ALT3"]
+            pub const GPIO_AD_B1_03_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_EMC_16 for Mode: ALT3"]
+            pub const GPIO_EMC_16_ALT3: u32 = 0x01;
         }
     }
 }
@@ -23900,10 +23900,10 @@ pub mod USDHC2_WP_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B1_13 for Mode: ALT3"]
-            pub const GPIO_AD_B1_13_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_35 for Mode: ALT3"]
-            pub const GPIO_EMC_35_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_37 for Mode: ALT6"]
+            pub const GPIO_EMC_37_ALT6: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B1_10 for Mode: ALT6"]
+            pub const GPIO_AD_B1_10_ALT6: u32 = 0x01;
         }
     }
 }
@@ -24064,10 +24064,10 @@ pub mod XBAR1_IN18_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_28 for Mode: ALT2"]
-            pub const GPIO_EMC_28_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_40 for Mode: ALT1"]
-            pub const GPIO_EMC_40_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_35 for Mode: ALT1"]
+            pub const GPIO_EMC_35_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_06 for Mode: ALT6"]
+            pub const GPIO_AD_B0_06_ALT6: u32 = 0x01;
         }
     }
 }
@@ -24144,10 +24144,10 @@ pub mod XBAR1_IN14_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B0_00 for Mode: ALT7"]
-            pub const GPIO_SD_B0_00_ALT7: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_14 for Mode: ALT1"]
-            pub const GPIO_EMC_14_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_AD_B0_00 for Mode: ALT1"]
+            pub const GPIO_AD_B0_00_ALT1: u32 = 0;
+            #[doc = "Selecting Pad:GPIO_B1_00 for Mode: ALT1"]
+            pub const GPIO_B1_00_ALT1: u32 = 0x01;
         }
     }
 }
@@ -24160,10 +24160,10 @@ pub mod XBAR1_IN15_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B0_01 for Mode: ALT7"]
-            pub const GPIO_SD_B0_01_ALT7: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_15 for Mode: ALT1"]
-            pub const GPIO_EMC_15_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_AD_B0_01 for Mode: ALT1"]
+            pub const GPIO_AD_B0_01_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B1_01 for Mode: ALT1"]
+            pub const GPIO_B1_01_ALT1: u32 = 0x01;
         }
     }
 }
@@ -24176,10 +24176,10 @@ pub mod XBAR1_IN16_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B0_02 for Mode: ALT7"]
-            pub const GPIO_SD_B0_02_ALT7: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_18 for Mode: ALT1"]
-            pub const GPIO_EMC_18_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_AD_B0_02 for Mode: ALT1"]
+            pub const GPIO_AD_B0_02_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_B1_02 for Mode: ALT1"]
+            pub const GPIO_B1_02_ALT1: u32 = 0x01;
         }
     }
 }
@@ -24208,10 +24208,10 @@ pub mod XBAR1_IN19_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_EMC_29 for Mode: ALT2"]
-            pub const GPIO_EMC_29_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_41 for Mode: ALT1"]
-            pub const GPIO_EMC_41_ALT1: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_14 for Mode: ALT1"]
+            pub const GPIO_EMC_14_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_B0_07 for Mode: ALT6"]
+            pub const GPIO_AD_B0_07_ALT6: u32 = 0x01;
         }
     }
 }
@@ -27270,10 +27270,10 @@ pub mod SAI3_IPG_CLK_SAI_MCLK_SELECT_INPUT_2 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B1_05 for Mode: ALT3"]
-            pub const GPIO_SD_B1_05_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_17 for Mode: ALT3"]
-            pub const GPIO_EMC_17_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_37 for Mode: ALT3"]
+            pub const GPIO_EMC_37_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_SD_B1_04 for Mode: ALT8"]
+            pub const GPIO_SD_B1_04_ALT8: u32 = 0x01;
         }
     }
 }
@@ -27334,10 +27334,10 @@ pub mod SAI3_IPP_IND_SAI_TXBCLK_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B1_06 for Mode: ALT3"]
-            pub const GPIO_SD_B1_06_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_33 for Mode: ALT3"]
-            pub const GPIO_EMC_33_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_38 for Mode: ALT3"]
+            pub const GPIO_EMC_38_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_SD_B1_03 for Mode: ALT8"]
+            pub const GPIO_SD_B1_03_ALT8: u32 = 0x01;
         }
     }
 }
@@ -27350,10 +27350,10 @@ pub mod SAI3_IPP_IND_SAI_TXSYNC_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_B1_07 for Mode: ALT3"]
-            pub const GPIO_SD_B1_07_ALT3: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_34 for Mode: ALT3"]
-            pub const GPIO_EMC_34_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_39 for Mode: ALT3"]
+            pub const GPIO_EMC_39_ALT3: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_SD_B1_02 for Mode: ALT8"]
+            pub const GPIO_SD_B1_02_ALT8: u32 = 0x01;
         }
     }
 }

--- a/src/blocks/imxrt1176_cm4/iomuxc.rs
+++ b/src/blocks/imxrt1176_cm4/iomuxc.rs
@@ -12010,10 +12010,10 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_00 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Keeper"]
-            pub const PUE_0_KEEPER: u32 = 0;
-            #[doc = "Pull"]
-            pub const PUE_1_PULL: u32 = 0x01;
+            #[doc = "Pull Disable, Highz"]
+            pub const PUE_0_PULL_DISABLE__HIGHZ: u32 = 0;
+            #[doc = "Pull Enable"]
+            pub const PUE_1_PULL_ENABLE: u32 = 0x01;
         }
     }
     #[doc = "Pull Up / Down Config. Field"]
@@ -12036,10 +12036,10 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_00 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Open Drain Disabled"]
-            pub const ODE_0_OPEN_DRAIN_DISABLED: u32 = 0;
-            #[doc = "Open Drain Enabled"]
-            pub const ODE_1_OPEN_DRAIN_ENABLED: u32 = 0x01;
+            #[doc = "Disabled"]
+            pub const ODE_0_DISABLED: u32 = 0;
+            #[doc = "Enabled"]
+            pub const ODE_1_ENABLED: u32 = 0x01;
         }
     }
     #[doc = "Domain write protection"]
@@ -12112,10 +12112,10 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_01 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Keeper"]
-            pub const PUE_0_KEEPER: u32 = 0;
-            #[doc = "Pull"]
-            pub const PUE_1_PULL: u32 = 0x01;
+            #[doc = "Pull Disable, Highz"]
+            pub const PUE_0_PULL_DISABLE__HIGHZ: u32 = 0;
+            #[doc = "Pull Enable"]
+            pub const PUE_1_PULL_ENABLE: u32 = 0x01;
         }
     }
     #[doc = "Pull Up / Down Config. Field"]
@@ -12138,10 +12138,10 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_01 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Open Drain Disabled"]
-            pub const ODE_0_OPEN_DRAIN_DISABLED: u32 = 0;
-            #[doc = "Open Drain Enabled"]
-            pub const ODE_1_OPEN_DRAIN_ENABLED: u32 = 0x01;
+            #[doc = "Disabled"]
+            pub const ODE_0_DISABLED: u32 = 0;
+            #[doc = "Enabled"]
+            pub const ODE_1_ENABLED: u32 = 0x01;
         }
     }
     #[doc = "Domain write protection"]
@@ -12214,10 +12214,10 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_02 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Keeper"]
-            pub const PUE_0_KEEPER: u32 = 0;
-            #[doc = "Pull"]
-            pub const PUE_1_PULL: u32 = 0x01;
+            #[doc = "Pull Disable, Highz"]
+            pub const PUE_0_PULL_DISABLE__HIGHZ: u32 = 0;
+            #[doc = "Pull Enable"]
+            pub const PUE_1_PULL_ENABLE: u32 = 0x01;
         }
     }
     #[doc = "Pull Up / Down Config. Field"]
@@ -12240,10 +12240,10 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_02 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Open Drain Disabled"]
-            pub const ODE_0_OPEN_DRAIN_DISABLED: u32 = 0;
-            #[doc = "Open Drain Enabled"]
-            pub const ODE_1_OPEN_DRAIN_ENABLED: u32 = 0x01;
+            #[doc = "Disabled"]
+            pub const ODE_0_DISABLED: u32 = 0;
+            #[doc = "Enabled"]
+            pub const ODE_1_ENABLED: u32 = 0x01;
         }
     }
     #[doc = "Domain write protection"]
@@ -12316,10 +12316,10 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_03 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Keeper"]
-            pub const PUE_0_KEEPER: u32 = 0;
-            #[doc = "Pull"]
-            pub const PUE_1_PULL: u32 = 0x01;
+            #[doc = "Pull Disable, Highz"]
+            pub const PUE_0_PULL_DISABLE__HIGHZ: u32 = 0;
+            #[doc = "Pull Enable"]
+            pub const PUE_1_PULL_ENABLE: u32 = 0x01;
         }
     }
     #[doc = "Pull Up / Down Config. Field"]
@@ -12342,10 +12342,10 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_03 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Open Drain Disabled"]
-            pub const ODE_0_OPEN_DRAIN_DISABLED: u32 = 0;
-            #[doc = "Open Drain Enabled"]
-            pub const ODE_1_OPEN_DRAIN_ENABLED: u32 = 0x01;
+            #[doc = "Disabled"]
+            pub const ODE_0_DISABLED: u32 = 0;
+            #[doc = "Enabled"]
+            pub const ODE_1_ENABLED: u32 = 0x01;
         }
     }
     #[doc = "Domain write protection"]
@@ -12418,10 +12418,10 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_04 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Keeper"]
-            pub const PUE_0_KEEPER: u32 = 0;
-            #[doc = "Pull"]
-            pub const PUE_1_PULL: u32 = 0x01;
+            #[doc = "Pull Disable, Highz"]
+            pub const PUE_0_PULL_DISABLE__HIGHZ: u32 = 0;
+            #[doc = "Pull Enable"]
+            pub const PUE_1_PULL_ENABLE: u32 = 0x01;
         }
     }
     #[doc = "Pull Up / Down Config. Field"]
@@ -12444,10 +12444,10 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_04 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Open Drain Disabled"]
-            pub const ODE_0_OPEN_DRAIN_DISABLED: u32 = 0;
-            #[doc = "Open Drain Enabled"]
-            pub const ODE_1_OPEN_DRAIN_ENABLED: u32 = 0x01;
+            #[doc = "Disabled"]
+            pub const ODE_0_DISABLED: u32 = 0;
+            #[doc = "Enabled"]
+            pub const ODE_1_ENABLED: u32 = 0x01;
         }
     }
     #[doc = "Domain write protection"]
@@ -12520,10 +12520,10 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_05 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Keeper"]
-            pub const PUE_0_KEEPER: u32 = 0;
-            #[doc = "Pull"]
-            pub const PUE_1_PULL: u32 = 0x01;
+            #[doc = "Pull Disable, Highz"]
+            pub const PUE_0_PULL_DISABLE__HIGHZ: u32 = 0;
+            #[doc = "Pull Enable"]
+            pub const PUE_1_PULL_ENABLE: u32 = 0x01;
         }
     }
     #[doc = "Pull Up / Down Config. Field"]
@@ -12546,10 +12546,10 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_05 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Open Drain Disabled"]
-            pub const ODE_0_OPEN_DRAIN_DISABLED: u32 = 0;
-            #[doc = "Open Drain Enabled"]
-            pub const ODE_1_OPEN_DRAIN_ENABLED: u32 = 0x01;
+            #[doc = "Disabled"]
+            pub const ODE_0_DISABLED: u32 = 0;
+            #[doc = "Enabled"]
+            pub const ODE_1_ENABLED: u32 = 0x01;
         }
     }
     #[doc = "Domain write protection"]
@@ -12622,10 +12622,10 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_06 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Keeper"]
-            pub const PUE_0_KEEPER: u32 = 0;
-            #[doc = "Pull"]
-            pub const PUE_1_PULL: u32 = 0x01;
+            #[doc = "Pull Disable, Highz"]
+            pub const PUE_0_PULL_DISABLE__HIGHZ: u32 = 0;
+            #[doc = "Pull Enable"]
+            pub const PUE_1_PULL_ENABLE: u32 = 0x01;
         }
     }
     #[doc = "Pull Up / Down Config. Field"]
@@ -12648,10 +12648,10 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_06 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Open Drain Disabled"]
-            pub const ODE_0_OPEN_DRAIN_DISABLED: u32 = 0;
-            #[doc = "Open Drain Enabled"]
-            pub const ODE_1_OPEN_DRAIN_ENABLED: u32 = 0x01;
+            #[doc = "Disabled"]
+            pub const ODE_0_DISABLED: u32 = 0;
+            #[doc = "Enabled"]
+            pub const ODE_1_ENABLED: u32 = 0x01;
         }
     }
     #[doc = "Domain write protection"]
@@ -12724,10 +12724,10 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_07 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Keeper"]
-            pub const PUE_0_KEEPER: u32 = 0;
-            #[doc = "Pull"]
-            pub const PUE_1_PULL: u32 = 0x01;
+            #[doc = "Pull Disable, Highz"]
+            pub const PUE_0_PULL_DISABLE__HIGHZ: u32 = 0;
+            #[doc = "Pull Enable"]
+            pub const PUE_1_PULL_ENABLE: u32 = 0x01;
         }
     }
     #[doc = "Pull Up / Down Config. Field"]
@@ -12750,10 +12750,10 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_07 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Open Drain Disabled"]
-            pub const ODE_0_OPEN_DRAIN_DISABLED: u32 = 0;
-            #[doc = "Open Drain Enabled"]
-            pub const ODE_1_OPEN_DRAIN_ENABLED: u32 = 0x01;
+            #[doc = "Disabled"]
+            pub const ODE_0_DISABLED: u32 = 0;
+            #[doc = "Enabled"]
+            pub const ODE_1_ENABLED: u32 = 0x01;
         }
     }
     #[doc = "Domain write protection"]
@@ -12826,10 +12826,10 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_08 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Keeper"]
-            pub const PUE_0_KEEPER: u32 = 0;
-            #[doc = "Pull"]
-            pub const PUE_1_PULL: u32 = 0x01;
+            #[doc = "Pull Disable, Highz"]
+            pub const PUE_0_PULL_DISABLE__HIGHZ: u32 = 0;
+            #[doc = "Pull Enable"]
+            pub const PUE_1_PULL_ENABLE: u32 = 0x01;
         }
     }
     #[doc = "Pull Up / Down Config. Field"]
@@ -12852,10 +12852,10 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_08 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Open Drain Disabled"]
-            pub const ODE_0_OPEN_DRAIN_DISABLED: u32 = 0;
-            #[doc = "Open Drain Enabled"]
-            pub const ODE_1_OPEN_DRAIN_ENABLED: u32 = 0x01;
+            #[doc = "Disabled"]
+            pub const ODE_0_DISABLED: u32 = 0;
+            #[doc = "Enabled"]
+            pub const ODE_1_ENABLED: u32 = 0x01;
         }
     }
     #[doc = "Domain write protection"]
@@ -12928,10 +12928,10 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_09 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Keeper"]
-            pub const PUE_0_KEEPER: u32 = 0;
-            #[doc = "Pull"]
-            pub const PUE_1_PULL: u32 = 0x01;
+            #[doc = "Pull Disable, Highz"]
+            pub const PUE_0_PULL_DISABLE__HIGHZ: u32 = 0;
+            #[doc = "Pull Enable"]
+            pub const PUE_1_PULL_ENABLE: u32 = 0x01;
         }
     }
     #[doc = "Pull Up / Down Config. Field"]
@@ -12954,10 +12954,10 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_09 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Open Drain Disabled"]
-            pub const ODE_0_OPEN_DRAIN_DISABLED: u32 = 0;
-            #[doc = "Open Drain Enabled"]
-            pub const ODE_1_OPEN_DRAIN_ENABLED: u32 = 0x01;
+            #[doc = "Disabled"]
+            pub const ODE_0_DISABLED: u32 = 0;
+            #[doc = "Enabled"]
+            pub const ODE_1_ENABLED: u32 = 0x01;
         }
     }
     #[doc = "Domain write protection"]
@@ -13030,10 +13030,10 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_10 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Keeper"]
-            pub const PUE_0_KEEPER: u32 = 0;
-            #[doc = "Pull"]
-            pub const PUE_1_PULL: u32 = 0x01;
+            #[doc = "Pull Disable, Highz"]
+            pub const PUE_0_PULL_DISABLE__HIGHZ: u32 = 0;
+            #[doc = "Pull Enable"]
+            pub const PUE_1_PULL_ENABLE: u32 = 0x01;
         }
     }
     #[doc = "Pull Up / Down Config. Field"]
@@ -13056,10 +13056,10 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_10 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Open Drain Disabled"]
-            pub const ODE_0_OPEN_DRAIN_DISABLED: u32 = 0;
-            #[doc = "Open Drain Enabled"]
-            pub const ODE_1_OPEN_DRAIN_ENABLED: u32 = 0x01;
+            #[doc = "Disabled"]
+            pub const ODE_0_DISABLED: u32 = 0;
+            #[doc = "Enabled"]
+            pub const ODE_1_ENABLED: u32 = 0x01;
         }
     }
     #[doc = "Domain write protection"]
@@ -13132,10 +13132,10 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_11 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Keeper"]
-            pub const PUE_0_KEEPER: u32 = 0;
-            #[doc = "Pull"]
-            pub const PUE_1_PULL: u32 = 0x01;
+            #[doc = "Pull Disable, Highz"]
+            pub const PUE_0_PULL_DISABLE__HIGHZ: u32 = 0;
+            #[doc = "Pull Enable"]
+            pub const PUE_1_PULL_ENABLE: u32 = 0x01;
         }
     }
     #[doc = "Pull Up / Down Config. Field"]
@@ -13158,10 +13158,10 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_11 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Open Drain Disabled"]
-            pub const ODE_0_OPEN_DRAIN_DISABLED: u32 = 0;
-            #[doc = "Open Drain Enabled"]
-            pub const ODE_1_OPEN_DRAIN_ENABLED: u32 = 0x01;
+            #[doc = "Disabled"]
+            pub const ODE_0_DISABLED: u32 = 0;
+            #[doc = "Enabled"]
+            pub const ODE_1_ENABLED: u32 = 0x01;
         }
     }
     #[doc = "Domain write protection"]
@@ -13234,10 +13234,10 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_12 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Keeper"]
-            pub const PUE_0_KEEPER: u32 = 0;
-            #[doc = "Pull"]
-            pub const PUE_1_PULL: u32 = 0x01;
+            #[doc = "Pull Disable, Highz"]
+            pub const PUE_0_PULL_DISABLE__HIGHZ: u32 = 0;
+            #[doc = "Pull Enable"]
+            pub const PUE_1_PULL_ENABLE: u32 = 0x01;
         }
     }
     #[doc = "Pull Up / Down Config. Field"]
@@ -13260,10 +13260,10 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_12 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Open Drain Disabled"]
-            pub const ODE_0_OPEN_DRAIN_DISABLED: u32 = 0;
-            #[doc = "Open Drain Enabled"]
-            pub const ODE_1_OPEN_DRAIN_ENABLED: u32 = 0x01;
+            #[doc = "Disabled"]
+            pub const ODE_0_DISABLED: u32 = 0;
+            #[doc = "Enabled"]
+            pub const ODE_1_ENABLED: u32 = 0x01;
         }
     }
     #[doc = "Domain write protection"]
@@ -13336,10 +13336,10 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_13 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Keeper"]
-            pub const PUE_0_KEEPER: u32 = 0;
-            #[doc = "Pull"]
-            pub const PUE_1_PULL: u32 = 0x01;
+            #[doc = "Pull Disable, Highz"]
+            pub const PUE_0_PULL_DISABLE__HIGHZ: u32 = 0;
+            #[doc = "Pull Enable"]
+            pub const PUE_1_PULL_ENABLE: u32 = 0x01;
         }
     }
     #[doc = "Pull Up / Down Config. Field"]
@@ -13362,10 +13362,10 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_13 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Open Drain Disabled"]
-            pub const ODE_0_OPEN_DRAIN_DISABLED: u32 = 0;
-            #[doc = "Open Drain Enabled"]
-            pub const ODE_1_OPEN_DRAIN_ENABLED: u32 = 0x01;
+            #[doc = "Disabled"]
+            pub const ODE_0_DISABLED: u32 = 0;
+            #[doc = "Enabled"]
+            pub const ODE_1_ENABLED: u32 = 0x01;
         }
     }
     #[doc = "Domain write protection"]
@@ -13438,10 +13438,10 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_14 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Keeper"]
-            pub const PUE_0_KEEPER: u32 = 0;
-            #[doc = "Pull"]
-            pub const PUE_1_PULL: u32 = 0x01;
+            #[doc = "Pull Disable, Highz"]
+            pub const PUE_0_PULL_DISABLE__HIGHZ: u32 = 0;
+            #[doc = "Pull Enable"]
+            pub const PUE_1_PULL_ENABLE: u32 = 0x01;
         }
     }
     #[doc = "Pull Up / Down Config. Field"]
@@ -13464,10 +13464,10 @@ pub mod SW_PAD_CTL_PAD_GPIO_AD_14 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Open Drain Disabled"]
-            pub const ODE_0_OPEN_DRAIN_DISABLED: u32 = 0;
-            #[doc = "Open Drain Enabled"]
-            pub const ODE_1_OPEN_DRAIN_ENABLED: u32 = 0x01;
+            #[doc = "Disabled"]
+            pub const ODE_0_DISABLED: u32 = 0;
+            #[doc = "Enabled"]
+            pub const ODE_1_ENABLED: u32 = 0x01;
         }
     }
     #[doc = "Domain write protection"]
@@ -15686,10 +15686,10 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_00 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Open Drain Disabled"]
-            pub const ODE_0_OPEN_DRAIN_DISABLED: u32 = 0;
-            #[doc = "Open Drain Enabled"]
-            pub const ODE_1_OPEN_DRAIN_ENABLED: u32 = 0x01;
+            #[doc = "Disabled"]
+            pub const ODE_0_DISABLED: u32 = 0;
+            #[doc = "Enabled"]
+            pub const ODE_1_ENABLED: u32 = 0x01;
         }
     }
     #[doc = "Domain write protection"]
@@ -15766,10 +15766,10 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_01 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Open Drain Disabled"]
-            pub const ODE_0_OPEN_DRAIN_DISABLED: u32 = 0;
-            #[doc = "Open Drain Enabled"]
-            pub const ODE_1_OPEN_DRAIN_ENABLED: u32 = 0x01;
+            #[doc = "Disabled"]
+            pub const ODE_0_DISABLED: u32 = 0;
+            #[doc = "Enabled"]
+            pub const ODE_1_ENABLED: u32 = 0x01;
         }
     }
     #[doc = "Domain write protection"]
@@ -15846,10 +15846,10 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_02 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Open Drain Disabled"]
-            pub const ODE_0_OPEN_DRAIN_DISABLED: u32 = 0;
-            #[doc = "Open Drain Enabled"]
-            pub const ODE_1_OPEN_DRAIN_ENABLED: u32 = 0x01;
+            #[doc = "Disabled"]
+            pub const ODE_0_DISABLED: u32 = 0;
+            #[doc = "Enabled"]
+            pub const ODE_1_ENABLED: u32 = 0x01;
         }
     }
     #[doc = "Domain write protection"]
@@ -15926,10 +15926,10 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_03 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Open Drain Disabled"]
-            pub const ODE_0_OPEN_DRAIN_DISABLED: u32 = 0;
-            #[doc = "Open Drain Enabled"]
-            pub const ODE_1_OPEN_DRAIN_ENABLED: u32 = 0x01;
+            #[doc = "Disabled"]
+            pub const ODE_0_DISABLED: u32 = 0;
+            #[doc = "Enabled"]
+            pub const ODE_1_ENABLED: u32 = 0x01;
         }
     }
     #[doc = "Domain write protection"]
@@ -16006,10 +16006,10 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_04 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Open Drain Disabled"]
-            pub const ODE_0_OPEN_DRAIN_DISABLED: u32 = 0;
-            #[doc = "Open Drain Enabled"]
-            pub const ODE_1_OPEN_DRAIN_ENABLED: u32 = 0x01;
+            #[doc = "Disabled"]
+            pub const ODE_0_DISABLED: u32 = 0;
+            #[doc = "Enabled"]
+            pub const ODE_1_ENABLED: u32 = 0x01;
         }
     }
     #[doc = "Domain write protection"]
@@ -16086,10 +16086,10 @@ pub mod SW_PAD_CTL_PAD_GPIO_SD_B1_05 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Open Drain Disabled"]
-            pub const ODE_0_OPEN_DRAIN_DISABLED: u32 = 0;
-            #[doc = "Open Drain Enabled"]
-            pub const ODE_1_OPEN_DRAIN_ENABLED: u32 = 0x01;
+            #[doc = "Disabled"]
+            pub const ODE_0_DISABLED: u32 = 0;
+            #[doc = "Enabled"]
+            pub const ODE_1_ENABLED: u32 = 0x01;
         }
     }
     #[doc = "Domain write protection"]
@@ -20134,10 +20134,10 @@ pub mod FLEXPWM1_PWMA_SELECT_INPUT_0 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_02 for Mode: ALT2"]
-            pub const GPIO_SD_02_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_02 for Mode: ALT2"]
-            pub const GPIO_02_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_B1_23 for Mode: ALT1"]
+            pub const SELECT_GPIO_EMC_B1_23_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_00 for Mode: ALT4"]
+            pub const SELECT_GPIO_AD_00_ALT4: u32 = 0x01;
         }
     }
 }
@@ -20150,10 +20150,10 @@ pub mod FLEXPWM1_PWMA_SELECT_INPUT_1 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_04 for Mode: ALT2"]
-            pub const GPIO_SD_04_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_04 for Mode: ALT2"]
-            pub const GPIO_04_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_B1_25 for Mode: ALT1"]
+            pub const SELECT_GPIO_EMC_B1_25_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_02 for Mode: ALT4"]
+            pub const SELECT_GPIO_AD_02_ALT4: u32 = 0x01;
         }
     }
 }
@@ -20166,10 +20166,10 @@ pub mod FLEXPWM1_PWMA_SELECT_INPUT_2 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_04 for Mode: ALT2"]
-            pub const GPIO_AD_04_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_06 for Mode: ALT2"]
-            pub const GPIO_06_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_B1_27 for Mode: ALT1"]
+            pub const SELECT_GPIO_EMC_B1_27_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_04 for Mode: ALT4"]
+            pub const SELECT_GPIO_AD_04_ALT4: u32 = 0x01;
         }
     }
 }
@@ -20182,10 +20182,10 @@ pub mod FLEXPWM1_PWMB_SELECT_INPUT_0 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_01 for Mode: ALT2"]
-            pub const GPIO_SD_01_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_01 for Mode: ALT2"]
-            pub const GPIO_01_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_B1_24 for Mode: ALT1"]
+            pub const SELECT_GPIO_EMC_B1_24_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_01 for Mode: ALT4"]
+            pub const SELECT_GPIO_AD_01_ALT4: u32 = 0x01;
         }
     }
 }
@@ -20198,10 +20198,10 @@ pub mod FLEXPWM1_PWMB_SELECT_INPUT_1 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_SD_03 for Mode: ALT2"]
-            pub const GPIO_SD_03_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_03 for Mode: ALT2"]
-            pub const GPIO_03_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_B1_26 for Mode: ALT1"]
+            pub const SELECT_GPIO_EMC_B1_26_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_03 for Mode: ALT4"]
+            pub const SELECT_GPIO_AD_03_ALT4: u32 = 0x01;
         }
     }
 }
@@ -20214,10 +20214,10 @@ pub mod FLEXPWM1_PWMB_SELECT_INPUT_2 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_03 for Mode: ALT2"]
-            pub const GPIO_AD_03_ALT2: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_05 for Mode: ALT2"]
-            pub const GPIO_05_ALT2: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_EMC_B1_28 for Mode: ALT1"]
+            pub const SELECT_GPIO_EMC_B1_28_ALT1: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_05 for Mode: ALT4"]
+            pub const SELECT_GPIO_AD_05_ALT4: u32 = 0x01;
         }
     }
 }
@@ -21822,10 +21822,10 @@ pub mod USB_OTG2_OC_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_B0_14 for Mode: ALT0"]
-            pub const GPIO_AD_B0_14_ALT0: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_EMC_40 for Mode: ALT3"]
-            pub const GPIO_EMC_40_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_AD_06 for Mode: ALT0"]
+            pub const SELECT_GPIO_AD_06_ALT0: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_30 for Mode: ALT1"]
+            pub const SELECT_GPIO_AD_30_ALT1: u32 = 0x01;
         }
     }
 }
@@ -21838,10 +21838,10 @@ pub mod USB_OTG_OC_SELECT_INPUT {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Selecting Pad: GPIO_AD_01 for Mode: ALT6"]
-            pub const GPIO_AD_01_ALT6: u32 = 0;
-            #[doc = "Selecting Pad: GPIO_12 for Mode: ALT3"]
-            pub const GPIO_12_ALT3: u32 = 0x01;
+            #[doc = "Selecting Pad: GPIO_AD_11 for Mode: ALT0"]
+            pub const SELECT_GPIO_AD_11_ALT0: u32 = 0;
+            #[doc = "Selecting Pad: GPIO_AD_35 for Mode: ALT1"]
+            pub const SELECT_GPIO_AD_35_ALT1: u32 = 0x01;
         }
     }
 }

--- a/src/blocks/imxrt1176_cm4/iomuxc_gpr.rs
+++ b/src/blocks/imxrt1176_cm4/iomuxc_gpr.rs
@@ -4579,10 +4579,10 @@ pub mod GPR71 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "the module is functional in Stop mode"]
-            pub const LPI2C1_IPG_STOP_MODE_0: u32 = 0;
-            #[doc = "the module is NOT functional in Stop mode, when this bit is equal to 1 and ipg_stop is asserted"]
-            pub const LPI2C1_IPG_STOP_MODE_1: u32 = 0x01;
+            #[doc = "This module is functional in Stop Mode"]
+            pub const FUNC: u32 = 0;
+            #[doc = "This module is not functional in Stop Mode and the corresponding x_STOP_REQ field is set to '1'."]
+            pub const NONFUNC: u32 = 0x01;
         }
     }
     #[doc = "LPI2C2 doze mode"]
@@ -4608,10 +4608,10 @@ pub mod GPR71 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "the module is functional in Stop mode"]
-            pub const LPI2C2_IPG_STOP_MODE_0: u32 = 0;
-            #[doc = "the module is NOT functional in Stop mode, when this bit is equal to 1 and ipg_stop is asserted"]
-            pub const LPI2C2_IPG_STOP_MODE_1: u32 = 0x01;
+            #[doc = "This module is functional in Stop Mode"]
+            pub const FUNC: u32 = 0;
+            #[doc = "This module is not functional in Stop Mode and the corresponding x_STOP_REQ field is set to '1'."]
+            pub const NONFUNC: u32 = 0x01;
         }
     }
     #[doc = "LPI2C3 doze mode"]
@@ -4637,10 +4637,10 @@ pub mod GPR71 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "the module is functional in Stop mode"]
-            pub const LPI2C3_IPG_STOP_MODE_0: u32 = 0;
-            #[doc = "the module is NOT functional in Stop mode, when this bit is equal to 1 and ipg_stop is asserted"]
-            pub const LPI2C3_IPG_STOP_MODE_1: u32 = 0x01;
+            #[doc = "This module is functional in Stop Mode"]
+            pub const FUNC: u32 = 0;
+            #[doc = "This module is not functional in Stop Mode and the corresponding x_STOP_REQ field is set to '1'."]
+            pub const NONFUNC: u32 = 0x01;
         }
     }
     #[doc = "LPI2C4 doze mode"]
@@ -4666,10 +4666,10 @@ pub mod GPR71 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "the module is functional in Stop mode"]
-            pub const LPI2C4_IPG_STOP_MODE_0: u32 = 0;
-            #[doc = "the module is NOT functional in Stop mode, when this bit is equal to 1 and ipg_stop is asserted"]
-            pub const LPI2C4_IPG_STOP_MODE_1: u32 = 0x01;
+            #[doc = "This module is functional in Stop Mode"]
+            pub const FUNC: u32 = 0;
+            #[doc = "This module is not functional in Stop Mode and the corresponding x_STOP_REQ field is set to '1'."]
+            pub const NONFUNC: u32 = 0x01;
         }
     }
     #[doc = "LPI2C5 doze mode"]
@@ -4753,10 +4753,10 @@ pub mod GPR71 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "the module is functional in Stop mode"]
-            pub const LPSPI1_IPG_STOP_MODE_0: u32 = 0;
-            #[doc = "the module is NOT functional in Stop mode, when this bit is equal to 1 and ipg_stop is asserted"]
-            pub const LPSPI1_IPG_STOP_MODE_1: u32 = 0x01;
+            #[doc = "This module is functional in Stop Mode"]
+            pub const FUNC: u32 = 0;
+            #[doc = "This module is not functional in Stop Mode and the corresponding x_STOP_REQ field is set to '1'."]
+            pub const NONFUNC: u32 = 0x01;
         }
     }
     #[doc = "Domain write protection"]
@@ -4819,10 +4819,10 @@ pub mod GPR72 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "the module is functional in Stop mode"]
-            pub const LPSPI2_IPG_STOP_MODE_0: u32 = 0;
-            #[doc = "the module is NOT functional in Stop mode, when this bit is equal to 1 and ipg_stop is asserted"]
-            pub const LPSPI2_IPG_STOP_MODE_1: u32 = 0x01;
+            #[doc = "This module is functional in Stop Mode"]
+            pub const FUNC: u32 = 0;
+            #[doc = "This module is not functional in Stop Mode and the corresponding x_STOP_REQ field is set to '1'."]
+            pub const NONFUNC: u32 = 0x01;
         }
     }
     #[doc = "LPSPI3 doze mode"]
@@ -4848,10 +4848,10 @@ pub mod GPR72 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "the module is functional in Stop mode"]
-            pub const LPSPI3_IPG_STOP_MODE_0: u32 = 0;
-            #[doc = "the module is NOT functional in Stop mode, when this bit is equal to 1 and ipg_stop is asserted"]
-            pub const LPSPI3_IPG_STOP_MODE_1: u32 = 0x01;
+            #[doc = "This module is functional in Stop Mode"]
+            pub const FUNC: u32 = 0;
+            #[doc = "This module is not functional in Stop Mode and the corresponding x_STOP_REQ field is set to '1'."]
+            pub const NONFUNC: u32 = 0x01;
         }
     }
     #[doc = "LPSPI4 doze mode"]
@@ -4877,10 +4877,10 @@ pub mod GPR72 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "the module is functional in Stop mode"]
-            pub const LPSPI4_IPG_STOP_MODE_0: u32 = 0;
-            #[doc = "the module is NOT functional in Stop mode, when this bit is equal to 1 and ipg_stop is asserted"]
-            pub const LPSPI4_IPG_STOP_MODE_1: u32 = 0x01;
+            #[doc = "This module is functional in Stop Mode"]
+            pub const FUNC: u32 = 0;
+            #[doc = "This module is not functional in Stop Mode and the corresponding x_STOP_REQ field is set to '1'."]
+            pub const NONFUNC: u32 = 0x01;
         }
     }
     #[doc = "LPSPI5 doze mode"]
@@ -4964,10 +4964,10 @@ pub mod GPR72 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "the module is functional in Stop mode"]
-            pub const LPUART1_IPG_STOP_MODE_0: u32 = 0;
-            #[doc = "the module is NOT functional in Stop mode, when this bit is equal to 1 and ipg_stop is asserted"]
-            pub const LPUART1_IPG_STOP_MODE_1: u32 = 0x01;
+            #[doc = "This module is functional in Stop Mode"]
+            pub const FUNC: u32 = 0;
+            #[doc = "This module is not functional in Stop Mode and the corresponding x_STOP_REQ field is set to '1'."]
+            pub const NONFUNC: u32 = 0x01;
         }
     }
     #[doc = "LPUART2 doze mode"]
@@ -4993,10 +4993,10 @@ pub mod GPR72 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "the module is functional in Stop mode"]
-            pub const LPUART2_IPG_STOP_MODE_0: u32 = 0;
-            #[doc = "the module is NOT functional in Stop mode, when this bit is equal to 1 and ipg_stop is asserted"]
-            pub const LPUART2_IPG_STOP_MODE_1: u32 = 0x01;
+            #[doc = "This module is functional in Stop Mode"]
+            pub const FUNC: u32 = 0;
+            #[doc = "This module is not functional in Stop Mode and the corresponding x_STOP_REQ field is set to '1'."]
+            pub const NONFUNC: u32 = 0x01;
         }
     }
     #[doc = "LPUART3 doze mode"]
@@ -5022,10 +5022,10 @@ pub mod GPR72 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "the module is functional in Stop mode"]
-            pub const LPUART3_IPG_STOP_MODE_0: u32 = 0;
-            #[doc = "the module is NOT functional in Stop mode, when this bit is equal to 1 and ipg_stop is asserted"]
-            pub const LPUART3_IPG_STOP_MODE_1: u32 = 0x01;
+            #[doc = "This module is functional in Stop Mode"]
+            pub const FUNC: u32 = 0;
+            #[doc = "This module is not functional in Stop Mode and the corresponding x_STOP_REQ field is set to '1'."]
+            pub const NONFUNC: u32 = 0x01;
         }
     }
     #[doc = "LPUART4 doze mode"]
@@ -5051,10 +5051,10 @@ pub mod GPR72 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "the module is functional in Stop mode"]
-            pub const LPUART4_IPG_STOP_MODE_0: u32 = 0;
-            #[doc = "the module is NOT functional in Stop mode, when this bit is equal to 1 and ipg_stop is asserted"]
-            pub const LPUART4_IPG_STOP_MODE_1: u32 = 0x01;
+            #[doc = "This module is functional in Stop Mode"]
+            pub const FUNC: u32 = 0;
+            #[doc = "This module is not functional in Stop Mode and the corresponding x_STOP_REQ field is set to '1'."]
+            pub const NONFUNC: u32 = 0x01;
         }
     }
     #[doc = "Domain write protection"]
@@ -5117,10 +5117,10 @@ pub mod GPR73 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "the module is functional in Stop mode"]
-            pub const LPUART5_IPG_STOP_MODE_0: u32 = 0;
-            #[doc = "the module is NOT functional in Stop mode, when this bit is equal to 1 and ipg_stop is asserted"]
-            pub const LPUART5_IPG_STOP_MODE_1: u32 = 0x01;
+            #[doc = "This module is functional in Stop Mode"]
+            pub const FUNC: u32 = 0;
+            #[doc = "This module is not functional in Stop Mode and the corresponding x_STOP_REQ field is set to '1'."]
+            pub const NONFUNC: u32 = 0x01;
         }
     }
     #[doc = "LPUART6 doze mode"]
@@ -5146,10 +5146,10 @@ pub mod GPR73 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "the module is functional in Stop mode"]
-            pub const LPUART6_IPG_STOP_MODE_0: u32 = 0;
-            #[doc = "the module is NOT functional in Stop mode, when this bit is equal to 1 and ipg_stop is asserted"]
-            pub const LPUART6_IPG_STOP_MODE_1: u32 = 0x01;
+            #[doc = "This module is functional in Stop Mode"]
+            pub const FUNC: u32 = 0;
+            #[doc = "This module is not functional in Stop Mode and the corresponding x_STOP_REQ field is set to '1'."]
+            pub const NONFUNC: u32 = 0x01;
         }
     }
     #[doc = "LPUART7 doze mode"]
@@ -5175,10 +5175,10 @@ pub mod GPR73 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "the module is functional in Stop mode"]
-            pub const LPUART7_IPG_STOP_MODE_0: u32 = 0;
-            #[doc = "the module is NOT functional in Stop mode, when this bit is equal to 1 and ipg_stop is asserted"]
-            pub const LPUART7_IPG_STOP_MODE_1: u32 = 0x01;
+            #[doc = "This module is functional in Stop Mode"]
+            pub const FUNC: u32 = 0;
+            #[doc = "This module is not functional in Stop Mode and the corresponding x_STOP_REQ field is set to '1'."]
+            pub const NONFUNC: u32 = 0x01;
         }
     }
     #[doc = "LPUART8 doze mode"]
@@ -5204,10 +5204,10 @@ pub mod GPR73 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "the module is functional in Stop mode"]
-            pub const LPUART8_IPG_STOP_MODE_0: u32 = 0;
-            #[doc = "the module is NOT functional in Stop mode, when this bit is equal to 1 and ipg_stop is asserted"]
-            pub const LPUART8_IPG_STOP_MODE_1: u32 = 0x01;
+            #[doc = "This module is functional in Stop Mode"]
+            pub const FUNC: u32 = 0;
+            #[doc = "This module is not functional in Stop Mode and the corresponding x_STOP_REQ field is set to '1'."]
+            pub const NONFUNC: u32 = 0x01;
         }
     }
     #[doc = "LPUART9 doze mode"]


### PR DESCRIPTION
Exploring #32 revealed that enum variants, not just fieldsets, may be combined with too much greed. In particular, most `*SELECT_INPUT*` IOMUXC symbols are incorrect. Once the combiner found an element called `LPSPI1_SCK_SELECT_INPUT`, it was free to substitute the enum variants for _all_ other IOMUXC peripherals across all chips.

This PR introduces combiner configurations. Configurations are expressed in the same raltool configuration file as the transforms. The first configuration enforces strict enum variant names on entire peripheral blocks. This prevents the combiner from replacing IOMUXC `*SELECT_INPUT*` enum variants across chips when the names are different.

See individual commits for more information and code study. Note that I'm only demonstrating the correction on the IOMUXC peripheral, and I haven't assessed the rest of the RAL to see if this issue is elsewhere.