### PR TITLE
Revise some API docs due to aggressive combining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ description, all lowercase). Dropping these fields changes the combiner's
 approach for combining fieldsets, enabling correct documentation for non-
 reserved fields.
 
+Fix the documentation associated with IOMUXC field values.
+
 ## [0.5.0] 2022-12-27
 
 Add support for NXP's i.MX RT 1176 dual-core MCUs. An `"imxrt1176_cm7"` feature

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@ Exclude the interrupt vector table when we're building for a target with an
 operating system. This ensures you can build imxrt-ral in different contexts,
 like build scripts.
 
+Drop all register fields that are documented as "reserved" (first word of the
+description, all lowercase). Dropping these fields changes the combiner's
+approach for combining fieldsets, enabling correct documentation for non-
+reserved fields.
+
 ## [0.5.0] 2022-12-27
 
 Add support for NXP's i.MX RT 1176 dual-core MCUs. An `"imxrt1176_cm7"` feature

--- a/devices/common_patches/ccm_cg_gpio5.yaml
+++ b/devices/common_patches/ccm_cg_gpio5.yaml
@@ -1,0 +1,11 @@
+# Clock gate 15 in CCM[CCGR1] is missing from 1050 and 1060 MCUs.
+# It isn't reserved according to the reference manual. This
+# clock gate is for GPIO5.
+CCM:
+  CCGR1:
+    _modify:
+      CG15:
+        description: gpio5 clock (gpio5_clk_enable)
+        bitOffset: 30
+        bitWidth: 2
+        access: read-write

--- a/devices/imxrt1021.yaml
+++ b/devices/imxrt1021.yaml
@@ -2,6 +2,7 @@ _svd: "../svd/imxrt1021.svd"
 
 _include:
   - "common.yaml"
+  - "common_patches/ccm_cg_gpio5.yaml"
   - "common_patches/pwm1/submodule_cluster.yaml"
   - "common_patches/usb.yaml"
   - "common_patches/dma0/tcd_cluster.yaml"

--- a/devices/imxrt1051.yaml
+++ b/devices/imxrt1051.yaml
@@ -2,6 +2,7 @@ _svd: "../svd/imxrt1051.svd"
 
 _include:
   - "common.yaml"
+  - "common_patches/ccm_cg_gpio5.yaml"
   - "common_patches/pwm1/submodule_cluster.yaml"
   - "common_patches/usb1.yaml"
   - "common_patches/dma0/tcd_cluster.yaml"

--- a/devices/imxrt1052.yaml
+++ b/devices/imxrt1052.yaml
@@ -2,6 +2,7 @@ _svd: "../svd/imxrt1052.svd"
 
 _include:
   - "common.yaml"
+  - "common_patches/ccm_cg_gpio5.yaml"
   - "common_patches/pwm1/submodule_cluster.yaml"
   - "common_patches/usb1.yaml"
   - "common_patches/dma0/tcd_cluster.yaml"

--- a/devices/imxrt1061.yaml
+++ b/devices/imxrt1061.yaml
@@ -2,6 +2,7 @@ _svd: "../svd/imxrt1061.svd"
 
 _include:
   - "common.yaml"
+  - "common_patches/ccm_cg_gpio5.yaml"
   - "common_patches/pwm1/submodule_cluster.yaml"
   - "common_patches/usb1.yaml"
   - "common_patches/dma0/tcd_cluster.yaml"

--- a/devices/imxrt1062.yaml
+++ b/devices/imxrt1062.yaml
@@ -2,6 +2,7 @@ _svd: "../svd/imxrt1062.svd"
 
 _include:
   - "common.yaml"
+  - "common_patches/ccm_cg_gpio5.yaml"
   - "common_patches/pwm1/submodule_cluster.yaml"
   - "common_patches/usb1.yaml"
   - "common_patches/dma0/tcd_cluster.yaml"

--- a/devices/imxrt1064.yaml
+++ b/devices/imxrt1064.yaml
@@ -2,6 +2,7 @@ _svd: "../svd/imxrt1064.svd"
 
 _include:
   - "common.yaml"
+  - "common_patches/ccm_cg_gpio5.yaml"
   - "common_patches/pwm1/submodule_cluster.yaml"
   - "common_patches/usb1.yaml"
   - "common_patches/dma0/tcd_cluster.yaml"

--- a/raltool-cfg.yaml
+++ b/raltool-cfg.yaml
@@ -187,6 +187,10 @@ combines:
     - iomuxc
     - iomuxc_gpr
     - iomuxc_snvs
+  - StrictEnumDescs:
+    - iomuxc
+    - iomuxc_gpr
+    - iomuxc_snvs
   # IR paths that should never be combined.
   #
   # These regexes match IR paths. If there's a match, that element is *never* considered for

--- a/raltool-cfg.yaml
+++ b/raltool-cfg.yaml
@@ -187,3 +187,11 @@ combines:
     - iomuxc
     - iomuxc_gpr
     - iomuxc_snvs
+  # IR paths that should never be combined.
+  #
+  # These regexes match IR paths. If there's a match, that element is *never* considered for
+  # combination by the combiner. When applied to blocks, this is a stronger "never combine"
+  # guarantee than StrictEnumNames. In particular, if an IOMUXC block were in this list, this
+  # would prevent the 1061 IOMUXC from being combined with the 1062 IOMUXC.
+  - NeverCombine:
+    - ccm::regs::Ccgr\d+

--- a/raltool/src/svd2ir.rs
+++ b/raltool/src/svd2ir.rs
@@ -201,6 +201,12 @@ pub fn convert_peripheral(ir: &mut IR, p: &svd::Peripheral) -> anyhow::Result<()
                 warn!("unsupported derived_from in fieldset");
             }
 
+            if let Some(desc) = &f.description {
+                if desc.to_lowercase().starts_with("reserved") {
+                    continue;
+                }
+            }
+
             let mut field = Field {
                 name: f.name.clone(),
                 description: f.description.clone(),

--- a/src/blocks/imxrt1011/ccm.rs
+++ b/src/blocks/imxrt1011/ccm.rs
@@ -2059,38 +2059,6 @@ pub mod CCGR0 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CG7 {
-        pub const offset: u32 = 14;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG8 {
-        pub const offset: u32 = 16;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG9 {
-        pub const offset: u32 = 18;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG10 {
-        pub const offset: u32 = 20;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "trace clock (trace_clk_enable)"]
     pub mod CG11 {
         pub const offset: u32 = 22;
@@ -2150,38 +2118,6 @@ pub mod CCGR1 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CG2 {
-        pub const offset: u32 = 4;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG3 {
-        pub const offset: u32 = 6;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG4 {
-        pub const offset: u32 = 8;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG5 {
-        pub const offset: u32 = 10;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "pit clocks (pit_clk_enable)"]
     pub mod CG6 {
         pub const offset: u32 = 12;
@@ -2190,25 +2126,9 @@ pub mod CCGR1 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CG7 {
-        pub const offset: u32 = 14;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "adc1 clock (adc1_clk_enable)"]
     pub mod CG8 {
         pub const offset: u32 = 16;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG9 {
-        pub const offset: u32 = 18;
         pub const mask: u32 = 0x03 << offset;
         pub mod R {}
         pub mod W {}
@@ -2273,14 +2193,6 @@ pub mod CCGR2 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CG1 {
-        pub const offset: u32 = 2;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "iomuxc_snvs clock (iomuxc_snvs_clk_enable)"]
     pub mod CG2 {
         pub const offset: u32 = 4;
@@ -2305,49 +2217,9 @@ pub mod CCGR2 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CG5 {
-        pub const offset: u32 = 10;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "OCOTP_CTRL clock (iim_clk_enable)"]
     pub mod CG6 {
         pub const offset: u32 = 12;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG7 {
-        pub const offset: u32 = 14;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG8 {
-        pub const offset: u32 = 16;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG9 {
-        pub const offset: u32 = 18;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG10 {
-        pub const offset: u32 = 20;
         pub const mask: u32 = 0x03 << offset;
         pub mod R {}
         pub mod W {}
@@ -2361,92 +2233,12 @@ pub mod CCGR2 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CG12 {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG13 {
-        pub const offset: u32 = 26;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG14 {
-        pub const offset: u32 = 28;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG15 {
-        pub const offset: u32 = 30;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "CCM Clock Gating Register 3"]
 pub mod CCGR3 {
-    #[doc = "Reserved"]
-    pub mod CG0 {
-        pub const offset: u32 = 0;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG1 {
-        pub const offset: u32 = 2;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG2 {
-        pub const offset: u32 = 4;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG3 {
-        pub const offset: u32 = 6;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "aoi1 clock (aoi1_clk_enable)"]
     pub mod CG4 {
         pub const offset: u32 = 8;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG5 {
-        pub const offset: u32 = 10;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG6 {
-        pub const offset: u32 = 12;
         pub const mask: u32 = 0x03 << offset;
         pub mod R {}
         pub mod W {}
@@ -2471,38 +2263,6 @@ pub mod CCGR3 {
     #[doc = "flexram clock (flexram_clk_enable)"]
     pub mod CG9 {
         pub const offset: u32 = 18;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG10 {
-        pub const offset: u32 = 20;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG11 {
-        pub const offset: u32 = 22;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG12 {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG13 {
-        pub const offset: u32 = 26;
         pub const mask: u32 = 0x03 << offset;
         pub mod R {}
         pub mod W {}
@@ -2551,25 +2311,9 @@ pub mod CCGR4 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CG3 {
-        pub const offset: u32 = 6;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "sim_m7 clock (sim_m7_clk_enable)"]
     pub mod CG4 {
         pub const offset: u32 = 8;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG5 {
-        pub const offset: u32 = 10;
         pub const mask: u32 = 0x03 << offset;
         pub mod R {}
         pub mod W {}
@@ -2594,54 +2338,6 @@ pub mod CCGR4 {
     #[doc = "pwm1 clocks (pwm1_clk_enable)"]
     pub mod CG8 {
         pub const offset: u32 = 16;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG9 {
-        pub const offset: u32 = 18;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG10 {
-        pub const offset: u32 = 20;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG11 {
-        pub const offset: u32 = 22;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG12 {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG13 {
-        pub const offset: u32 = 26;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG14 {
-        pub const offset: u32 = 28;
         pub const mask: u32 = 0x03 << offset;
         pub mod R {}
         pub mod W {}
@@ -2706,14 +2402,6 @@ pub mod CCGR5 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CG6 {
-        pub const offset: u32 = 12;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "spdif clock (spdif_clk_enable)"]
     pub mod CG7 {
         pub const offset: u32 = 14;
@@ -2722,25 +2410,9 @@ pub mod CCGR5 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CG8 {
-        pub const offset: u32 = 16;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "sai1 clock (sai1_clk_enable)"]
     pub mod CG9 {
         pub const offset: u32 = 18;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG10 {
-        pub const offset: u32 = 20;
         pub const mask: u32 = 0x03 << offset;
         pub mod R {}
         pub mod W {}
@@ -2757,14 +2429,6 @@ pub mod CCGR5 {
     #[doc = "lpuart1 clock (lpuart1_clk_enable)"]
     pub mod CG12 {
         pub const offset: u32 = 24;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG13 {
-        pub const offset: u32 = 26;
         pub const mask: u32 = 0x03 << offset;
         pub mod R {}
         pub mod W {}
@@ -2797,33 +2461,9 @@ pub mod CCGR6 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CG1 {
-        pub const offset: u32 = 2;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG2 {
-        pub const offset: u32 = 4;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "dcdc clocks (dcdc_clk_enable)"]
     pub mod CG3 {
         pub const offset: u32 = 6;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG4 {
-        pub const offset: u32 = 8;
         pub const mask: u32 = 0x03 << offset;
         pub mod R {}
         pub mod W {}
@@ -2845,30 +2485,6 @@ pub mod CCGR6 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CG7 {
-        pub const offset: u32 = 14;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG8 {
-        pub const offset: u32 = 16;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG9 {
-        pub const offset: u32 = 18;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "sim_per clock (sim_per_clk_enable)"]
     pub mod CG10 {
         pub const offset: u32 = 20;
@@ -2880,38 +2496,6 @@ pub mod CCGR6 {
     #[doc = "anadig clocks (anadig_clk_enable)"]
     pub mod CG11 {
         pub const offset: u32 = 22;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG12 {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG13 {
-        pub const offset: u32 = 26;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG14 {
-        pub const offset: u32 = 28;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG15 {
-        pub const offset: u32 = 30;
         pub const mask: u32 = 0x03 << offset;
         pub mod R {}
         pub mod W {}

--- a/src/blocks/imxrt1011/dcdc.rs
+++ b/src/blocks/imxrt1011/dcdc.rs
@@ -333,14 +333,6 @@ pub mod REG3 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod MISC_DISABLEFET_LOGIC {
-        pub const offset: u32 = 28;
-        pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Disable stepping for the output VDD_SOC of DCDC"]
     pub mod DISABLE_STEP {
         pub const offset: u32 = 30;

--- a/src/blocks/imxrt1011/ocotp.rs
+++ b/src/blocks/imxrt1011/ocotp.rs
@@ -707,14 +707,6 @@ pub mod LOCK {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod FIELD_RETURN {
-        pub const offset: u32 = 28;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "Value of OTP Bank0 Word1 (Configuration and Manufacturing Info.)"]
 pub mod CFG0 {

--- a/src/blocks/imxrt1011/usbphy.rs
+++ b/src/blocks/imxrt1011/usbphy.rs
@@ -60,14 +60,6 @@ pub struct RegisterBlock {
 }
 #[doc = "USB PHY Power-Down Register"]
 pub mod PWD {
-    #[doc = "Reserved."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 0;
-        pub const mask: u32 = 0x03ff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "0 = Normal operation"]
     pub mod TXPWDFS {
         pub const offset: u32 = 10;
@@ -88,14 +80,6 @@ pub mod PWD {
     pub mod TXPWDV2I {
         pub const offset: u32 = 12;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 13;
-        pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -128,14 +112,6 @@ pub mod PWD {
     pub mod RXPWDRX {
         pub const offset: u32 = 20;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD2 {
-        pub const offset: u32 = 21;
-        pub const mask: u32 = 0x07ff << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -143,14 +119,6 @@ pub mod PWD {
 }
 #[doc = "USB PHY Power-Down Register"]
 pub mod PWD_SET {
-    #[doc = "Reserved."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 0;
-        pub const mask: u32 = 0x03ff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "0 = Normal operation"]
     pub mod TXPWDFS {
         pub const offset: u32 = 10;
@@ -171,14 +139,6 @@ pub mod PWD_SET {
     pub mod TXPWDV2I {
         pub const offset: u32 = 12;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 13;
-        pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -211,14 +171,6 @@ pub mod PWD_SET {
     pub mod RXPWDRX {
         pub const offset: u32 = 20;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD2 {
-        pub const offset: u32 = 21;
-        pub const mask: u32 = 0x07ff << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -226,14 +178,6 @@ pub mod PWD_SET {
 }
 #[doc = "USB PHY Power-Down Register"]
 pub mod PWD_CLR {
-    #[doc = "Reserved."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 0;
-        pub const mask: u32 = 0x03ff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "0 = Normal operation"]
     pub mod TXPWDFS {
         pub const offset: u32 = 10;
@@ -254,14 +198,6 @@ pub mod PWD_CLR {
     pub mod TXPWDV2I {
         pub const offset: u32 = 12;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 13;
-        pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -294,14 +230,6 @@ pub mod PWD_CLR {
     pub mod RXPWDRX {
         pub const offset: u32 = 20;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD2 {
-        pub const offset: u32 = 21;
-        pub const mask: u32 = 0x07ff << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -309,14 +237,6 @@ pub mod PWD_CLR {
 }
 #[doc = "USB PHY Power-Down Register"]
 pub mod PWD_TOG {
-    #[doc = "Reserved."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 0;
-        pub const mask: u32 = 0x03ff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "0 = Normal operation"]
     pub mod TXPWDFS {
         pub const offset: u32 = 10;
@@ -337,14 +257,6 @@ pub mod PWD_TOG {
     pub mod TXPWDV2I {
         pub const offset: u32 = 12;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 13;
-        pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -377,14 +289,6 @@ pub mod PWD_TOG {
     pub mod RXPWDRX {
         pub const offset: u32 = 20;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD2 {
-        pub const offset: u32 = 21;
-        pub const mask: u32 = 0x07ff << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -400,25 +304,9 @@ pub mod TX {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved. Note: This bit should remain clear."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 4;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Decode to select a 45-Ohm resistance to the USB_DN output pin"]
     pub mod TXCAL45DN {
         pub const offset: u32 = 8;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved. Note: This bit should remain clear."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 12;
         pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
@@ -432,25 +320,9 @@ pub mod TX {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD2 {
-        pub const offset: u32 = 20;
-        pub const mask: u32 = 0x3f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Controls the edge-rate of the current sensing transistors used in HS transmit"]
     pub mod USBPHY_TX_EDGECTRL {
         pub const offset: u32 = 26;
-        pub const mask: u32 = 0x07 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD5 {
-        pub const offset: u32 = 29;
         pub const mask: u32 = 0x07 << offset;
         pub mod R {}
         pub mod W {}
@@ -467,25 +339,9 @@ pub mod TX_SET {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved. Note: This bit should remain clear."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 4;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Decode to select a 45-Ohm resistance to the USB_DN output pin"]
     pub mod TXCAL45DN {
         pub const offset: u32 = 8;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved. Note: This bit should remain clear."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 12;
         pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
@@ -499,25 +355,9 @@ pub mod TX_SET {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD2 {
-        pub const offset: u32 = 20;
-        pub const mask: u32 = 0x3f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Controls the edge-rate of the current sensing transistors used in HS transmit"]
     pub mod USBPHY_TX_EDGECTRL {
         pub const offset: u32 = 26;
-        pub const mask: u32 = 0x07 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD5 {
-        pub const offset: u32 = 29;
         pub const mask: u32 = 0x07 << offset;
         pub mod R {}
         pub mod W {}
@@ -534,25 +374,9 @@ pub mod TX_CLR {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved. Note: This bit should remain clear."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 4;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Decode to select a 45-Ohm resistance to the USB_DN output pin"]
     pub mod TXCAL45DN {
         pub const offset: u32 = 8;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved. Note: This bit should remain clear."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 12;
         pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
@@ -566,25 +390,9 @@ pub mod TX_CLR {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD2 {
-        pub const offset: u32 = 20;
-        pub const mask: u32 = 0x3f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Controls the edge-rate of the current sensing transistors used in HS transmit"]
     pub mod USBPHY_TX_EDGECTRL {
         pub const offset: u32 = 26;
-        pub const mask: u32 = 0x07 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD5 {
-        pub const offset: u32 = 29;
         pub const mask: u32 = 0x07 << offset;
         pub mod R {}
         pub mod W {}
@@ -601,25 +409,9 @@ pub mod TX_TOG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved. Note: This bit should remain clear."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 4;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Decode to select a 45-Ohm resistance to the USB_DN output pin"]
     pub mod TXCAL45DN {
         pub const offset: u32 = 8;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved. Note: This bit should remain clear."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 12;
         pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
@@ -633,25 +425,9 @@ pub mod TX_TOG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD2 {
-        pub const offset: u32 = 20;
-        pub const mask: u32 = 0x3f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Controls the edge-rate of the current sensing transistors used in HS transmit"]
     pub mod USBPHY_TX_EDGECTRL {
         pub const offset: u32 = 26;
-        pub const mask: u32 = 0x07 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD5 {
-        pub const offset: u32 = 29;
         pub const mask: u32 = 0x07 << offset;
         pub mod R {}
         pub mod W {}
@@ -668,14 +444,6 @@ pub mod RX {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 3;
-        pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "The DISCONADJ field adjusts the trip point for the disconnect detector: 000 = Trip-Level Voltage is 0"]
     pub mod DISCONADJ {
         pub const offset: u32 = 4;
@@ -684,26 +452,10 @@ pub mod RX {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 7;
-        pub const mask: u32 = 0x7fff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "0 = Normal operation"]
     pub mod RXDBYPASS {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD2 {
-        pub const offset: u32 = 23;
-        pub const mask: u32 = 0x01ff << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -719,14 +471,6 @@ pub mod RX_SET {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 3;
-        pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "The DISCONADJ field adjusts the trip point for the disconnect detector: 000 = Trip-Level Voltage is 0"]
     pub mod DISCONADJ {
         pub const offset: u32 = 4;
@@ -735,26 +479,10 @@ pub mod RX_SET {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 7;
-        pub const mask: u32 = 0x7fff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "0 = Normal operation"]
     pub mod RXDBYPASS {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD2 {
-        pub const offset: u32 = 23;
-        pub const mask: u32 = 0x01ff << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -770,14 +498,6 @@ pub mod RX_CLR {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 3;
-        pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "The DISCONADJ field adjusts the trip point for the disconnect detector: 000 = Trip-Level Voltage is 0"]
     pub mod DISCONADJ {
         pub const offset: u32 = 4;
@@ -786,26 +506,10 @@ pub mod RX_CLR {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 7;
-        pub const mask: u32 = 0x7fff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "0 = Normal operation"]
     pub mod RXDBYPASS {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD2 {
-        pub const offset: u32 = 23;
-        pub const mask: u32 = 0x01ff << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -821,14 +525,6 @@ pub mod RX_TOG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 3;
-        pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "The DISCONADJ field adjusts the trip point for the disconnect detector: 000 = Trip-Level Voltage is 0"]
     pub mod DISCONADJ {
         pub const offset: u32 = 4;
@@ -837,26 +533,10 @@ pub mod RX_TOG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 7;
-        pub const mask: u32 = 0x7fff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "0 = Normal operation"]
     pub mod RXDBYPASS {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD2 {
-        pub const offset: u32 = 23;
-        pub const mask: u32 = 0x01ff << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -1060,14 +740,6 @@ pub mod CTRL {
     pub mod FSDLL_RST_EN {
         pub const offset: u32 = 24;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 25;
-        pub const mask: u32 = 0x03 << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -1315,14 +987,6 @@ pub mod CTRL_SET {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 25;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Almost same as OTGID_STATUS in USBPHYx_STATUS Register"]
     pub mod OTG_ID_VALUE {
         pub const offset: u32 = 27;
@@ -1562,14 +1226,6 @@ pub mod CTRL_CLR {
     pub mod FSDLL_RST_EN {
         pub const offset: u32 = 24;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 25;
-        pub const mask: u32 = 0x03 << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -1817,14 +1473,6 @@ pub mod CTRL_TOG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 25;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Almost same as OTGID_STATUS in USBPHYx_STATUS Register"]
     pub mod OTG_ID_VALUE {
         pub const offset: u32 = 27;
@@ -1868,14 +1516,6 @@ pub mod CTRL_TOG {
 }
 #[doc = "USB PHY Status Register"]
 pub mod STATUS {
-    #[doc = "Reserved."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 0;
-        pub const mask: u32 = 0x07 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Indicates that the device has disconnected while in high-speed host mode."]
     pub mod HOSTDISCONDETECT_STATUS {
         pub const offset: u32 = 3;
@@ -1884,25 +1524,9 @@ pub mod STATUS {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 4;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Indicates that the device has been connected on the USB_DP and USB_DM lines."]
     pub mod DEVPLUGIN_STATUS {
         pub const offset: u32 = 6;
-        pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD2 {
-        pub const offset: u32 = 7;
         pub const mask: u32 = 0x01 << offset;
         pub mod R {}
         pub mod W {}
@@ -1916,26 +1540,10 @@ pub mod STATUS {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD3 {
-        pub const offset: u32 = 9;
-        pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Indicates that the host is sending a wake-up after suspend and has triggered an interrupt."]
     pub mod RESUME_STATUS {
         pub const offset: u32 = 10;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD4 {
-        pub const offset: u32 = 11;
-        pub const mask: u32 = 0x001f_ffff << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -1975,14 +1583,6 @@ pub mod DEBUG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 6;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Delay in between the end of transmit to the beginning of receive"]
     pub mod TX2RXCOUNT {
         pub const offset: u32 = 8;
@@ -1999,26 +1599,10 @@ pub mod DEBUG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 13;
-        pub const mask: u32 = 0x07 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Delay in between the detection of squelch to the reset of high-speed RX."]
     pub mod SQUELCHRESETCOUNT {
         pub const offset: u32 = 16;
         pub const mask: u32 = 0x1f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD2 {
-        pub const offset: u32 = 21;
-        pub const mask: u32 = 0x07 << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -2050,14 +1634,6 @@ pub mod DEBUG {
     #[doc = "Gate Test Clocks"]
     pub mod CLKGATE {
         pub const offset: u32 = 30;
-        pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD3 {
-        pub const offset: u32 = 31;
         pub const mask: u32 = 0x01 << offset;
         pub mod R {}
         pub mod W {}
@@ -2098,14 +1674,6 @@ pub mod DEBUG_SET {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 6;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Delay in between the end of transmit to the beginning of receive"]
     pub mod TX2RXCOUNT {
         pub const offset: u32 = 8;
@@ -2122,26 +1690,10 @@ pub mod DEBUG_SET {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 13;
-        pub const mask: u32 = 0x07 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Delay in between the detection of squelch to the reset of high-speed RX."]
     pub mod SQUELCHRESETCOUNT {
         pub const offset: u32 = 16;
         pub const mask: u32 = 0x1f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD2 {
-        pub const offset: u32 = 21;
-        pub const mask: u32 = 0x07 << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -2173,14 +1725,6 @@ pub mod DEBUG_SET {
     #[doc = "Gate Test Clocks"]
     pub mod CLKGATE {
         pub const offset: u32 = 30;
-        pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD3 {
-        pub const offset: u32 = 31;
         pub const mask: u32 = 0x01 << offset;
         pub mod R {}
         pub mod W {}
@@ -2221,14 +1765,6 @@ pub mod DEBUG_CLR {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 6;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Delay in between the end of transmit to the beginning of receive"]
     pub mod TX2RXCOUNT {
         pub const offset: u32 = 8;
@@ -2245,26 +1781,10 @@ pub mod DEBUG_CLR {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 13;
-        pub const mask: u32 = 0x07 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Delay in between the detection of squelch to the reset of high-speed RX."]
     pub mod SQUELCHRESETCOUNT {
         pub const offset: u32 = 16;
         pub const mask: u32 = 0x1f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD2 {
-        pub const offset: u32 = 21;
-        pub const mask: u32 = 0x07 << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -2296,14 +1816,6 @@ pub mod DEBUG_CLR {
     #[doc = "Gate Test Clocks"]
     pub mod CLKGATE {
         pub const offset: u32 = 30;
-        pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD3 {
-        pub const offset: u32 = 31;
         pub const mask: u32 = 0x01 << offset;
         pub mod R {}
         pub mod W {}
@@ -2344,14 +1856,6 @@ pub mod DEBUG_TOG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 6;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Delay in between the end of transmit to the beginning of receive"]
     pub mod TX2RXCOUNT {
         pub const offset: u32 = 8;
@@ -2368,26 +1872,10 @@ pub mod DEBUG_TOG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 13;
-        pub const mask: u32 = 0x07 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Delay in between the detection of squelch to the reset of high-speed RX."]
     pub mod SQUELCHRESETCOUNT {
         pub const offset: u32 = 16;
         pub const mask: u32 = 0x1f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD2 {
-        pub const offset: u32 = 21;
-        pub const mask: u32 = 0x07 << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -2424,14 +1912,6 @@ pub mod DEBUG_TOG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD3 {
-        pub const offset: u32 = 31;
-        pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "UTMI Debug Status Register 0"]
 pub mod DEBUG0_STATUS {
@@ -2462,26 +1942,10 @@ pub mod DEBUG0_STATUS {
 }
 #[doc = "UTMI Debug Status Register 1"]
 pub mod DEBUG1 {
-    #[doc = "Reserved. Note: This bit should remain clear."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 0;
-        pub const mask: u32 = 0x1fff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Delay increment of the rise of squelch: 00 = Delay is nominal 01 = Delay is +20% 10 = Delay is -20% 11 = Delay is -40%"]
     pub mod ENTAILADJVD {
         pub const offset: u32 = 13;
         pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 15;
-        pub const mask: u32 = 0x0001_ffff << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -2489,26 +1953,10 @@ pub mod DEBUG1 {
 }
 #[doc = "UTMI Debug Status Register 1"]
 pub mod DEBUG1_SET {
-    #[doc = "Reserved. Note: This bit should remain clear."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 0;
-        pub const mask: u32 = 0x1fff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Delay increment of the rise of squelch: 00 = Delay is nominal 01 = Delay is +20% 10 = Delay is -20% 11 = Delay is -40%"]
     pub mod ENTAILADJVD {
         pub const offset: u32 = 13;
         pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 15;
-        pub const mask: u32 = 0x0001_ffff << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -2516,26 +1964,10 @@ pub mod DEBUG1_SET {
 }
 #[doc = "UTMI Debug Status Register 1"]
 pub mod DEBUG1_CLR {
-    #[doc = "Reserved. Note: This bit should remain clear."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 0;
-        pub const mask: u32 = 0x1fff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Delay increment of the rise of squelch: 00 = Delay is nominal 01 = Delay is +20% 10 = Delay is -20% 11 = Delay is -40%"]
     pub mod ENTAILADJVD {
         pub const offset: u32 = 13;
         pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 15;
-        pub const mask: u32 = 0x0001_ffff << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -2543,26 +1975,10 @@ pub mod DEBUG1_CLR {
 }
 #[doc = "UTMI Debug Status Register 1"]
 pub mod DEBUG1_TOG {
-    #[doc = "Reserved. Note: This bit should remain clear."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 0;
-        pub const mask: u32 = 0x1fff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Delay increment of the rise of squelch: 00 = Delay is nominal 01 = Delay is +20% 10 = Delay is -20% 11 = Delay is -40%"]
     pub mod ENTAILADJVD {
         pub const offset: u32 = 13;
         pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 15;
-        pub const mask: u32 = 0x0001_ffff << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}

--- a/src/blocks/imxrt1015/ccm.rs
+++ b/src/blocks/imxrt1015/ccm.rs
@@ -2265,14 +2265,6 @@ pub mod CCGR0 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "flexspi_exsc clock (flexspi_exsc_clk_enable)"]
-    pub mod CG3 {
-        pub const offset: u32 = 6;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "sim_m_clk_r_clk_enable"]
     pub mod CG4 {
         pub const offset: u32 = 8;
@@ -2292,38 +2284,6 @@ pub mod CCGR0 {
     #[doc = "lpuart3 clock (lpuart3_clk_enable)"]
     pub mod CG6 {
         pub const offset: u32 = 12;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG7 {
-        pub const offset: u32 = 14;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG8 {
-        pub const offset: u32 = 16;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG9 {
-        pub const offset: u32 = 18;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG10 {
-        pub const offset: u32 = 20;
         pub const mask: u32 = 0x03 << offset;
         pub mod R {}
         pub mod W {}
@@ -2388,38 +2348,6 @@ pub mod CCGR1 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CG2 {
-        pub const offset: u32 = 4;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG3 {
-        pub const offset: u32 = 6;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG4 {
-        pub const offset: u32 = 8;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG5 {
-        pub const offset: u32 = 10;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "pit clocks (pit_clk_enable)"]
     pub mod CG6 {
         pub const offset: u32 = 12;
@@ -2428,25 +2356,9 @@ pub mod CCGR1 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CG7 {
-        pub const offset: u32 = 14;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "adc1 clock (adc1_clk_enable)"]
     pub mod CG8 {
         pub const offset: u32 = 16;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG9 {
-        pub const offset: u32 = 18;
         pub const mask: u32 = 0x03 << offset;
         pub mod R {}
         pub mod W {}
@@ -2511,14 +2423,6 @@ pub mod CCGR2 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CG1 {
-        pub const offset: u32 = 2;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "iomuxc_snvs clock (iomuxc_snvs_clk_enable)"]
     pub mod CG2 {
         pub const offset: u32 = 4;
@@ -2543,49 +2447,9 @@ pub mod CCGR2 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CG5 {
-        pub const offset: u32 = 10;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "OCOTP_CTRL clock (iim_clk_enable)"]
     pub mod CG6 {
         pub const offset: u32 = 12;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG7 {
-        pub const offset: u32 = 14;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG8 {
-        pub const offset: u32 = 16;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG9 {
-        pub const offset: u32 = 18;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG10 {
-        pub const offset: u32 = 20;
         pub const mask: u32 = 0x03 << offset;
         pub mod R {}
         pub mod W {}
@@ -2599,7 +2463,7 @@ pub mod CCGR2 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "xbar2 clock (xbar2_clk_enable)"]
     pub mod CG12 {
         pub const offset: u32 = 24;
         pub const mask: u32 = 0x03 << offset;
@@ -2607,25 +2471,9 @@ pub mod CCGR2 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "gpio3 clock (gpio3_clk_enable)"]
     pub mod CG13 {
         pub const offset: u32 = 26;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG14 {
-        pub const offset: u32 = 28;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG15 {
-        pub const offset: u32 = 30;
         pub const mask: u32 = 0x03 << offset;
         pub mod R {}
         pub mod W {}
@@ -2634,57 +2482,9 @@ pub mod CCGR2 {
 }
 #[doc = "CCM Clock Gating Register 3"]
 pub mod CCGR3 {
-    #[doc = "Reserved"]
-    pub mod CG0 {
-        pub const offset: u32 = 0;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG1 {
-        pub const offset: u32 = 2;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG2 {
-        pub const offset: u32 = 4;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG3 {
-        pub const offset: u32 = 6;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "aoi1 clock (aoi1_clk_enable)"]
     pub mod CG4 {
         pub const offset: u32 = 8;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG5 {
-        pub const offset: u32 = 10;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG6 {
-        pub const offset: u32 = 12;
         pub const mask: u32 = 0x03 << offset;
         pub mod R {}
         pub mod W {}
@@ -2709,38 +2509,6 @@ pub mod CCGR3 {
     #[doc = "flexram clock (flexram_clk_enable)"]
     pub mod CG9 {
         pub const offset: u32 = 18;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG10 {
-        pub const offset: u32 = 20;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG11 {
-        pub const offset: u32 = 22;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG12 {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG13 {
-        pub const offset: u32 = 26;
         pub const mask: u32 = 0x03 << offset;
         pub mod R {}
         pub mod W {}
@@ -2789,7 +2557,7 @@ pub mod CCGR4 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "bee clock(bee_clk_enable)"]
     pub mod CG3 {
         pub const offset: u32 = 6;
         pub const mask: u32 = 0x03 << offset;
@@ -2800,14 +2568,6 @@ pub mod CCGR4 {
     #[doc = "sim_m7 clock (sim_m7_clk_enable)"]
     pub mod CG4 {
         pub const offset: u32 = 8;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG5 {
-        pub const offset: u32 = 10;
         pub const mask: u32 = 0x03 << offset;
         pub mod R {}
         pub mod W {}
@@ -2837,57 +2597,9 @@ pub mod CCGR4 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CG9 {
-        pub const offset: u32 = 18;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG10 {
-        pub const offset: u32 = 20;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG11 {
-        pub const offset: u32 = 22;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
+    #[doc = "enc1 clocks (enc1_clk_enable)"]
     pub mod CG12 {
         pub const offset: u32 = 24;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG13 {
-        pub const offset: u32 = 26;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG14 {
-        pub const offset: u32 = 28;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "dma_ps clocks (dma_ps_clk_enable)"]
-    pub mod CG15 {
-        pub const offset: u32 = 30;
         pub const mask: u32 = 0x03 << offset;
         pub mod R {}
         pub mod W {}
@@ -2944,7 +2656,7 @@ pub mod CCGR5 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "aipstz4 clocks (aips_tz4_clk_enable)"]
     pub mod CG6 {
         pub const offset: u32 = 12;
         pub const mask: u32 = 0x03 << offset;
@@ -2960,14 +2672,6 @@ pub mod CCGR5 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CG8 {
-        pub const offset: u32 = 16;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "sai1 clock (sai1_clk_enable)"]
     pub mod CG9 {
         pub const offset: u32 = 18;
@@ -2976,7 +2680,7 @@ pub mod CCGR5 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "sai2 clock (sai2_clk_enable)"]
     pub mod CG10 {
         pub const offset: u32 = 20;
         pub const mask: u32 = 0x03 << offset;
@@ -2995,14 +2699,6 @@ pub mod CCGR5 {
     #[doc = "lpuart1 clock (lpuart1_clk_enable)"]
     pub mod CG12 {
         pub const offset: u32 = 24;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG13 {
-        pub const offset: u32 = 26;
         pub const mask: u32 = 0x03 << offset;
         pub mod R {}
         pub mod W {}
@@ -3035,33 +2731,9 @@ pub mod CCGR6 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CG1 {
-        pub const offset: u32 = 2;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG2 {
-        pub const offset: u32 = 4;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "dcdc clocks (dcdc_clk_enable)"]
     pub mod CG3 {
         pub const offset: u32 = 6;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG4 {
-        pub const offset: u32 = 8;
         pub const mask: u32 = 0x03 << offset;
         pub mod R {}
         pub mod W {}
@@ -3083,23 +2755,7 @@ pub mod CCGR6 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CG7 {
-        pub const offset: u32 = 14;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG8 {
-        pub const offset: u32 = 16;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
+    #[doc = "aips_tz3 clock (aips_tz3_clk_enable)"]
     pub mod CG9 {
         pub const offset: u32 = 18;
         pub const mask: u32 = 0x03 << offset;
@@ -3123,33 +2779,9 @@ pub mod CCGR6 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CG12 {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
+    #[doc = "timer1 clocks (timer1_clk_enable)"]
     pub mod CG13 {
         pub const offset: u32 = 26;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG14 {
-        pub const offset: u32 = 28;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG15 {
-        pub const offset: u32 = 30;
         pub const mask: u32 = 0x03 << offset;
         pub mod R {}
         pub mod W {}

--- a/src/blocks/imxrt1015/iomuxc_gpr.rs
+++ b/src/blocks/imxrt1015/iomuxc_gpr.rs
@@ -845,16 +845,16 @@ pub mod GPR2 {
 }
 #[doc = "GPR3 General Purpose Register"]
 pub mod GPR3 {
-    #[doc = "Select 128-bit DCP key from 256-bit key from SNVS Master Key"]
+    #[doc = "Select 128-bit DCP key from 256-bit key from SNVS/OCOTP"]
     pub mod DCP_KEY_SEL {
         pub const offset: u32 = 4;
         pub const mask: u32 = 0x01 << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select \\[127:0\\] from SNVS Master Key as DCP key"]
+            #[doc = "Select \\[127:0\\] from SNVS/OCOTP key as DCP key"]
             pub const DCP_KEY_SEL_0: u32 = 0;
-            #[doc = "Select \\[255:128\\] from SNVS Master Key as DCP key"]
+            #[doc = "Select \\[255:128\\] from SNVS/OCOTP key as DCP key"]
             pub const DCP_KEY_SEL_1: u32 = 0x01;
         }
     }
@@ -1871,7 +1871,7 @@ pub mod GPR10 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select key from SNVS Master Key."]
+            #[doc = "Select key from Key MUX (SNVS/OTPMK)."]
             pub const DCPKEY_OCOTP_OR_KEYMUX_0: u32 = 0;
             #[doc = "Select key from OCOTP (SW_GP2)."]
             pub const DCPKEY_OCOTP_OR_KEYMUX_1: u32 = 0x01;

--- a/src/blocks/imxrt1015/iomuxc_snvs.rs
+++ b/src/blocks/imxrt1015/iomuxc_snvs.rs
@@ -26,7 +26,7 @@ pub mod SW_MUX_CTL_PAD_PMIC_ON_REQ {
         pub mod RW {
             #[doc = "Select mux mode: ALT0 mux port: SNVS_LP_PMIC_ON_REQ of instance: snvs_lp"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO5_IO00 of instance: gpio5"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO5_IO01 of instance: gpio5"]
             pub const ALT5: u32 = 0x05;
         }
     }

--- a/src/blocks/imxrt1015/ocotp.rs
+++ b/src/blocks/imxrt1015/ocotp.rs
@@ -707,14 +707,6 @@ pub mod LOCK {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod FIELD_RETURN {
-        pub const offset: u32 = 28;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "Value of OTP Bank0 Word1 (Configuration and Manufacturing Info.)"]
 pub mod CFG0 {

--- a/src/blocks/imxrt1021/can.rs
+++ b/src/blocks/imxrt1021/can.rs
@@ -1677,14 +1677,6 @@ pub mod CS0 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "Message Buffer 0 ID Register"]
 pub mod ID0 {
@@ -1821,14 +1813,6 @@ pub mod CS1 {
     pub mod SRR {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -1973,14 +1957,6 @@ pub mod CS2 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "Message Buffer 2 ID Register"]
 pub mod ID2 {
@@ -2117,14 +2093,6 @@ pub mod CS3 {
     pub mod SRR {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -2269,14 +2237,6 @@ pub mod CS4 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "Message Buffer 4 ID Register"]
 pub mod ID4 {
@@ -2413,14 +2373,6 @@ pub mod CS5 {
     pub mod SRR {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -2565,14 +2517,6 @@ pub mod CS6 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "Message Buffer 6 ID Register"]
 pub mod ID6 {
@@ -2709,14 +2653,6 @@ pub mod CS7 {
     pub mod SRR {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -2861,14 +2797,6 @@ pub mod CS8 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "Message Buffer 8 ID Register"]
 pub mod ID8 {
@@ -3005,14 +2933,6 @@ pub mod CS9 {
     pub mod SRR {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -3157,14 +3077,6 @@ pub mod CS10 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "Message Buffer 10 ID Register"]
 pub mod ID10 {
@@ -3301,14 +3213,6 @@ pub mod CS11 {
     pub mod SRR {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -3453,14 +3357,6 @@ pub mod CS12 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "Message Buffer 12 ID Register"]
 pub mod ID12 {
@@ -3597,14 +3493,6 @@ pub mod CS13 {
     pub mod SRR {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -3749,14 +3637,6 @@ pub mod CS14 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "Message Buffer 14 ID Register"]
 pub mod ID14 {
@@ -3893,14 +3773,6 @@ pub mod CS15 {
     pub mod SRR {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -4045,14 +3917,6 @@ pub mod CS16 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "Message Buffer 16 ID Register"]
 pub mod ID16 {
@@ -4189,14 +4053,6 @@ pub mod CS17 {
     pub mod SRR {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -4341,14 +4197,6 @@ pub mod CS18 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "Message Buffer 18 ID Register"]
 pub mod ID18 {
@@ -4485,14 +4333,6 @@ pub mod CS19 {
     pub mod SRR {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -4637,14 +4477,6 @@ pub mod CS20 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "Message Buffer 20 ID Register"]
 pub mod ID20 {
@@ -4781,14 +4613,6 @@ pub mod CS21 {
     pub mod SRR {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -4933,14 +4757,6 @@ pub mod CS22 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "Message Buffer 22 ID Register"]
 pub mod ID22 {
@@ -5077,14 +4893,6 @@ pub mod CS23 {
     pub mod SRR {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -5229,14 +5037,6 @@ pub mod CS24 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "Message Buffer 24 ID Register"]
 pub mod ID24 {
@@ -5373,14 +5173,6 @@ pub mod CS25 {
     pub mod SRR {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -5525,14 +5317,6 @@ pub mod CS26 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "Message Buffer 26 ID Register"]
 pub mod ID26 {
@@ -5669,14 +5453,6 @@ pub mod CS27 {
     pub mod SRR {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -5821,14 +5597,6 @@ pub mod CS28 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "Message Buffer 28 ID Register"]
 pub mod ID28 {
@@ -5965,14 +5733,6 @@ pub mod CS29 {
     pub mod SRR {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -6117,14 +5877,6 @@ pub mod CS30 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "Message Buffer 30 ID Register"]
 pub mod ID30 {
@@ -6261,14 +6013,6 @@ pub mod CS31 {
     pub mod SRR {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -6413,14 +6157,6 @@ pub mod CS32 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "Message Buffer 32 ID Register"]
 pub mod ID32 {
@@ -6557,14 +6293,6 @@ pub mod CS33 {
     pub mod SRR {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -6709,14 +6437,6 @@ pub mod CS34 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "Message Buffer 34 ID Register"]
 pub mod ID34 {
@@ -6853,14 +6573,6 @@ pub mod CS35 {
     pub mod SRR {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -7005,14 +6717,6 @@ pub mod CS36 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "Message Buffer 36 ID Register"]
 pub mod ID36 {
@@ -7149,14 +6853,6 @@ pub mod CS37 {
     pub mod SRR {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -7301,14 +6997,6 @@ pub mod CS38 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "Message Buffer 38 ID Register"]
 pub mod ID38 {
@@ -7445,14 +7133,6 @@ pub mod CS39 {
     pub mod SRR {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -7597,14 +7277,6 @@ pub mod CS40 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "Message Buffer 40 ID Register"]
 pub mod ID40 {
@@ -7741,14 +7413,6 @@ pub mod CS41 {
     pub mod SRR {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -7893,14 +7557,6 @@ pub mod CS42 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "Message Buffer 42 ID Register"]
 pub mod ID42 {
@@ -8037,14 +7693,6 @@ pub mod CS43 {
     pub mod SRR {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -8189,14 +7837,6 @@ pub mod CS44 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "Message Buffer 44 ID Register"]
 pub mod ID44 {
@@ -8333,14 +7973,6 @@ pub mod CS45 {
     pub mod SRR {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -8485,14 +8117,6 @@ pub mod CS46 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "Message Buffer 46 ID Register"]
 pub mod ID46 {
@@ -8629,14 +8253,6 @@ pub mod CS47 {
     pub mod SRR {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -8781,14 +8397,6 @@ pub mod CS48 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "Message Buffer 48 ID Register"]
 pub mod ID48 {
@@ -8925,14 +8533,6 @@ pub mod CS49 {
     pub mod SRR {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -9077,14 +8677,6 @@ pub mod CS50 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "Message Buffer 50 ID Register"]
 pub mod ID50 {
@@ -9221,14 +8813,6 @@ pub mod CS51 {
     pub mod SRR {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -9373,14 +8957,6 @@ pub mod CS52 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "Message Buffer 52 ID Register"]
 pub mod ID52 {
@@ -9517,14 +9093,6 @@ pub mod CS53 {
     pub mod SRR {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -9669,14 +9237,6 @@ pub mod CS54 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "Message Buffer 54 ID Register"]
 pub mod ID54 {
@@ -9813,14 +9373,6 @@ pub mod CS55 {
     pub mod SRR {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -9965,14 +9517,6 @@ pub mod CS56 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "Message Buffer 56 ID Register"]
 pub mod ID56 {
@@ -10109,14 +9653,6 @@ pub mod CS57 {
     pub mod SRR {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -10261,14 +9797,6 @@ pub mod CS58 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "Message Buffer 58 ID Register"]
 pub mod ID58 {
@@ -10405,14 +9933,6 @@ pub mod CS59 {
     pub mod SRR {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -10557,14 +10077,6 @@ pub mod CS60 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "Message Buffer 60 ID Register"]
 pub mod ID60 {
@@ -10701,14 +10213,6 @@ pub mod CS61 {
     pub mod SRR {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -10853,14 +10357,6 @@ pub mod CS62 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "Message Buffer 62 ID Register"]
 pub mod ID62 {
@@ -10997,14 +10493,6 @@ pub mod CS63 {
     pub mod SRR {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CODE {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}

--- a/src/blocks/imxrt1021/ccm.rs
+++ b/src/blocks/imxrt1021/ccm.rs
@@ -2720,6 +2720,14 @@ pub mod CCGR1 {
         pub mod W {}
         pub mod RW {}
     }
+    #[doc = "gpio5 clock (gpio5_clk_enable)"]
+    pub mod CG15 {
+        pub const offset: u32 = 30;
+        pub const mask: u32 = 0x03 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
 }
 #[doc = "CCM Clock Gating Register 2"]
 pub mod CCGR2 {

--- a/src/blocks/imxrt1021/ccm.rs
+++ b/src/blocks/imxrt1021/ccm.rs
@@ -2533,7 +2533,7 @@ pub mod CCGR0 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "can1 clock (can1_clk_enable)"]
     pub mod CG7 {
         pub const offset: u32 = 14;
         pub const mask: u32 = 0x03 << offset;
@@ -2541,7 +2541,7 @@ pub mod CCGR0 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "can1_serial clock (can1_serial_clk_enable)"]
     pub mod CG8 {
         pub const offset: u32 = 16;
         pub const mask: u32 = 0x03 << offset;
@@ -2549,7 +2549,7 @@ pub mod CCGR0 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "can2 clock (can2_clk_enable)"]
     pub mod CG9 {
         pub const offset: u32 = 18;
         pub const mask: u32 = 0x03 << offset;
@@ -2557,7 +2557,7 @@ pub mod CCGR0 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "can2_serial clock (can2_serial_clk_enable)"]
     pub mod CG10 {
         pub const offset: u32 = 20;
         pub const mask: u32 = 0x03 << offset;
@@ -2624,7 +2624,7 @@ pub mod CCGR1 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "lpspi3 clocks (lpspi3_clk_enable)"]
     pub mod CG2 {
         pub const offset: u32 = 4;
         pub const mask: u32 = 0x03 << offset;
@@ -2632,7 +2632,7 @@ pub mod CCGR1 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "lpspi4 clocks (lpspi4_clk_enable)"]
     pub mod CG3 {
         pub const offset: u32 = 6;
         pub const mask: u32 = 0x03 << offset;
@@ -2640,7 +2640,7 @@ pub mod CCGR1 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "adc2 clock (adc2_clk_enable)"]
     pub mod CG4 {
         pub const offset: u32 = 8;
         pub const mask: u32 = 0x03 << offset;
@@ -2648,7 +2648,7 @@ pub mod CCGR1 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "enet clock (enet_clk_enable)"]
     pub mod CG5 {
         pub const offset: u32 = 10;
         pub const mask: u32 = 0x03 << offset;
@@ -2664,14 +2664,6 @@ pub mod CCGR1 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CG7 {
-        pub const offset: u32 = 14;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "adc1 clock (adc1_clk_enable)"]
     pub mod CG8 {
         pub const offset: u32 = 16;
@@ -2680,7 +2672,7 @@ pub mod CCGR1 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "semc_exsc clock (semc_exsc_clk_enable)"]
     pub mod CG9 {
         pub const offset: u32 = 18;
         pub const mask: u32 = 0x03 << offset;
@@ -2728,28 +2720,12 @@ pub mod CCGR1 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "gpio5 clock (gpio5_clk_enable)"]
-    pub mod CG15 {
-        pub const offset: u32 = 30;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "CCM Clock Gating Register 2"]
 pub mod CCGR2 {
     #[doc = "ocram_exsc clock (ocram_exsc_clk_enable)"]
     pub mod CG0 {
         pub const offset: u32 = 0;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG1 {
-        pub const offset: u32 = 2;
         pub const mask: u32 = 0x03 << offset;
         pub mod R {}
         pub mod W {}
@@ -2779,7 +2755,7 @@ pub mod CCGR2 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "lpi2c3 clock (lpi2c3_clk_enable)"]
     pub mod CG5 {
         pub const offset: u32 = 10;
         pub const mask: u32 = 0x03 << offset;
@@ -2795,38 +2771,6 @@ pub mod CCGR2 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CG7 {
-        pub const offset: u32 = 14;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG8 {
-        pub const offset: u32 = 16;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG9 {
-        pub const offset: u32 = 18;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG10 {
-        pub const offset: u32 = 20;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "xbar1 clock (xbar1_clk_enable)"]
     pub mod CG11 {
         pub const offset: u32 = 22;
@@ -2835,7 +2779,7 @@ pub mod CCGR2 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "xbar2 clock (xbar2_clk_enable)"]
     pub mod CG12 {
         pub const offset: u32 = 24;
         pub const mask: u32 = 0x03 << offset;
@@ -2843,25 +2787,9 @@ pub mod CCGR2 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "gpio3 clock (gpio3_clk_enable)"]
     pub mod CG13 {
         pub const offset: u32 = 26;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG14 {
-        pub const offset: u32 = 28;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG15 {
-        pub const offset: u32 = 30;
         pub const mask: u32 = 0x03 << offset;
         pub mod R {}
         pub mod W {}
@@ -2870,15 +2798,7 @@ pub mod CCGR2 {
 }
 #[doc = "CCM Clock Gating Register 3"]
 pub mod CCGR3 {
-    #[doc = "Reserved"]
-    pub mod CG0 {
-        pub const offset: u32 = 0;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
+    #[doc = "lpuart5 clock (lpuart5_clk_enable)"]
     pub mod CG1 {
         pub const offset: u32 = 2;
         pub const mask: u32 = 0x03 << offset;
@@ -2886,7 +2806,7 @@ pub mod CCGR3 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "semc clocks (semc_clk_enable)"]
     pub mod CG2 {
         pub const offset: u32 = 4;
         pub const mask: u32 = 0x03 << offset;
@@ -2894,7 +2814,7 @@ pub mod CCGR3 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "lpuart6 clock (lpuart6_clk_enable)"]
     pub mod CG3 {
         pub const offset: u32 = 6;
         pub const mask: u32 = 0x03 << offset;
@@ -2905,22 +2825,6 @@ pub mod CCGR3 {
     #[doc = "aoi1 clock (aoi1_clk_enable)"]
     pub mod CG4 {
         pub const offset: u32 = 8;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG5 {
-        pub const offset: u32 = 10;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG6 {
-        pub const offset: u32 = 12;
         pub const mask: u32 = 0x03 << offset;
         pub mod R {}
         pub mod W {}
@@ -2950,7 +2854,7 @@ pub mod CCGR3 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "acmp1 clocks (acmp1_clk_enable)"]
     pub mod CG10 {
         pub const offset: u32 = 20;
         pub const mask: u32 = 0x03 << offset;
@@ -2958,7 +2862,7 @@ pub mod CCGR3 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "acmp2 clocks (acmp2_clk_enable)"]
     pub mod CG11 {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x03 << offset;
@@ -2966,7 +2870,7 @@ pub mod CCGR3 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "acmp3 clocks (acmp3_clk_enable)"]
     pub mod CG12 {
         pub const offset: u32 = 24;
         pub const mask: u32 = 0x03 << offset;
@@ -2974,7 +2878,7 @@ pub mod CCGR3 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "acmp4 clocks (acmp4_clk_enable)"]
     pub mod CG13 {
         pub const offset: u32 = 26;
         pub const mask: u32 = 0x03 << offset;
@@ -3025,7 +2929,7 @@ pub mod CCGR4 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "bee clock(bee_clk_enable)"]
     pub mod CG3 {
         pub const offset: u32 = 6;
         pub const mask: u32 = 0x03 << offset;
@@ -3036,14 +2940,6 @@ pub mod CCGR4 {
     #[doc = "sim_m7 clock (sim_m7_clk_enable)"]
     pub mod CG4 {
         pub const offset: u32 = 8;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG5 {
-        pub const offset: u32 = 10;
         pub const mask: u32 = 0x03 << offset;
         pub mod R {}
         pub mod W {}
@@ -3073,7 +2969,7 @@ pub mod CCGR4 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "pwm2 clocks (pwm2_clk_enable)"]
     pub mod CG9 {
         pub const offset: u32 = 18;
         pub const mask: u32 = 0x03 << offset;
@@ -3081,23 +2977,7 @@ pub mod CCGR4 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CG10 {
-        pub const offset: u32 = 20;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG11 {
-        pub const offset: u32 = 22;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
+    #[doc = "enc1 clocks (enc1_clk_enable)"]
     pub mod CG12 {
         pub const offset: u32 = 24;
         pub const mask: u32 = 0x03 << offset;
@@ -3105,25 +2985,9 @@ pub mod CCGR4 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "enc2 clocks (enc2_clk_enable)"]
     pub mod CG13 {
         pub const offset: u32 = 26;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG14 {
-        pub const offset: u32 = 28;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "dma_ps clocks (dma_ps_clk_enable)"]
-    pub mod CG15 {
-        pub const offset: u32 = 30;
         pub const mask: u32 = 0x03 << offset;
         pub mod R {}
         pub mod W {}
@@ -3180,7 +3044,7 @@ pub mod CCGR5 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "aipstz4 clocks (aips_tz4_clk_enable)"]
     pub mod CG6 {
         pub const offset: u32 = 12;
         pub const mask: u32 = 0x03 << offset;
@@ -3196,14 +3060,6 @@ pub mod CCGR5 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CG8 {
-        pub const offset: u32 = 16;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "sai1 clock (sai1_clk_enable)"]
     pub mod CG9 {
         pub const offset: u32 = 18;
@@ -3212,7 +3068,7 @@ pub mod CCGR5 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "sai2 clock (sai2_clk_enable)"]
     pub mod CG10 {
         pub const offset: u32 = 20;
         pub const mask: u32 = 0x03 << offset;
@@ -3236,7 +3092,7 @@ pub mod CCGR5 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "lpuart7 clock (lpuart7_clk_enable)"]
     pub mod CG13 {
         pub const offset: u32 = 26;
         pub const mask: u32 = 0x03 << offset;
@@ -3271,7 +3127,7 @@ pub mod CCGR6 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "usdhc1 clocks (usdhc1_clk_enable)"]
     pub mod CG1 {
         pub const offset: u32 = 2;
         pub const mask: u32 = 0x03 << offset;
@@ -3279,7 +3135,7 @@ pub mod CCGR6 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "usdhc2 clocks (usdhc2_clk_enable)"]
     pub mod CG2 {
         pub const offset: u32 = 4;
         pub const mask: u32 = 0x03 << offset;
@@ -3290,14 +3146,6 @@ pub mod CCGR6 {
     #[doc = "dcdc clocks (dcdc_clk_enable)"]
     pub mod CG3 {
         pub const offset: u32 = 6;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG4 {
-        pub const offset: u32 = 8;
         pub const mask: u32 = 0x03 << offset;
         pub mod R {}
         pub mod W {}
@@ -3319,7 +3167,7 @@ pub mod CCGR6 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "lpuart8 clocks (lpuart8_clk_enable)"]
     pub mod CG7 {
         pub const offset: u32 = 14;
         pub const mask: u32 = 0x03 << offset;
@@ -3327,15 +3175,7 @@ pub mod CCGR6 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod CG8 {
-        pub const offset: u32 = 16;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
+    #[doc = "aips_tz3 clock (aips_tz3_clk_enable)"]
     pub mod CG9 {
         pub const offset: u32 = 18;
         pub const mask: u32 = 0x03 << offset;
@@ -3359,7 +3199,7 @@ pub mod CCGR6 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "lpi2c4 serial clock (lpi2c4_serial_clk_enable)"]
     pub mod CG12 {
         pub const offset: u32 = 24;
         pub const mask: u32 = 0x03 << offset;
@@ -3367,7 +3207,7 @@ pub mod CCGR6 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "timer1 clocks (timer1_clk_enable)"]
     pub mod CG13 {
         pub const offset: u32 = 26;
         pub const mask: u32 = 0x03 << offset;
@@ -3375,17 +3215,9 @@ pub mod CCGR6 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "timer2 clocks (timer2_clk_enable)"]
     pub mod CG14 {
         pub const offset: u32 = 28;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod CG15 {
-        pub const offset: u32 = 30;
         pub const mask: u32 = 0x03 << offset;
         pub mod R {}
         pub mod W {}

--- a/src/blocks/imxrt1021/iomuxc.rs
+++ b/src/blocks/imxrt1021/iomuxc.rs
@@ -2254,7 +2254,7 @@ pub mod SW_MUX_CTL_PAD_GPIO_AD_B0_00 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: JTAG_MUX_TMS of instance: jtag_mux"]
+            #[doc = "Select mux mode: ALT0 mux port: JTAG_TMS of instance: jtag_mux"]
             pub const ALT0: u32 = 0;
             #[doc = "Select mux mode: ALT5 mux port: GPIO1_IO00 of instance: gpio1"]
             pub const ALT5: u32 = 0x05;
@@ -2285,7 +2285,7 @@ pub mod SW_MUX_CTL_PAD_GPIO_AD_B0_01 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: JTAG_MUX_TCK of instance: jtag_mux"]
+            #[doc = "Select mux mode: ALT0 mux port: JTAG_TCK of instance: jtag_mux"]
             pub const ALT0: u32 = 0;
             #[doc = "Select mux mode: ALT5 mux port: GPIO1_IO01 of instance: gpio1"]
             pub const ALT5: u32 = 0x05;
@@ -2316,7 +2316,7 @@ pub mod SW_MUX_CTL_PAD_GPIO_AD_B0_02 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: JTAG_MUX_MOD of instance: jtag_mux"]
+            #[doc = "Select mux mode: ALT0 mux port: JTAG_MOD of instance: jtag_mux"]
             pub const ALT0: u32 = 0;
             #[doc = "Select mux mode: ALT5 mux port: GPIO1_IO02 of instance: gpio1"]
             pub const ALT5: u32 = 0x05;

--- a/src/blocks/imxrt1021/iomuxc_gpr.rs
+++ b/src/blocks/imxrt1021/iomuxc_gpr.rs
@@ -249,7 +249,7 @@ pub mod GPR1 {
         pub mod RW {
             #[doc = "OKAY response"]
             pub const EXC_MON_0: u32 = 0;
-            #[doc = "SLVError response"]
+            #[doc = "SLVError response (default)"]
             pub const EXC_MON_1: u32 = 0x01;
         }
     }
@@ -273,9 +273,9 @@ pub mod GPR1 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "AHB clock is not running (gated) when CM7 is sleeping and TCM is not accessible."]
+            #[doc = "AHB clock is not running (gated)"]
             pub const CM7_FORCE_HCLK_EN_0: u32 = 0;
-            #[doc = "AHB clock is running (enabled) when CM7 is sleeping and TCM is accessible."]
+            #[doc = "AHB clock is running (enabled)"]
             pub const CM7_FORCE_HCLK_EN_1: u32 = 0x01;
         }
     }
@@ -289,9 +289,9 @@ pub mod GPR2 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Enters power saving mode only when chip is in SUSPEND mode"]
+            #[doc = "none memory power saving features enabled, SHUTDOWN/DEEPSLEEP/LIGHTSLEEP will have no effect"]
             pub const L2_MEM_EN_POWERSAVING_0: u32 = 0;
-            #[doc = "Controlled by L2_MEM_DEEPSLEEP bitfield"]
+            #[doc = "memory power saving features enabled, set SHUTDOWN/DEEPSLEEP/LIGHTSLEEP(priority high to low) to enable power saving levels"]
             pub const L2_MEM_EN_POWERSAVING_1: u32 = 0x01;
         }
     }
@@ -315,9 +315,9 @@ pub mod GPR2 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "No force sleep control supported, memory deep sleep mode only entered when whole system in stop mode (OCRAM in normal mode)"]
+            #[doc = "no force sleep control supported, memory deep sleep mode only entered when whole system in stop mode"]
             pub const L2_MEM_DEEPSLEEP_0: u32 = 0;
-            #[doc = "Force memory into deep sleep mode (OCRAM in power saving mode)"]
+            #[doc = "force memory into deep sleep mode"]
             pub const L2_MEM_DEEPSLEEP_1: u32 = 0x01;
         }
     }
@@ -888,9 +888,9 @@ pub mod GPR2 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Timer counter works normally"]
+            #[doc = "timer counter work normally"]
             pub const QTIMER1_TMR_CNTS_FREEZE_0: u32 = 0;
-            #[doc = "Reset counter and ouput flags"]
+            #[doc = "reset counter and ouput flags"]
             pub const QTIMER1_TMR_CNTS_FREEZE_1: u32 = 0x01;
         }
     }
@@ -925,9 +925,9 @@ pub mod GPR3 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select \\[127:0\\] from SNVS Master Key as DCP key"]
+            #[doc = "Select \\[127:0\\] from snvs/ocotp key as dcp key"]
             pub const DCP_KEY_SEL_0: u32 = 0;
-            #[doc = "Select \\[255:128\\] from SNVS Master Key as DCP key"]
+            #[doc = "Select \\[255:128\\] from snvs/ocotp key as dcp key"]
             pub const DCP_KEY_SEL_1: u32 = 0x01;
         }
     }
@@ -2542,7 +2542,7 @@ pub mod GPR10 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select key from SNVS Master Key."]
+            #[doc = "Select key from Key MUX (SNVS/OTPMK)."]
             pub const DCPKEY_OCOTP_OR_KEYMUX_0: u32 = 0;
             #[doc = "Select key from OCOTP (SW_GP2)."]
             pub const DCPKEY_OCOTP_OR_KEYMUX_1: u32 = 0x01;

--- a/src/blocks/imxrt1021/iomuxc_snvs.rs
+++ b/src/blocks/imxrt1021/iomuxc_snvs.rs
@@ -60,7 +60,7 @@ pub mod SW_MUX_CTL_PAD_PMIC_ON_REQ {
         pub mod RW {
             #[doc = "Select mux mode: ALT0 mux port: SNVS_LP_PMIC_ON_REQ of instance: snvs_lp"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO5_IO00 of instance: gpio5"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO5_IO01 of instance: gpio5"]
             pub const ALT5: u32 = 0x05;
         }
     }

--- a/src/blocks/imxrt1021/ocotp.rs
+++ b/src/blocks/imxrt1021/ocotp.rs
@@ -731,14 +731,6 @@ pub mod LOCK {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod FIELD_RETURN {
-        pub const offset: u32 = 28;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "Value of OTP Bank0 Word1 (Configuration and Manufacturing Info.)"]
 pub mod CFG0 {

--- a/src/blocks/imxrt1051/ccm.rs
+++ b/src/blocks/imxrt1051/ccm.rs
@@ -2927,6 +2927,14 @@ pub mod CCGR1 {
         pub mod W {}
         pub mod RW {}
     }
+    #[doc = "gpio5 clock (gpio5_clk_enable)"]
+    pub mod CG15 {
+        pub const offset: u32 = 30;
+        pub const mask: u32 = 0x03 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
 }
 #[doc = "CCM Clock Gating Register 2"]
 pub mod CCGR2 {

--- a/src/blocks/imxrt1051/ccm.rs
+++ b/src/blocks/imxrt1051/ccm.rs
@@ -2708,7 +2708,7 @@ pub mod CCGR0 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "sim_m_clk_r_clk_enable"]
+    #[doc = "sim_m or sim_main register access clock (sim_m_mainclk_r_enable)"]
     pub mod CG4 {
         pub const offset: u32 = 8;
         pub const mask: u32 = 0x03 << offset;

--- a/src/blocks/imxrt1051/ccm.rs
+++ b/src/blocks/imxrt1051/ccm.rs
@@ -2732,7 +2732,7 @@ pub mod CCGR0 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "can1 clock (can1_clk_enable)"]
     pub mod CG7 {
         pub const offset: u32 = 14;
         pub const mask: u32 = 0x03 << offset;
@@ -2740,7 +2740,7 @@ pub mod CCGR0 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "can1_serial clock (can1_serial_clk_enable)"]
     pub mod CG8 {
         pub const offset: u32 = 16;
         pub const mask: u32 = 0x03 << offset;
@@ -2748,7 +2748,7 @@ pub mod CCGR0 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "can2 clock (can2_clk_enable)"]
     pub mod CG9 {
         pub const offset: u32 = 18;
         pub const mask: u32 = 0x03 << offset;
@@ -2756,7 +2756,7 @@ pub mod CCGR0 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "can2_serial clock (can2_serial_clk_enable)"]
     pub mod CG10 {
         pub const offset: u32 = 20;
         pub const mask: u32 = 0x03 << offset;
@@ -2823,7 +2823,7 @@ pub mod CCGR1 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "lpspi3 clocks (lpspi3_clk_enable)"]
     pub mod CG2 {
         pub const offset: u32 = 4;
         pub const mask: u32 = 0x03 << offset;
@@ -2831,7 +2831,7 @@ pub mod CCGR1 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "lpspi4 clocks (lpspi4_clk_enable)"]
     pub mod CG3 {
         pub const offset: u32 = 6;
         pub const mask: u32 = 0x03 << offset;
@@ -2839,7 +2839,7 @@ pub mod CCGR1 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "adc2 clock (adc2_clk_enable)"]
     pub mod CG4 {
         pub const offset: u32 = 8;
         pub const mask: u32 = 0x03 << offset;
@@ -2847,7 +2847,7 @@ pub mod CCGR1 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "enet clock (enet_clk_enable)"]
     pub mod CG5 {
         pub const offset: u32 = 10;
         pub const mask: u32 = 0x03 << offset;
@@ -2863,7 +2863,7 @@ pub mod CCGR1 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "aoi2 clocks (aoi2_clk_enable)"]
     pub mod CG7 {
         pub const offset: u32 = 14;
         pub const mask: u32 = 0x03 << offset;
@@ -2879,7 +2879,7 @@ pub mod CCGR1 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "semc_exsc clock (semc_exsc_clk_enable)"]
     pub mod CG9 {
         pub const offset: u32 = 18;
         pub const mask: u32 = 0x03 << offset;
@@ -2927,14 +2927,6 @@ pub mod CCGR1 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "gpio5 clock (gpio5_clk_enable)"]
-    pub mod CG15 {
-        pub const offset: u32 = 30;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "CCM Clock Gating Register 2"]
 pub mod CCGR2 {
@@ -2946,7 +2938,7 @@ pub mod CCGR2 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "csi clock (csi_clk_enable)"]
     pub mod CG1 {
         pub const offset: u32 = 2;
         pub const mask: u32 = 0x03 << offset;
@@ -2978,7 +2970,7 @@ pub mod CCGR2 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "lpi2c3 clock (lpi2c3_clk_enable)"]
     pub mod CG5 {
         pub const offset: u32 = 10;
         pub const mask: u32 = 0x03 << offset;
@@ -2994,7 +2986,7 @@ pub mod CCGR2 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "xbar3 clock (xbar3_clk_enable)"]
     pub mod CG7 {
         pub const offset: u32 = 14;
         pub const mask: u32 = 0x03 << offset;
@@ -3002,7 +2994,7 @@ pub mod CCGR2 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "ipmux1 clock (ipmux1_clk_enable)"]
     pub mod CG8 {
         pub const offset: u32 = 16;
         pub const mask: u32 = 0x03 << offset;
@@ -3010,7 +3002,7 @@ pub mod CCGR2 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "ipmux2 clock (ipmux2_clk_enable)"]
     pub mod CG9 {
         pub const offset: u32 = 18;
         pub const mask: u32 = 0x03 << offset;
@@ -3018,7 +3010,7 @@ pub mod CCGR2 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "ipmux3 clock (ipmux3_clk_enable)"]
     pub mod CG10 {
         pub const offset: u32 = 20;
         pub const mask: u32 = 0x03 << offset;
@@ -3034,7 +3026,7 @@ pub mod CCGR2 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "xbar2 clock (xbar2_clk_enable)"]
     pub mod CG12 {
         pub const offset: u32 = 24;
         pub const mask: u32 = 0x03 << offset;
@@ -3042,7 +3034,7 @@ pub mod CCGR2 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "gpio3 clock (gpio3_clk_enable)"]
     pub mod CG13 {
         pub const offset: u32 = 26;
         pub const mask: u32 = 0x03 << offset;
@@ -3050,7 +3042,7 @@ pub mod CCGR2 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "lcd clocks (lcd_clk_enable)"]
     pub mod CG14 {
         pub const offset: u32 = 28;
         pub const mask: u32 = 0x03 << offset;
@@ -3058,7 +3050,7 @@ pub mod CCGR2 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "pxp clocks (pxp_clk_enable)"]
     pub mod CG15 {
         pub const offset: u32 = 30;
         pub const mask: u32 = 0x03 << offset;
@@ -3069,7 +3061,7 @@ pub mod CCGR2 {
 }
 #[doc = "CCM Clock Gating Register 3"]
 pub mod CCGR3 {
-    #[doc = "Reserved"]
+    #[doc = "flexio2 clocks (flexio2_clk_enable)"]
     pub mod CG0 {
         pub const offset: u32 = 0;
         pub const mask: u32 = 0x03 << offset;
@@ -3077,7 +3069,7 @@ pub mod CCGR3 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "lpuart5 clock (lpuart5_clk_enable)"]
     pub mod CG1 {
         pub const offset: u32 = 2;
         pub const mask: u32 = 0x03 << offset;
@@ -3085,7 +3077,7 @@ pub mod CCGR3 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "semc clocks (semc_clk_enable)"]
     pub mod CG2 {
         pub const offset: u32 = 4;
         pub const mask: u32 = 0x03 << offset;
@@ -3093,7 +3085,7 @@ pub mod CCGR3 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "lpuart6 clock (lpuart6_clk_enable)"]
     pub mod CG3 {
         pub const offset: u32 = 6;
         pub const mask: u32 = 0x03 << offset;
@@ -3109,7 +3101,7 @@ pub mod CCGR3 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "lcdif pix clock (lcdif_pix_clk_enable)"]
     pub mod CG5 {
         pub const offset: u32 = 10;
         pub const mask: u32 = 0x03 << offset;
@@ -3117,7 +3109,7 @@ pub mod CCGR3 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "gpio4 clock (gpio4_clk_enable)"]
     pub mod CG6 {
         pub const offset: u32 = 12;
         pub const mask: u32 = 0x03 << offset;
@@ -3149,7 +3141,7 @@ pub mod CCGR3 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "acmp1 clocks (acmp1_clk_enable)"]
     pub mod CG10 {
         pub const offset: u32 = 20;
         pub const mask: u32 = 0x03 << offset;
@@ -3157,7 +3149,7 @@ pub mod CCGR3 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "acmp2 clocks (acmp2_clk_enable)"]
     pub mod CG11 {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x03 << offset;
@@ -3165,7 +3157,7 @@ pub mod CCGR3 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "acmp3 clocks (acmp3_clk_enable)"]
     pub mod CG12 {
         pub const offset: u32 = 24;
         pub const mask: u32 = 0x03 << offset;
@@ -3173,7 +3165,7 @@ pub mod CCGR3 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "acmp4 clocks (acmp4_clk_enable)"]
     pub mod CG13 {
         pub const offset: u32 = 26;
         pub const mask: u32 = 0x03 << offset;
@@ -3181,7 +3173,7 @@ pub mod CCGR3 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "The OCRAM clock cannot be turned off when the CM cache is running on this device."]
+    #[doc = "ocram clock (ocram_clk_enable)"]
     pub mod CG14 {
         pub const offset: u32 = 28;
         pub const mask: u32 = 0x03 << offset;
@@ -3200,7 +3192,7 @@ pub mod CCGR3 {
 }
 #[doc = "CCM Clock Gating Register 4"]
 pub mod CCGR4 {
-    #[doc = "sim_m7_clk_r_enable"]
+    #[doc = "sim_m7 register access clock (sim_m7_mainclk_r_enable)"]
     pub mod CG0 {
         pub const offset: u32 = 0;
         pub const mask: u32 = 0x03 << offset;
@@ -3224,7 +3216,7 @@ pub mod CCGR4 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "bee clock(bee_clk_enable)"]
     pub mod CG3 {
         pub const offset: u32 = 6;
         pub const mask: u32 = 0x03 << offset;
@@ -3240,7 +3232,7 @@ pub mod CCGR4 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "tsc_dig clock (tsc_clk_enable)"]
     pub mod CG5 {
         pub const offset: u32 = 10;
         pub const mask: u32 = 0x03 << offset;
@@ -3272,7 +3264,7 @@ pub mod CCGR4 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "pwm2 clocks (pwm2_clk_enable)"]
     pub mod CG9 {
         pub const offset: u32 = 18;
         pub const mask: u32 = 0x03 << offset;
@@ -3280,7 +3272,7 @@ pub mod CCGR4 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "pwm3 clocks (pwm3_clk_enable)"]
     pub mod CG10 {
         pub const offset: u32 = 20;
         pub const mask: u32 = 0x03 << offset;
@@ -3288,7 +3280,7 @@ pub mod CCGR4 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "pwm4 clocks (pwm4_clk_enable)"]
     pub mod CG11 {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x03 << offset;
@@ -3296,7 +3288,7 @@ pub mod CCGR4 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "enc1 clocks (enc1_clk_enable)"]
     pub mod CG12 {
         pub const offset: u32 = 24;
         pub const mask: u32 = 0x03 << offset;
@@ -3304,7 +3296,7 @@ pub mod CCGR4 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "enc2 clocks (enc2_clk_enable)"]
     pub mod CG13 {
         pub const offset: u32 = 26;
         pub const mask: u32 = 0x03 << offset;
@@ -3312,7 +3304,7 @@ pub mod CCGR4 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "enc3 clocks (enc3_clk_enable)"]
     pub mod CG14 {
         pub const offset: u32 = 28;
         pub const mask: u32 = 0x03 << offset;
@@ -3320,7 +3312,7 @@ pub mod CCGR4 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "dma_ps clocks (dma_ps_clk_enable)"]
+    #[doc = "enc4 clocks (enc4_clk_enable)"]
     pub mod CG15 {
         pub const offset: u32 = 30;
         pub const mask: u32 = 0x03 << offset;
@@ -3379,7 +3371,7 @@ pub mod CCGR5 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "aipstz4 clocks (aips_tz4_clk_enable)"]
     pub mod CG6 {
         pub const offset: u32 = 12;
         pub const mask: u32 = 0x03 << offset;
@@ -3395,7 +3387,7 @@ pub mod CCGR5 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "sim_main clock (sim_main_clk_enable)"]
     pub mod CG8 {
         pub const offset: u32 = 16;
         pub const mask: u32 = 0x03 << offset;
@@ -3411,7 +3403,7 @@ pub mod CCGR5 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "sai2 clock (sai2_clk_enable)"]
     pub mod CG10 {
         pub const offset: u32 = 20;
         pub const mask: u32 = 0x03 << offset;
@@ -3435,7 +3427,7 @@ pub mod CCGR5 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "lpuart7 clock (lpuart7_clk_enable)"]
     pub mod CG13 {
         pub const offset: u32 = 26;
         pub const mask: u32 = 0x03 << offset;
@@ -3470,7 +3462,7 @@ pub mod CCGR6 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "usdhc1 clocks (usdhc1_clk_enable)"]
     pub mod CG1 {
         pub const offset: u32 = 2;
         pub const mask: u32 = 0x03 << offset;
@@ -3478,7 +3470,7 @@ pub mod CCGR6 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "usdhc2 clocks (usdhc2_clk_enable)"]
     pub mod CG2 {
         pub const offset: u32 = 4;
         pub const mask: u32 = 0x03 << offset;
@@ -3494,7 +3486,7 @@ pub mod CCGR6 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "ipmux4 clock (ipmux4_clk_enable)"]
     pub mod CG4 {
         pub const offset: u32 = 8;
         pub const mask: u32 = 0x03 << offset;
@@ -3518,7 +3510,7 @@ pub mod CCGR6 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "lpuart8 clocks (lpuart8_clk_enable)"]
     pub mod CG7 {
         pub const offset: u32 = 14;
         pub const mask: u32 = 0x03 << offset;
@@ -3526,7 +3518,7 @@ pub mod CCGR6 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "timer4 clocks (timer4_clk_enable)"]
     pub mod CG8 {
         pub const offset: u32 = 16;
         pub const mask: u32 = 0x03 << offset;
@@ -3534,7 +3526,7 @@ pub mod CCGR6 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "aips_tz3 clock (aips_tz3_clk_enable)"]
     pub mod CG9 {
         pub const offset: u32 = 18;
         pub const mask: u32 = 0x03 << offset;
@@ -3558,7 +3550,7 @@ pub mod CCGR6 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "lpi2c4 serial clock (lpi2c4_serial_clk_enable)"]
     pub mod CG12 {
         pub const offset: u32 = 24;
         pub const mask: u32 = 0x03 << offset;
@@ -3566,7 +3558,7 @@ pub mod CCGR6 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "timer1 clocks (timer1_clk_enable)"]
     pub mod CG13 {
         pub const offset: u32 = 26;
         pub const mask: u32 = 0x03 << offset;
@@ -3574,7 +3566,7 @@ pub mod CCGR6 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "timer2 clocks (timer2_clk_enable)"]
     pub mod CG14 {
         pub const offset: u32 = 28;
         pub const mask: u32 = 0x03 << offset;
@@ -3582,7 +3574,7 @@ pub mod CCGR6 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "timer3 clocks (timer3_clk_enable)"]
     pub mod CG15 {
         pub const offset: u32 = 30;
         pub const mask: u32 = 0x03 << offset;

--- a/src/blocks/imxrt1051/ccm_analog.rs
+++ b/src/blocks/imxrt1051/ccm_analog.rs
@@ -167,14 +167,6 @@ pub mod PLL_ARM {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod PLL_SEL {
-        pub const offset: u32 = 19;
-        pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "1 - PLL is currently locked. 0 - PLL is not currently locked."]
     pub mod LOCK {
         pub const offset: u32 = 31;
@@ -226,14 +218,6 @@ pub mod PLL_ARM_SET {
     #[doc = "Bypass the PLL."]
     pub mod BYPASS {
         pub const offset: u32 = 16;
-        pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod PLL_SEL {
-        pub const offset: u32 = 19;
         pub const mask: u32 = 0x01 << offset;
         pub mod R {}
         pub mod W {}
@@ -295,14 +279,6 @@ pub mod PLL_ARM_CLR {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod PLL_SEL {
-        pub const offset: u32 = 19;
-        pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "1 - PLL is currently locked. 0 - PLL is not currently locked."]
     pub mod LOCK {
         pub const offset: u32 = 31;
@@ -354,14 +330,6 @@ pub mod PLL_ARM_TOG {
     #[doc = "Bypass the PLL."]
     pub mod BYPASS {
         pub const offset: u32 = 16;
-        pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod PLL_SEL {
-        pub const offset: u32 = 19;
         pub const mask: u32 = 0x01 << offset;
         pub mod R {}
         pub mod W {}

--- a/src/blocks/imxrt1051/dcdc.rs
+++ b/src/blocks/imxrt1051/dcdc.rs
@@ -325,14 +325,6 @@ pub mod REG3 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod MISC_DISABLEFET_LOGIC {
-        pub const offset: u32 = 28;
-        pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Disable stepping for the output VDD_SOC of DCDC"]
     pub mod DISABLE_STEP {
         pub const offset: u32 = 30;

--- a/src/blocks/imxrt1051/iomuxc.rs
+++ b/src/blocks/imxrt1051/iomuxc.rs
@@ -966,15 +966,15 @@ pub mod SW_MUX_CTL_PAD_GPIO_EMC_04 {
         pub mod RW {
             #[doc = "Select mux mode: ALT0 mux port: SEMC_DATA04 of instance: semc"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: XBAR1_INOUT04 of instance: xbar1"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXPWM4_PWMA02 of instance: flexpwm4"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: SPDIF_OUT of instance: spdif"]
+            #[doc = "Select mux mode: ALT2 mux port: SAI2_TX_DATA of instance: sai2"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI2_TX_BCLK of instance: sai2"]
+            #[doc = "Select mux mode: ALT3 mux port: XBAR1_INOUT06 of instance: xbar1"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO16 of instance: flexio1"]
+            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO04 of instance: flexio1"]
             pub const ALT4: u32 = 0x04;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO2_IO04 of instance: gpio2"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO4_IO04 of instance: gpio4"]
             pub const ALT5: u32 = 0x05;
         }
     }
@@ -1003,15 +1003,15 @@ pub mod SW_MUX_CTL_PAD_GPIO_EMC_05 {
         pub mod RW {
             #[doc = "Select mux mode: ALT0 mux port: SEMC_DATA05 of instance: semc"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: XBAR1_INOUT05 of instance: xbar1"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXPWM4_PWMB02 of instance: flexpwm4"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: SPDIF_IN of instance: spdif"]
+            #[doc = "Select mux mode: ALT2 mux port: SAI2_TX_SYNC of instance: sai2"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI2_TX_SYNC of instance: sai2"]
+            #[doc = "Select mux mode: ALT3 mux port: XBAR1_INOUT07 of instance: xbar1"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO17 of instance: flexio1"]
+            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO05 of instance: flexio1"]
             pub const ALT4: u32 = 0x04;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO2_IO05 of instance: gpio2"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO4_IO05 of instance: gpio4"]
             pub const ALT5: u32 = 0x05;
         }
     }
@@ -1040,15 +1040,15 @@ pub mod SW_MUX_CTL_PAD_GPIO_EMC_06 {
         pub mod RW {
             #[doc = "Select mux mode: ALT0 mux port: SEMC_DATA06 of instance: semc"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: XBAR1_INOUT06 of instance: xbar1"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXPWM2_PWMA00 of instance: flexpwm2"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: LPUART3_TX of instance: lpuart3"]
+            #[doc = "Select mux mode: ALT2 mux port: SAI2_TX_BCLK of instance: sai2"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI2_TX_DATA of instance: sai2"]
+            #[doc = "Select mux mode: ALT3 mux port: XBAR1_INOUT08 of instance: xbar1"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO18 of instance: flexio1"]
+            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO06 of instance: flexio1"]
             pub const ALT4: u32 = 0x04;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO2_IO06 of instance: gpio2"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO4_IO06 of instance: gpio4"]
             pub const ALT5: u32 = 0x05;
         }
     }
@@ -1077,15 +1077,15 @@ pub mod SW_MUX_CTL_PAD_GPIO_EMC_07 {
         pub mod RW {
             #[doc = "Select mux mode: ALT0 mux port: SEMC_DATA07 of instance: semc"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: XBAR1_INOUT07 of instance: xbar1"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXPWM2_PWMB00 of instance: flexpwm2"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: LPUART3_RX of instance: lpuart3"]
+            #[doc = "Select mux mode: ALT2 mux port: SAI2_MCLK of instance: sai2"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI2_RX_SYNC of instance: sai2"]
+            #[doc = "Select mux mode: ALT3 mux port: XBAR1_INOUT09 of instance: xbar1"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO19 of instance: flexio1"]
+            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO07 of instance: flexio1"]
             pub const ALT4: u32 = 0x04;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO2_IO07 of instance: gpio2"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO4_IO07 of instance: gpio4"]
             pub const ALT5: u32 = 0x05;
         }
     }
@@ -1114,15 +1114,15 @@ pub mod SW_MUX_CTL_PAD_GPIO_EMC_08 {
         pub mod RW {
             #[doc = "Select mux mode: ALT0 mux port: SEMC_DM00 of instance: semc"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: XBAR1_INOUT08 of instance: xbar1"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXPWM2_PWMA01 of instance: flexpwm2"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: FLEXCAN2_TX of instance: flexcan2"]
+            #[doc = "Select mux mode: ALT2 mux port: SAI2_RX_DATA of instance: sai2"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI2_RX_DATA of instance: sai2"]
+            #[doc = "Select mux mode: ALT3 mux port: XBAR1_INOUT17 of instance: xbar1"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO20 of instance: flexio1"]
+            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO08 of instance: flexio1"]
             pub const ALT4: u32 = 0x04;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO2_IO08 of instance: gpio2"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO4_IO08 of instance: gpio4"]
             pub const ALT5: u32 = 0x05;
         }
     }
@@ -1149,17 +1149,17 @@ pub mod SW_MUX_CTL_PAD_GPIO_EMC_09 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: SEMC_WE of instance: semc"]
+            #[doc = "Select mux mode: ALT0 mux port: SEMC_ADDR00 of instance: semc"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: XBAR1_INOUT09 of instance: xbar1"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXPWM2_PWMB01 of instance: flexpwm2"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: FLEXCAN2_RX of instance: flexcan2"]
+            #[doc = "Select mux mode: ALT2 mux port: SAI2_RX_SYNC of instance: sai2"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI2_RX_BCLK of instance: sai2"]
+            #[doc = "Select mux mode: ALT3 mux port: FLEXCAN2_TX of instance: flexcan2"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO21 of instance: flexio1"]
+            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO09 of instance: flexio1"]
             pub const ALT4: u32 = 0x04;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO2_IO09 of instance: gpio2"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO4_IO09 of instance: gpio4"]
             pub const ALT5: u32 = 0x05;
         }
     }
@@ -1482,19 +1482,19 @@ pub mod SW_MUX_CTL_PAD_GPIO_EMC_18 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: SEMC_ADDR02 of instance: semc"]
+            #[doc = "Select mux mode: ALT0 mux port: SEMC_ADDR09 of instance: semc"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: XBAR1_INOUT16 of instance: xbar1"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXPWM4_PWMB03 of instance: flexpwm4"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: LPI2C2_SDA of instance: lpi2c2"]
+            #[doc = "Select mux mode: ALT2 mux port: LPUART4_RTS_B of instance: lpuart4"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI1_RX_SYNC of instance: sai1"]
+            #[doc = "Select mux mode: ALT3 mux port: FLEXCAN1_RX of instance: flexcan1"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO22 of instance: flexio1"]
+            #[doc = "Select mux mode: ALT4 mux port: QTIMER3_TIMER3 of instance: qtimer3"]
             pub const ALT4: u32 = 0x04;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO2_IO18 of instance: gpio2"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO4_IO18 of instance: gpio4"]
             pub const ALT5: u32 = 0x05;
-            #[doc = "Select mux mode: ALT6 mux port: SRC_BT_CFG00 of instance: src"]
+            #[doc = "Select mux mode: ALT6 mux port: SNVS_VIO_5_CTL of instance: snvs_hp"]
             pub const ALT6: u32 = 0x06;
         }
     }
@@ -1521,19 +1521,19 @@ pub mod SW_MUX_CTL_PAD_GPIO_EMC_19 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: SEMC_ADDR03 of instance: semc"]
+            #[doc = "Select mux mode: ALT0 mux port: SEMC_ADDR11 of instance: semc"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: XBAR1_INOUT17 of instance: xbar1"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXPWM2_PWMA03 of instance: flexpwm2"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: LPI2C2_SCL of instance: lpi2c2"]
+            #[doc = "Select mux mode: ALT2 mux port: LPUART4_TX of instance: lpuart4"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI1_RX_BCLK of instance: sai1"]
+            #[doc = "Select mux mode: ALT3 mux port: ENET_RDATA01 of instance: enet"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO23 of instance: flexio1"]
+            #[doc = "Select mux mode: ALT4 mux port: QTIMER2_TIMER0 of instance: qtimer2"]
             pub const ALT4: u32 = 0x04;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO2_IO19 of instance: gpio2"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO4_IO19 of instance: gpio4"]
             pub const ALT5: u32 = 0x05;
-            #[doc = "Select mux mode: ALT6 mux port: SRC_BT_CFG01 of instance: src"]
+            #[doc = "Select mux mode: ALT6 mux port: SNVS_VIO_5 of instance: snvs_hp"]
             pub const ALT6: u32 = 0x06;
         }
     }
@@ -2041,17 +2041,17 @@ pub mod SW_MUX_CTL_PAD_GPIO_EMC_33 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: SEMC_DATA09 of instance: semc"]
+            #[doc = "Select mux mode: ALT0 mux port: SEMC_DATA11 of instance: semc"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: QTIMER1_TIMER1 of instance: qtimer1"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXPWM3_PWMA02 of instance: flexpwm3"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: LPUART4_RX of instance: lpuart4"]
+            #[doc = "Select mux mode: ALT2 mux port: USDHC1_RESET_B of instance: usdhc1"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI3_TX_BCLK of instance: sai3"]
+            #[doc = "Select mux mode: ALT3 mux port: SAI3_RX_DATA of instance: sai3"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: LPSPI4_PCS0 of instance: lpspi4"]
+            #[doc = "Select mux mode: ALT4 mux port: CSI_DATA20 of instance: csi"]
             pub const ALT4: u32 = 0x04;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO3_IO01 of instance: gpio3"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO3_IO19 of instance: gpio3"]
             pub const ALT5: u32 = 0x05;
         }
     }
@@ -2115,19 +2115,19 @@ pub mod SW_MUX_CTL_PAD_GPIO_EMC_35 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: SEMC_DATA11 of instance: semc"]
+            #[doc = "Select mux mode: ALT0 mux port: SEMC_DATA13 of instance: semc"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: QTIMER1_TIMER3 of instance: qtimer1"]
+            #[doc = "Select mux mode: ALT1 mux port: XBAR1_INOUT18 of instance: xbar1"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: LPUART7_RX of instance: lpuart7"]
+            #[doc = "Select mux mode: ALT2 mux port: GPT1_COMPARE1 of instance: gpt1"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: USDHC2_WP of instance: usdhc2"]
+            #[doc = "Select mux mode: ALT3 mux port: SAI3_RX_BCLK of instance: sai3"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: LPSPI4_SDI of instance: lpspi4"]
+            #[doc = "Select mux mode: ALT4 mux port: CSI_DATA18 of instance: csi"]
             pub const ALT4: u32 = 0x04;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO3_IO03 of instance: gpio3"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO3_IO21 of instance: gpio3"]
             pub const ALT5: u32 = 0x05;
-            #[doc = "Select mux mode: ALT6 mux port: ENET_COL of instance: enet"]
+            #[doc = "Select mux mode: ALT6 mux port: USDHC1_CD_B of instance: usdhc1"]
             pub const ALT6: u32 = 0x06;
         }
     }
@@ -2511,21 +2511,21 @@ pub mod SW_MUX_CTL_PAD_GPIO_AD_B0_03 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: JTAG_TDI of instance: jtag_mux"]
+            #[doc = "Select mux mode: ALT0 mux port: FLEXCAN2_RX of instance: flexcan2"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: USDHC2_CD_B of instance: usdhc2"]
+            #[doc = "Select mux mode: ALT1 mux port: XBAR1_INOUT17 of instance: xbar1"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: WDOG1_B of instance: wdog1"]
+            #[doc = "Select mux mode: ALT2 mux port: LPUART6_RX of instance: lpuart6"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI1_MCLK of instance: sai1"]
+            #[doc = "Select mux mode: ALT3 mux port: USB_OTG1_OC of instance: usb"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: USDHC1_WP of instance: usdhc1"]
+            #[doc = "Select mux mode: ALT4 mux port: FLEXPWM1_PWMX01 of instance: flexpwm1"]
             pub const ALT4: u32 = 0x04;
             #[doc = "Select mux mode: ALT5 mux port: GPIO1_IO03 of instance: gpio1"]
             pub const ALT5: u32 = 0x05;
-            #[doc = "Select mux mode: ALT6 mux port: USB_OTG1_OC of instance: usb"]
+            #[doc = "Select mux mode: ALT6 mux port: REF_CLK_24M of instance: anatop"]
             pub const ALT6: u32 = 0x06;
-            #[doc = "Select mux mode: ALT7 mux port: CCM_PMIC_RDY of instance: ccm"]
+            #[doc = "Select mux mode: ALT7 mux port: LPSPI3_PCS0 of instance: lpspi3"]
             pub const ALT7: u32 = 0x07;
         }
     }
@@ -2552,21 +2552,21 @@ pub mod SW_MUX_CTL_PAD_GPIO_AD_B0_04 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: JTAG_TDO of instance: jtag_mux"]
+            #[doc = "Select mux mode: ALT0 mux port: SRC_BOOT_MODE00 of instance: src"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: FLEXCAN1_TX of instance: flexcan1"]
+            #[doc = "Select mux mode: ALT1 mux port: MQS_RIGHT of instance: mqs"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: USDHC1_WP of instance: usdhc1"]
+            #[doc = "Select mux mode: ALT2 mux port: ENET_TX_DATA03 of instance: enet"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: QTIMER2_TIMER0 of instance: qtimer2"]
+            #[doc = "Select mux mode: ALT3 mux port: SAI2_TX_SYNC of instance: sai2"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: ENET_MDIO of instance: enet"]
+            #[doc = "Select mux mode: ALT4 mux port: CSI_DATA09 of instance: csi"]
             pub const ALT4: u32 = 0x04;
             #[doc = "Select mux mode: ALT5 mux port: GPIO1_IO04 of instance: gpio1"]
             pub const ALT5: u32 = 0x05;
-            #[doc = "Select mux mode: ALT6 mux port: USB_OTG1_PWR of instance: usb"]
+            #[doc = "Select mux mode: ALT6 mux port: PIT_TRIGGER00 of instance: pit"]
             pub const ALT6: u32 = 0x06;
-            #[doc = "Select mux mode: ALT7 mux port: EWM_OUT_B of instance: ewm"]
+            #[doc = "Select mux mode: ALT7 mux port: LPSPI3_PCS1 of instance: lpspi3"]
             pub const ALT7: u32 = 0x07;
         }
     }
@@ -2593,21 +2593,21 @@ pub mod SW_MUX_CTL_PAD_GPIO_AD_B0_05 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: JTAG_TRSTB of instance: jtag_mux"]
+            #[doc = "Select mux mode: ALT0 mux port: SRC_BOOT_MODE01 of instance: src"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: FLEXCAN1_RX of instance: flexcan1"]
+            #[doc = "Select mux mode: ALT1 mux port: MQS_LEFT of instance: mqs"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: USDHC1_CD_B of instance: usdhc1"]
+            #[doc = "Select mux mode: ALT2 mux port: ENET_TX_DATA02 of instance: enet"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: QTIMER2_TIMER1 of instance: qtimer2"]
+            #[doc = "Select mux mode: ALT3 mux port: SAI2_TX_BCLK of instance: sai2"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: ENET_MDC of instance: enet"]
+            #[doc = "Select mux mode: ALT4 mux port: CSI_DATA08 of instance: csi"]
             pub const ALT4: u32 = 0x04;
             #[doc = "Select mux mode: ALT5 mux port: GPIO1_IO05 of instance: gpio1"]
             pub const ALT5: u32 = 0x05;
-            #[doc = "Select mux mode: ALT6 mux port: USB_OTG1_ID of instance: anatop"]
+            #[doc = "Select mux mode: ALT6 mux port: XBAR1_INOUT17 of instance: xbar1"]
             pub const ALT6: u32 = 0x06;
-            #[doc = "Select mux mode: ALT7 mux port: NMI_GLUE_NMI of instance: nmi_glue"]
+            #[doc = "Select mux mode: ALT7 mux port: LPSPI3_PCS2 of instance: lpspi3"]
             pub const ALT7: u32 = 0x07;
         }
     }
@@ -2880,21 +2880,21 @@ pub mod SW_MUX_CTL_PAD_GPIO_AD_B0_12 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: ENET_RX_ER of instance: enet"]
+            #[doc = "Select mux mode: ALT0 mux port: LPI2C4_SCL of instance: lpi2c4"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: LPSPI1_SDO of instance: lpspi1"]
+            #[doc = "Select mux mode: ALT1 mux port: CCM_PMIC_READY of instance: ccm"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: LPUART3_CTS_B of instance: lpuart3"]
+            #[doc = "Select mux mode: ALT2 mux port: LPUART1_TX of instance: lpuart1"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: KPP_COL02 of instance: kpp"]
+            #[doc = "Select mux mode: ALT3 mux port: WDOG2_WDOG_B of instance: wdog2"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: FLEXPWM2_PWMA01 of instance: flexpwm2"]
+            #[doc = "Select mux mode: ALT4 mux port: FLEXPWM1_PWMX02 of instance: flexpwm1"]
             pub const ALT4: u32 = 0x04;
             #[doc = "Select mux mode: ALT5 mux port: GPIO1_IO12 of instance: gpio1"]
             pub const ALT5: u32 = 0x05;
-            #[doc = "Select mux mode: ALT6 mux port: ARM_CM7_TRACE00 of instance: cm7_mxrt"]
+            #[doc = "Select mux mode: ALT6 mux port: ENET_1588_EVENT1_OUT of instance: enet"]
             pub const ALT6: u32 = 0x06;
-            #[doc = "Select mux mode: ALT7 mux port: SNVS_HP_VIO_5_CTL of instance: snvs_hp"]
+            #[doc = "Select mux mode: ALT7 mux port: NMI_GLUE_NMI of instance: nmi_glue"]
             pub const ALT7: u32 = 0x07;
         }
     }
@@ -2921,21 +2921,21 @@ pub mod SW_MUX_CTL_PAD_GPIO_AD_B0_13 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: ENET_TX_EN of instance: enet"]
+            #[doc = "Select mux mode: ALT0 mux port: LPI2C4_SDA of instance: lpi2c4"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: LPSPI1_SDI of instance: lpspi1"]
+            #[doc = "Select mux mode: ALT1 mux port: GPT1_CLK of instance: gpt1"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: LPUART3_RTS_B of instance: lpuart3"]
+            #[doc = "Select mux mode: ALT2 mux port: LPUART1_RX of instance: lpuart1"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: KPP_ROW02 of instance: kpp"]
+            #[doc = "Select mux mode: ALT3 mux port: EWM_OUT_B of instance: ewm"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: FLEXPWM2_PWMB01 of instance: flexpwm2"]
+            #[doc = "Select mux mode: ALT4 mux port: FLEXPWM1_PWMX03 of instance: flexpwm1"]
             pub const ALT4: u32 = 0x04;
             #[doc = "Select mux mode: ALT5 mux port: GPIO1_IO13 of instance: gpio1"]
             pub const ALT5: u32 = 0x05;
-            #[doc = "Select mux mode: ALT6 mux port: ARM_CM7_TRACE01 of instance: cm7_mxrt"]
+            #[doc = "Select mux mode: ALT6 mux port: ENET_1588_EVENT1_IN of instance: enet"]
             pub const ALT6: u32 = 0x06;
-            #[doc = "Select mux mode: ALT7 mux port: SNVS_HP_VIO_5_B of instance: snvs_hp"]
+            #[doc = "Select mux mode: ALT7 mux port: REF_CLK_24M of instance: anatop"]
             pub const ALT7: u32 = 0x07;
         }
     }
@@ -3042,21 +3042,21 @@ pub mod SW_MUX_CTL_PAD_GPIO_AD_B1_00 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: SEMC_READY of instance: semc"]
+            #[doc = "Select mux mode: ALT0 mux port: USB_OTG2_ID of instance: anatop"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: FLEXSPI_A_DATA03 of instance: flexspi_bus2bit"]
+            #[doc = "Select mux mode: ALT1 mux port: QTIMER3_TIMER0 of instance: qtimer3"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: FLEXCAN2_TX of instance: flexcan2"]
+            #[doc = "Select mux mode: ALT2 mux port: LPUART2_CTS_B of instance: lpuart2"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI1_MCLK of instance: sai1"]
+            #[doc = "Select mux mode: ALT3 mux port: LPI2C1_SCL of instance: lpi2c1"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO15 of instance: flexio1"]
+            #[doc = "Select mux mode: ALT4 mux port: WDOG1_B of instance: wdog1"]
             pub const ALT4: u32 = 0x04;
             #[doc = "Select mux mode: ALT5 mux port: GPIO1_IO16 of instance: gpio1"]
             pub const ALT5: u32 = 0x05;
-            #[doc = "Select mux mode: ALT6 mux port: ENET_1588_EVENT2_OUT of instance: enet"]
+            #[doc = "Select mux mode: ALT6 mux port: USDHC1_WP of instance: usdhc1"]
             pub const ALT6: u32 = 0x06;
-            #[doc = "Select mux mode: ALT7 mux port: KPP_COL04 of instance: kpp"]
+            #[doc = "Select mux mode: ALT7 mux port: KPP_ROW07 of instance: kpp"]
             pub const ALT7: u32 = 0x07;
         }
     }
@@ -3083,21 +3083,21 @@ pub mod SW_MUX_CTL_PAD_GPIO_AD_B1_01 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: SEMC_CSX00 of instance: semc"]
+            #[doc = "Select mux mode: ALT0 mux port: USB_OTG1_PWR of instance: usb"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: FLEXSPI_A_SCLK of instance: flexspi_bus2bit"]
+            #[doc = "Select mux mode: ALT1 mux port: QTIMER3_TIMER1 of instance: qtimer3"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: FLEXCAN2_RX of instance: flexcan2"]
+            #[doc = "Select mux mode: ALT2 mux port: LPUART2_RTS_B of instance: lpuart2"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI1_TX_BCLK of instance: sai1"]
+            #[doc = "Select mux mode: ALT3 mux port: LPI2C1_SDA of instance: lpi2c1"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO14 of instance: flexio1"]
+            #[doc = "Select mux mode: ALT4 mux port: CCM_PMIC_READY of instance: ccm"]
             pub const ALT4: u32 = 0x04;
             #[doc = "Select mux mode: ALT5 mux port: GPIO1_IO17 of instance: gpio1"]
             pub const ALT5: u32 = 0x05;
-            #[doc = "Select mux mode: ALT6 mux port: ENET_1588_EVENT2_IN of instance: enet"]
+            #[doc = "Select mux mode: ALT6 mux port: USDHC1_VSELECT of instance: usdhc1"]
             pub const ALT6: u32 = 0x06;
-            #[doc = "Select mux mode: ALT7 mux port: KPP_ROW04 of instance: kpp"]
+            #[doc = "Select mux mode: ALT7 mux port: KPP_COL07 of instance: kpp"]
             pub const ALT7: u32 = 0x07;
         }
     }
@@ -3124,21 +3124,21 @@ pub mod SW_MUX_CTL_PAD_GPIO_AD_B1_02 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: SEMC_CSX01 of instance: semc"]
+            #[doc = "Select mux mode: ALT0 mux port: USB_OTG1_ID of instance: anatop"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: FLEXSPI_A_DATA00 of instance: flexspi_bus2bit"]
+            #[doc = "Select mux mode: ALT1 mux port: QTIMER3_TIMER2 of instance: qtimer3"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: LPSPI4_SCK of instance: lpspi4"]
+            #[doc = "Select mux mode: ALT2 mux port: LPUART2_TX of instance: lpuart2"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI1_TX_SYNC of instance: sai1"]
+            #[doc = "Select mux mode: ALT3 mux port: SPDIF_OUT of instance: spdif"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO13 of instance: flexio1"]
+            #[doc = "Select mux mode: ALT4 mux port: ENET_1588_EVENT2_OUT of instance: enet"]
             pub const ALT4: u32 = 0x04;
             #[doc = "Select mux mode: ALT5 mux port: GPIO1_IO18 of instance: gpio1"]
             pub const ALT5: u32 = 0x05;
-            #[doc = "Select mux mode: ALT6 mux port: ENET_1588_EVENT3_OUT of instance: enet"]
+            #[doc = "Select mux mode: ALT6 mux port: USDHC1_CD_B of instance: usdhc1"]
             pub const ALT6: u32 = 0x06;
-            #[doc = "Select mux mode: ALT7 mux port: KPP_COL05 of instance: kpp"]
+            #[doc = "Select mux mode: ALT7 mux port: KPP_ROW06 of instance: kpp"]
             pub const ALT7: u32 = 0x07;
         }
     }
@@ -3165,21 +3165,21 @@ pub mod SW_MUX_CTL_PAD_GPIO_AD_B1_03 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: SEMC_CSX02 of instance: semc"]
+            #[doc = "Select mux mode: ALT0 mux port: USB_OTG1_OC of instance: usb"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: FLEXSPI_A_DATA02 of instance: flexspi_bus2bit"]
+            #[doc = "Select mux mode: ALT1 mux port: QTIMER3_TIMER3 of instance: qtimer3"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: LPSPI4_PCS0 of instance: lpspi4"]
+            #[doc = "Select mux mode: ALT2 mux port: LPUART2_RX of instance: lpuart2"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI1_TX_DATA00 of instance: sai1"]
+            #[doc = "Select mux mode: ALT3 mux port: SPDIF_IN of instance: spdif"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO12 of instance: flexio1"]
+            #[doc = "Select mux mode: ALT4 mux port: ENET_1588_EVENT2_IN of instance: enet"]
             pub const ALT4: u32 = 0x04;
             #[doc = "Select mux mode: ALT5 mux port: GPIO1_IO19 of instance: gpio1"]
             pub const ALT5: u32 = 0x05;
-            #[doc = "Select mux mode: ALT6 mux port: ENET_1588_EVENT3_IN of instance: enet"]
+            #[doc = "Select mux mode: ALT6 mux port: USDHC2_CD_B of instance: usdhc2"]
             pub const ALT6: u32 = 0x06;
-            #[doc = "Select mux mode: ALT7 mux port: KPP_ROW05 of instance: kpp"]
+            #[doc = "Select mux mode: ALT7 mux port: KPP_COL06 of instance: kpp"]
             pub const ALT7: u32 = 0x07;
         }
     }
@@ -3206,21 +3206,21 @@ pub mod SW_MUX_CTL_PAD_GPIO_AD_B1_04 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: SEMC_CSX03 of instance: semc"]
+            #[doc = "Select mux mode: ALT0 mux port: FLEXSPIB_DATA03 of instance: flexspi"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: FLEXSPI_A_DATA01 of instance: flexspi_bus2bit"]
+            #[doc = "Select mux mode: ALT1 mux port: ENET_MDC of instance: enet"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: LPSPI4_SDO of instance: lpspi4"]
+            #[doc = "Select mux mode: ALT2 mux port: LPUART3_CTS_B of instance: lpuart3"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI1_RX_SYNC of instance: sai1"]
+            #[doc = "Select mux mode: ALT3 mux port: SPDIF_SR_CLK of instance: spdif"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO11 of instance: flexio1"]
+            #[doc = "Select mux mode: ALT4 mux port: CSI_PIXCLK of instance: csi"]
             pub const ALT4: u32 = 0x04;
             #[doc = "Select mux mode: ALT5 mux port: GPIO1_IO20 of instance: gpio1"]
             pub const ALT5: u32 = 0x05;
-            #[doc = "Select mux mode: ALT6 mux port: LPSPI1_PCS1 of instance: lpspi1"]
+            #[doc = "Select mux mode: ALT6 mux port: USDHC2_DATA0 of instance: usdhc2"]
             pub const ALT6: u32 = 0x06;
-            #[doc = "Select mux mode: ALT7 mux port: KPP_COL06 of instance: kpp"]
+            #[doc = "Select mux mode: ALT7 mux port: KPP_ROW05 of instance: kpp"]
             pub const ALT7: u32 = 0x07;
         }
     }
@@ -3247,21 +3247,21 @@ pub mod SW_MUX_CTL_PAD_GPIO_AD_B1_05 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: USDHC1_WP of instance: usdhc1"]
+            #[doc = "Select mux mode: ALT0 mux port: FLEXSPIB_DATA02 of instance: flexspi"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: FLEXSPI_A_SS0_B of instance: flexspi_bus2bit"]
+            #[doc = "Select mux mode: ALT1 mux port: ENET_MDIO of instance: enet"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: LPSPI4_SDI of instance: lpspi4"]
+            #[doc = "Select mux mode: ALT2 mux port: LPUART3_RTS_B of instance: lpuart3"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI1_RX_DATA00 of instance: sai1"]
+            #[doc = "Select mux mode: ALT3 mux port: SPDIF_OUT of instance: spdif"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO10 of instance: flexio1"]
+            #[doc = "Select mux mode: ALT4 mux port: CSI_MCLK of instance: csi"]
             pub const ALT4: u32 = 0x04;
             #[doc = "Select mux mode: ALT5 mux port: GPIO1_IO21 of instance: gpio1"]
             pub const ALT5: u32 = 0x05;
-            #[doc = "Select mux mode: ALT6 mux port: LPSPI1_PCS2 of instance: lpspi1"]
+            #[doc = "Select mux mode: ALT6 mux port: USDHC2_DATA1 of instance: usdhc2"]
             pub const ALT6: u32 = 0x06;
-            #[doc = "Select mux mode: ALT7 mux port: KPP_ROW06 of instance: kpp"]
+            #[doc = "Select mux mode: ALT7 mux port: KPP_COL05 of instance: kpp"]
             pub const ALT7: u32 = 0x07;
         }
     }
@@ -3288,21 +3288,21 @@ pub mod SW_MUX_CTL_PAD_GPIO_AD_B1_06 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: USDHC1_RESET_B of instance: usdhc1"]
+            #[doc = "Select mux mode: ALT0 mux port: FLEXSPIB_DATA01 of instance: flexspi"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: FLEXPWM1_PWMA00 of instance: flexpwm1"]
+            #[doc = "Select mux mode: ALT1 mux port: LPI2C3_SDA of instance: lpi2c3"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: LPUART2_CTS_B of instance: lpuart2"]
+            #[doc = "Select mux mode: ALT2 mux port: LPUART3_TX of instance: lpuart3"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI1_RX_BCLK of instance: sai1"]
+            #[doc = "Select mux mode: ALT3 mux port: SPDIF_LOCK of instance: spdif"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO09 of instance: flexio1"]
+            #[doc = "Select mux mode: ALT4 mux port: CSI_VSYNC of instance: csi"]
             pub const ALT4: u32 = 0x04;
             #[doc = "Select mux mode: ALT5 mux port: GPIO1_IO22 of instance: gpio1"]
             pub const ALT5: u32 = 0x05;
-            #[doc = "Select mux mode: ALT6 mux port: LPSPI1_PCS3 of instance: lpspi1"]
+            #[doc = "Select mux mode: ALT6 mux port: USDHC2_DATA2 of instance: usdhc2"]
             pub const ALT6: u32 = 0x06;
-            #[doc = "Select mux mode: ALT7 mux port: KPP_COL07 of instance: kpp"]
+            #[doc = "Select mux mode: ALT7 mux port: KPP_ROW04 of instance: kpp"]
             pub const ALT7: u32 = 0x07;
         }
     }
@@ -3329,21 +3329,21 @@ pub mod SW_MUX_CTL_PAD_GPIO_AD_B1_07 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: USDHC1_VSELECT of instance: usdhc1"]
+            #[doc = "Select mux mode: ALT0 mux port: FLEXSPIB_DATA00 of instance: flexspi"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: FLEXPWM1_PWMB00 of instance: flexpwm1"]
+            #[doc = "Select mux mode: ALT1 mux port: LPI2C3_SCL of instance: lpi2c3"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: LPUART2_RTS_B of instance: lpuart2"]
+            #[doc = "Select mux mode: ALT2 mux port: LPUART3_RX of instance: lpuart3"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI1_TX_DATA01 of instance: sai1"]
+            #[doc = "Select mux mode: ALT3 mux port: SPDIF_EXT_CLK of instance: spdif"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO08 of instance: flexio1"]
+            #[doc = "Select mux mode: ALT4 mux port: CSI_HSYNC of instance: csi"]
             pub const ALT4: u32 = 0x04;
             #[doc = "Select mux mode: ALT5 mux port: GPIO1_IO23 of instance: gpio1"]
             pub const ALT5: u32 = 0x05;
-            #[doc = "Select mux mode: ALT6 mux port: LPSPI3_PCS3 of instance: lpspi3"]
+            #[doc = "Select mux mode: ALT6 mux port: USDHC2_DATA3 of instance: usdhc2"]
             pub const ALT6: u32 = 0x06;
-            #[doc = "Select mux mode: ALT7 mux port: KPP_ROW07 of instance: kpp"]
+            #[doc = "Select mux mode: ALT7 mux port: KPP_COL04 of instance: kpp"]
             pub const ALT7: u32 = 0x07;
         }
     }
@@ -3370,21 +3370,21 @@ pub mod SW_MUX_CTL_PAD_GPIO_AD_B1_08 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: LPI2C2_SCL of instance: lpi2c2"]
+            #[doc = "Select mux mode: ALT0 mux port: FLEXSPIA_SS1_B of instance: flexspi"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: FLEXPWM1_PWMA01 of instance: flexpwm1"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXPWM4_PWMA00 of instance: flexpwm4"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: LPUART2_TX of instance: lpuart2"]
+            #[doc = "Select mux mode: ALT2 mux port: FLEXCAN1_TX of instance: flexcan1"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI1_TX_DATA02 of instance: sai1"]
+            #[doc = "Select mux mode: ALT3 mux port: CCM_PMIC_READY of instance: ccm"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO07 of instance: flexio1"]
+            #[doc = "Select mux mode: ALT4 mux port: CSI_DATA09 of instance: csi"]
             pub const ALT4: u32 = 0x04;
             #[doc = "Select mux mode: ALT5 mux port: GPIO1_IO24 of instance: gpio1"]
             pub const ALT5: u32 = 0x05;
-            #[doc = "Select mux mode: ALT6 mux port: LPSPI3_PCS2 of instance: lpspi3"]
+            #[doc = "Select mux mode: ALT6 mux port: USDHC2_CMD of instance: usdhc2"]
             pub const ALT6: u32 = 0x06;
-            #[doc = "Select mux mode: ALT7 mux port: XBAR1_INOUT12 of instance: xbar1"]
+            #[doc = "Select mux mode: ALT7 mux port: KPP_ROW03 of instance: kpp"]
             pub const ALT7: u32 = 0x07;
         }
     }
@@ -3411,21 +3411,21 @@ pub mod SW_MUX_CTL_PAD_GPIO_AD_B1_09 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: LPI2C2_SDA of instance: lpi2c2"]
+            #[doc = "Select mux mode: ALT0 mux port: FLEXSPIA_DQS of instance: flexspi"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: FLEXPWM1_PWMB01 of instance: flexpwm1"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXPWM4_PWMA01 of instance: flexpwm4"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: LPUART2_RX of instance: lpuart2"]
+            #[doc = "Select mux mode: ALT2 mux port: FLEXCAN1_RX of instance: flexcan1"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI1_TX_DATA03 of instance: sai1"]
+            #[doc = "Select mux mode: ALT3 mux port: SAI1_MCLK of instance: sai1"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO06 of instance: flexio1"]
+            #[doc = "Select mux mode: ALT4 mux port: CSI_DATA08 of instance: csi"]
             pub const ALT4: u32 = 0x04;
             #[doc = "Select mux mode: ALT5 mux port: GPIO1_IO25 of instance: gpio1"]
             pub const ALT5: u32 = 0x05;
-            #[doc = "Select mux mode: ALT6 mux port: LPSPI3_PCS1 of instance: lpspi3"]
+            #[doc = "Select mux mode: ALT6 mux port: USDHC2_CLK of instance: usdhc2"]
             pub const ALT6: u32 = 0x06;
-            #[doc = "Select mux mode: ALT7 mux port: XBAR1_INOUT13 of instance: xbar1"]
+            #[doc = "Select mux mode: ALT7 mux port: KPP_COL03 of instance: kpp"]
             pub const ALT7: u32 = 0x07;
         }
     }
@@ -5088,19 +5088,19 @@ pub mod SW_MUX_CTL_PAD_GPIO_SD_B0_04 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: USDHC1_DATA0 of instance: usdhc1"]
+            #[doc = "Select mux mode: ALT0 mux port: USDHC1_DATA2 of instance: usdhc1"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: FLEXCAN2_TX of instance: flexcan2"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXPWM1_PWMA02 of instance: flexpwm1"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: LPUART7_TX of instance: lpuart7"]
+            #[doc = "Select mux mode: ALT2 mux port: LPUART8_TX of instance: lpuart8"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI2_TX_DATA of instance: sai2"]
+            #[doc = "Select mux mode: ALT3 mux port: XBAR1_INOUT08 of instance: xbar1"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: LPSPI1_SDO of instance: lpspi1"]
+            #[doc = "Select mux mode: ALT4 mux port: FLEXSPIB_SS0_B of instance: flexspi"]
             pub const ALT4: u32 = 0x04;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO3_IO17 of instance: gpio3"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO3_IO16 of instance: gpio3"]
             pub const ALT5: u32 = 0x05;
-            #[doc = "Select mux mode: ALT6 mux port: FLEXSPI_B_SS0_B of instance: flexspi_bus2bit"]
+            #[doc = "Select mux mode: ALT6 mux port: CCM_CLKO1 of instance: ccm"]
             pub const ALT6: u32 = 0x06;
         }
     }
@@ -5127,19 +5127,19 @@ pub mod SW_MUX_CTL_PAD_GPIO_SD_B0_05 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: USDHC1_DATA1 of instance: usdhc1"]
+            #[doc = "Select mux mode: ALT0 mux port: USDHC1_DATA3 of instance: usdhc1"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: FLEXCAN2_RX of instance: flexcan2"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXPWM1_PWMB02 of instance: flexpwm1"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: LPUART7_RX of instance: lpuart7"]
+            #[doc = "Select mux mode: ALT2 mux port: LPUART8_RX of instance: lpuart8"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI2_TX_BCLK of instance: sai2"]
+            #[doc = "Select mux mode: ALT3 mux port: XBAR1_INOUT09 of instance: xbar1"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: LPSPI1_SDI of instance: lpspi1"]
+            #[doc = "Select mux mode: ALT4 mux port: FLEXSPIB_DQS of instance: flexspi"]
             pub const ALT4: u32 = 0x04;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO3_IO18 of instance: gpio3"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO3_IO17 of instance: gpio3"]
             pub const ALT5: u32 = 0x05;
-            #[doc = "Select mux mode: ALT6 mux port: FLEXSPI_B_DQS of instance: flexspi_bus2bit"]
+            #[doc = "Select mux mode: ALT6 mux port: CCM_CLKO2 of instance: ccm"]
             pub const ALT6: u32 = 0x06;
         }
     }
@@ -5166,17 +5166,17 @@ pub mod SW_MUX_CTL_PAD_GPIO_SD_B1_00 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: USDHC2_DATA2 of instance: usdhc2"]
+            #[doc = "Select mux mode: ALT0 mux port: USDHC2_DATA3 of instance: usdhc2"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: FLEXSPI_B_DATA03 of instance: flexspi_bus2bit"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXSPIB_DATA03 of instance: flexspi"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: LPUART6_TX of instance: lpuart6"]
+            #[doc = "Select mux mode: ALT2 mux port: FLEXPWM1_PWMA03 of instance: flexpwm1"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: XBAR1_INOUT10 of instance: xbar1"]
+            #[doc = "Select mux mode: ALT3 mux port: SAI1_TX_DATA03 of instance: sai1"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: FLEXCAN1_TX of instance: flexcan1"]
+            #[doc = "Select mux mode: ALT4 mux port: LPUART4_TX of instance: lpuart4"]
             pub const ALT4: u32 = 0x04;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO3_IO20 of instance: gpio3"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO3_IO00 of instance: gpio3"]
             pub const ALT5: u32 = 0x05;
         }
     }
@@ -5203,17 +5203,17 @@ pub mod SW_MUX_CTL_PAD_GPIO_SD_B1_01 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: USDHC2_DATA3 of instance: usdhc2"]
+            #[doc = "Select mux mode: ALT0 mux port: USDHC2_DATA2 of instance: usdhc2"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: FLEXSPI_B_SCLK of instance: flexspi_bus2bit"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXSPIB_DATA02 of instance: flexspi"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: LPUART6_RX of instance: lpuart6"]
+            #[doc = "Select mux mode: ALT2 mux port: FLEXPWM1_PWMB03 of instance: flexpwm1"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: FLEXSPI_A_SS1_B of instance: flexspi_bus2bit"]
+            #[doc = "Select mux mode: ALT3 mux port: SAI1_TX_DATA02 of instance: sai1"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: FLEXCAN1_RX of instance: flexcan1"]
+            #[doc = "Select mux mode: ALT4 mux port: LPUART4_RX of instance: lpuart4"]
             pub const ALT4: u32 = 0x04;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO3_IO21 of instance: gpio3"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO3_IO01 of instance: gpio3"]
             pub const ALT5: u32 = 0x05;
         }
     }
@@ -5240,19 +5240,19 @@ pub mod SW_MUX_CTL_PAD_GPIO_SD_B1_02 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: USDHC2_CMD of instance: usdhc2"]
+            #[doc = "Select mux mode: ALT0 mux port: USDHC2_DATA1 of instance: usdhc2"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: FLEXSPI_B_DATA00 of instance: flexspi_bus2bit"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXSPIB_DATA01 of instance: flexspi"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: LPUART8_TX of instance: lpuart8"]
+            #[doc = "Select mux mode: ALT2 mux port: FLEXPWM2_PWMA03 of instance: flexpwm2"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: LPI2C4_SCL of instance: lpi2c4"]
+            #[doc = "Select mux mode: ALT3 mux port: SAI1_TX_DATA01 of instance: sai1"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: ENET_1588_EVENT1_OUT of instance: enet"]
+            #[doc = "Select mux mode: ALT4 mux port: FLEXCAN1_TX of instance: flexcan1"]
             pub const ALT4: u32 = 0x04;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO3_IO22 of instance: gpio3"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO3_IO02 of instance: gpio3"]
             pub const ALT5: u32 = 0x05;
-            #[doc = "Select mux mode: ALT6 mux port: CCM_CLKO1 of instance: ccm"]
+            #[doc = "Select mux mode: ALT6 mux port: CCM_WAIT of instance: ccm"]
             pub const ALT6: u32 = 0x06;
         }
     }
@@ -5279,19 +5279,19 @@ pub mod SW_MUX_CTL_PAD_GPIO_SD_B1_03 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: USDHC2_CLK of instance: usdhc2"]
+            #[doc = "Select mux mode: ALT0 mux port: USDHC2_DATA0 of instance: usdhc2"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: FLEXSPI_B_DATA02 of instance: flexspi_bus2bit"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXSPIB_DATA00 of instance: flexspi"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: LPUART8_RX of instance: lpuart8"]
+            #[doc = "Select mux mode: ALT2 mux port: FLEXPWM2_PWMB03 of instance: flexpwm2"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: LPI2C4_SDA of instance: lpi2c4"]
+            #[doc = "Select mux mode: ALT3 mux port: SAI1_MCLK of instance: sai1"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: ENET_1588_EVENT1_IN of instance: enet"]
+            #[doc = "Select mux mode: ALT4 mux port: FLEXCAN1_RX of instance: flexcan1"]
             pub const ALT4: u32 = 0x04;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO3_IO23 of instance: gpio3"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO3_IO03 of instance: gpio3"]
             pub const ALT5: u32 = 0x05;
-            #[doc = "Select mux mode: ALT6 mux port: CCM_CLKO2 of instance: ccm"]
+            #[doc = "Select mux mode: ALT6 mux port: CCM_PMIC_READY of instance: ccm"]
             pub const ALT6: u32 = 0x06;
         }
     }
@@ -5318,19 +5318,19 @@ pub mod SW_MUX_CTL_PAD_GPIO_SD_B1_04 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: USDHC2_DATA0 of instance: usdhc2"]
+            #[doc = "Select mux mode: ALT0 mux port: USDHC2_CLK of instance: usdhc2"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: FLEXSPI_B_DATA01 of instance: flexspi_bus2bit"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXSPIB_SCLK of instance: flexspi"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: ENET_TX_CLK of instance: enet"]
+            #[doc = "Select mux mode: ALT2 mux port: LPI2C1_SCL of instance: lpi2c1"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: ENET_REF_CLK1 of instance: enet"]
+            #[doc = "Select mux mode: ALT3 mux port: SAI1_RX_SYNC of instance: sai1"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: EWM_OUT_B of instance: ewm"]
+            #[doc = "Select mux mode: ALT4 mux port: FLEXSPIA_SS1_B of instance: flexspi"]
             pub const ALT4: u32 = 0x04;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO3_IO24 of instance: gpio3"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO3_IO04 of instance: gpio3"]
             pub const ALT5: u32 = 0x05;
-            #[doc = "Select mux mode: ALT6 mux port: CCM_WAIT of instance: ccm"]
+            #[doc = "Select mux mode: ALT6 mux port: CCM_STOP of instance: ccm"]
             pub const ALT6: u32 = 0x06;
         }
     }
@@ -5431,17 +5431,17 @@ pub mod SW_MUX_CTL_PAD_GPIO_SD_B1_07 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: USDHC2_RESET_B of instance: usdhc2"]
+            #[doc = "Select mux mode: ALT0 mux port: SEMC_CSX01 of instance: semc"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: FLEXSPI_A_SCLK of instance: flexspi_bus2bit"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXSPIA_SCLK of instance: flexspi"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: ENET_RX_EN of instance: enet"]
+            #[doc = "Select mux mode: ALT2 mux port: LPUART7_RTS_B of instance: lpuart7"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI3_TX_SYNC of instance: sai3"]
+            #[doc = "Select mux mode: ALT3 mux port: SAI1_TX_DATA00 of instance: sai1"]
             pub const ALT3: u32 = 0x03;
             #[doc = "Select mux mode: ALT4 mux port: LPSPI2_SCK of instance: lpspi2"]
             pub const ALT4: u32 = 0x04;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO3_IO27 of instance: gpio3"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO3_IO07 of instance: gpio3"]
             pub const ALT5: u32 = 0x05;
         }
     }
@@ -5509,15 +5509,15 @@ pub mod SW_MUX_CTL_PAD_GPIO_SD_B1_09 {
         pub mod RW {
             #[doc = "Select mux mode: ALT0 mux port: USDHC2_DATA5 of instance: usdhc2"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: FLEXSPI_A_DATA02 of instance: flexspi_bus2bit"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXSPIA_DATA01 of instance: flexspi"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: ENET_TX_EN of instance: enet"]
+            #[doc = "Select mux mode: ALT2 mux port: LPUART7_RX of instance: lpuart7"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI3_RX_BCLK of instance: sai3"]
+            #[doc = "Select mux mode: ALT3 mux port: SAI1_TX_SYNC of instance: sai1"]
             pub const ALT3: u32 = 0x03;
             #[doc = "Select mux mode: ALT4 mux port: LPSPI2_SDI of instance: lpspi2"]
             pub const ALT4: u32 = 0x04;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO3_IO29 of instance: gpio3"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO3_IO09 of instance: gpio3"]
             pub const ALT5: u32 = 0x05;
         }
     }
@@ -5546,15 +5546,15 @@ pub mod SW_MUX_CTL_PAD_GPIO_SD_B1_10 {
         pub mod RW {
             #[doc = "Select mux mode: ALT0 mux port: USDHC2_DATA6 of instance: usdhc2"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: FLEXSPI_A_DATA01 of instance: flexspi_bus2bit"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXSPIA_DATA02 of instance: flexspi"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: ENET_TDATA00 of instance: enet"]
+            #[doc = "Select mux mode: ALT2 mux port: LPUART2_RX of instance: lpuart2"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI3_RX_SYNC of instance: sai3"]
+            #[doc = "Select mux mode: ALT3 mux port: LPI2C2_SDA of instance: lpi2c2"]
             pub const ALT3: u32 = 0x03;
             #[doc = "Select mux mode: ALT4 mux port: LPSPI2_PCS2 of instance: lpspi2"]
             pub const ALT4: u32 = 0x04;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO3_IO30 of instance: gpio3"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO3_IO10 of instance: gpio3"]
             pub const ALT5: u32 = 0x05;
         }
     }
@@ -5583,15 +5583,15 @@ pub mod SW_MUX_CTL_PAD_GPIO_SD_B1_11 {
         pub mod RW {
             #[doc = "Select mux mode: ALT0 mux port: USDHC2_DATA7 of instance: usdhc2"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: FLEXSPI_A_SS0_B of instance: flexspi_bus2bit"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXSPIA_DATA03 of instance: flexspi"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: ENET_TDATA01 of instance: enet"]
+            #[doc = "Select mux mode: ALT2 mux port: LPUART2_TX of instance: lpuart2"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI3_RX_DATA of instance: sai3"]
+            #[doc = "Select mux mode: ALT3 mux port: LPI2C2_SCL of instance: lpi2c2"]
             pub const ALT3: u32 = 0x03;
             #[doc = "Select mux mode: ALT4 mux port: LPSPI2_PCS3 of instance: lpspi2"]
             pub const ALT4: u32 = 0x04;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO3_IO31 of instance: gpio3"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO3_IO11 of instance: gpio3"]
             pub const ALT5: u32 = 0x05;
         }
     }

--- a/src/blocks/imxrt1051/iomuxc_gpr.rs
+++ b/src/blocks/imxrt1051/iomuxc_gpr.rs
@@ -107,7 +107,7 @@ pub mod GPR1 {
         pub mod RW {
             #[doc = "ccm.spdif0_clk_root"]
             pub const SAI1_MCLK3_SEL_0: u32 = 0;
-            #[doc = "SPDIF_EXT_CLK"]
+            #[doc = "iomux.spdif_tx_clk2"]
             pub const SAI1_MCLK3_SEL_1: u32 = 0x01;
             #[doc = "spdif.spdif_srclk"]
             pub const SAI1_MCLK3_SEL_2: u32 = 0x02;
@@ -124,7 +124,7 @@ pub mod GPR1 {
         pub mod RW {
             #[doc = "ccm.spdif0_clk_root"]
             pub const SAI2_MCLK3_SEL_0: u32 = 0;
-            #[doc = "SPDIF_EXT_CLK"]
+            #[doc = "iomux.spdif_tx_clk2"]
             pub const SAI2_MCLK3_SEL_1: u32 = 0x01;
             #[doc = "spdif.spdif_srclk"]
             pub const SAI2_MCLK3_SEL_2: u32 = 0x02;
@@ -141,7 +141,7 @@ pub mod GPR1 {
         pub mod RW {
             #[doc = "ccm.spdif0_clk_root"]
             pub const SAI3_MCLK3_SEL_0: u32 = 0;
-            #[doc = "SPDIF_EXT_CLK"]
+            #[doc = "iomux.spdif_tx_clk2"]
             pub const SAI3_MCLK3_SEL_1: u32 = 0x01;
             #[doc = "spdif.spdif_srclk"]
             pub const SAI3_MCLK3_SEL_2: u32 = 0x02;
@@ -149,7 +149,7 @@ pub mod GPR1 {
             pub const SAI3_MCLK3_SEL_3: u32 = 0x03;
         }
     }
-    #[doc = "Global interrupt bit (connected to ARM M7 IRQ#41)"]
+    #[doc = "Global interrupt bit (connected to ARM M7 IRQ#41 and GPC)"]
     pub mod GINT {
         pub const offset: u32 = 12;
         pub const mask: u32 = 0x01 << offset;
@@ -169,7 +169,7 @@ pub mod GPR1 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "ENET1 TX reference clock driven by ref_enetpll."]
+            #[doc = "ENET1 TX reference clock driven by ref_enetpll0. This clock is also output to pins via the IOMUX. ENET_REF_CLK1 function."]
             pub const ENET1_CLK_SEL_0: u32 = 0;
             #[doc = "Gets ENET1 TX reference clock from the ENET1_TX_CLK pin. In this use case, an external OSC provides the clock for both the external PHY and the internal controller."]
             pub const ENET1_CLK_SEL_1: u32 = 0x01;
@@ -188,16 +188,16 @@ pub mod GPR1 {
             pub const USB_EXP_MODE_1: u32 = 0x01;
         }
     }
-    #[doc = "ENET1_TX_CLK data direction control"]
+    #[doc = "ENET1_TX_CLK data direction control when ENET_REF_CLK1 ALT is selected."]
     pub mod ENET1_TX_CLK_DIR {
         pub const offset: u32 = 17;
         pub const mask: u32 = 0x01 << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "ENET1_TX_CLK output driver is disabled"]
+            #[doc = "ENET1_TX_CLK output driver is disabled and ENET_REF_CLK1 is a clock input."]
             pub const ENET1_TX_CLK_DIR_0: u32 = 0;
-            #[doc = "ENET1_TX_CLK output driver is enabled"]
+            #[doc = "ENET1_TX_CLK output driver is enabled and ENET_REF_CLK1 is an output driven by ref_enetpll0."]
             pub const ENET1_TX_CLK_DIR_1: u32 = 0x01;
         }
     }
@@ -273,9 +273,9 @@ pub mod GPR1 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "AHB clock is not running (gated) when CM7 is sleeping and TCM is not accessible."]
+            #[doc = "AHB clock is not running (gated)"]
             pub const CM7_FORCE_HCLK_EN_0: u32 = 0;
-            #[doc = "AHB clock is running (enabled) when CM7 is sleeping and TCM is accessible."]
+            #[doc = "AHB clock is running (enabled)"]
             pub const CM7_FORCE_HCLK_EN_1: u32 = 0x01;
         }
     }
@@ -289,9 +289,9 @@ pub mod GPR2 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Enters power saving mode only when chip is in SUSPEND mode"]
+            #[doc = "none memory power saving features enabled, SHUTDOWN/DEEPSLEEP/LIGHTSLEEP will have no effect"]
             pub const L2_MEM_EN_POWERSAVING_0: u32 = 0;
-            #[doc = "Controlled by L2_MEM_DEEPSLEEP bitfield"]
+            #[doc = "memory power saving features enabled, set SHUTDOWN/DEEPSLEEP/LIGHTSLEEP(priority high to low) to enable power saving levels"]
             pub const L2_MEM_EN_POWERSAVING_1: u32 = 0x01;
         }
     }
@@ -302,9 +302,9 @@ pub mod GPR2 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "No force sleep control supported, memory deep sleep mode only entered when whole system in stop mode (OCRAM in normal mode)"]
+            #[doc = "no force sleep control supported, memory deep sleep mode only entered when whole system in stop mode"]
             pub const L2_MEM_DEEPSLEEP_0: u32 = 0;
-            #[doc = "Force memory into deep sleep mode (OCRAM in power saving mode)"]
+            #[doc = "force memory into deep sleep mode"]
             pub const L2_MEM_DEEPSLEEP_1: u32 = 0x01;
         }
     }
@@ -875,9 +875,9 @@ pub mod GPR2 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Timer counter works normally"]
+            #[doc = "timer counter work normally"]
             pub const QTIMER1_TMR_CNTS_FREEZE_0: u32 = 0;
-            #[doc = "Reset counter and ouput flags"]
+            #[doc = "reset counter and ouput flags"]
             pub const QTIMER1_TMR_CNTS_FREEZE_1: u32 = 0x01;
         }
     }
@@ -938,9 +938,9 @@ pub mod GPR3 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select \\[127:0\\] from SNVS Master Key as DCP key"]
+            #[doc = "Select \\[127:0\\] from snvs/ocotp key as dcp key"]
             pub const DCP_KEY_SEL_0: u32 = 0;
-            #[doc = "Select \\[255:128\\] from SNVS Master Key as DCP key"]
+            #[doc = "Select \\[255:128\\] from snvs/ocotp key as dcp key"]
             pub const DCP_KEY_SEL_1: u32 = 0x01;
         }
     }
@@ -1334,9 +1334,9 @@ pub mod GPR5 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "source from GPT2_CAPTURE1"]
+            #[doc = "source from pad"]
             pub const GPT2_CAPIN1_SEL_0: u32 = 0;
-            #[doc = "source from ENET_1588_EVENT3_OUT (chnnal 3 of IEEE 1588 timer)"]
+            #[doc = "source from enet1.ipp_do_mac0_timer\\[3\\]"]
             pub const GPT2_CAPIN1_SEL_1: u32 = 0x01;
         }
     }
@@ -1347,9 +1347,9 @@ pub mod GPR5 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "event3 source input from ENET_1588_EVENT3_IN"]
+            #[doc = "event3 source input from pad"]
             pub const ENET_EVENT3IN_SEL_0: u32 = 0;
-            #[doc = "event3 source input from GPT2.GPT_COMPARE1"]
+            #[doc = "event3 source input from gpt2.ipp_do_cmpout1"]
             pub const ENET_EVENT3IN_SEL_1: u32 = 0x01;
         }
     }
@@ -2685,7 +2685,7 @@ pub mod GPR10 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select key from SNVS Master Key."]
+            #[doc = "Select key from Key MUX (SNVS/OTPMK)."]
             pub const DCPKEY_OCOTP_OR_KEYMUX_0: u32 = 0;
             #[doc = "Select key from OCOTP (SW_GP2)."]
             pub const DCPKEY_OCOTP_OR_KEYMUX_1: u32 = 0x01;

--- a/src/blocks/imxrt1051/usbphy.rs
+++ b/src/blocks/imxrt1051/usbphy.rs
@@ -60,14 +60,6 @@ pub struct RegisterBlock {
 }
 #[doc = "USB PHY Power-Down Register"]
 pub mod PWD {
-    #[doc = "Reserved."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 0;
-        pub const mask: u32 = 0x03ff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "0 = Normal operation"]
     pub mod TXPWDFS {
         pub const offset: u32 = 10;
@@ -88,14 +80,6 @@ pub mod PWD {
     pub mod TXPWDV2I {
         pub const offset: u32 = 12;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 13;
-        pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -128,14 +112,6 @@ pub mod PWD {
     pub mod RXPWDRX {
         pub const offset: u32 = 20;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD2 {
-        pub const offset: u32 = 21;
-        pub const mask: u32 = 0x07ff << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -143,14 +119,6 @@ pub mod PWD {
 }
 #[doc = "USB PHY Power-Down Register"]
 pub mod PWD_SET {
-    #[doc = "Reserved."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 0;
-        pub const mask: u32 = 0x03ff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "0 = Normal operation"]
     pub mod TXPWDFS {
         pub const offset: u32 = 10;
@@ -171,14 +139,6 @@ pub mod PWD_SET {
     pub mod TXPWDV2I {
         pub const offset: u32 = 12;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 13;
-        pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -211,14 +171,6 @@ pub mod PWD_SET {
     pub mod RXPWDRX {
         pub const offset: u32 = 20;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD2 {
-        pub const offset: u32 = 21;
-        pub const mask: u32 = 0x07ff << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -226,14 +178,6 @@ pub mod PWD_SET {
 }
 #[doc = "USB PHY Power-Down Register"]
 pub mod PWD_CLR {
-    #[doc = "Reserved."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 0;
-        pub const mask: u32 = 0x03ff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "0 = Normal operation"]
     pub mod TXPWDFS {
         pub const offset: u32 = 10;
@@ -254,14 +198,6 @@ pub mod PWD_CLR {
     pub mod TXPWDV2I {
         pub const offset: u32 = 12;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 13;
-        pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -294,14 +230,6 @@ pub mod PWD_CLR {
     pub mod RXPWDRX {
         pub const offset: u32 = 20;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD2 {
-        pub const offset: u32 = 21;
-        pub const mask: u32 = 0x07ff << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -309,14 +237,6 @@ pub mod PWD_CLR {
 }
 #[doc = "USB PHY Power-Down Register"]
 pub mod PWD_TOG {
-    #[doc = "Reserved."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 0;
-        pub const mask: u32 = 0x03ff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "0 = Normal operation"]
     pub mod TXPWDFS {
         pub const offset: u32 = 10;
@@ -337,14 +257,6 @@ pub mod PWD_TOG {
     pub mod TXPWDV2I {
         pub const offset: u32 = 12;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 13;
-        pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -377,14 +289,6 @@ pub mod PWD_TOG {
     pub mod RXPWDRX {
         pub const offset: u32 = 20;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD2 {
-        pub const offset: u32 = 21;
-        pub const mask: u32 = 0x07ff << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -400,25 +304,9 @@ pub mod TX {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved. Note: This bit should remain clear."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 4;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Decode to select a 45-Ohm resistance to the USB_DN output pin"]
     pub mod TXCAL45DN {
         pub const offset: u32 = 8;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved. Note: This bit should remain clear."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 12;
         pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
@@ -432,25 +320,9 @@ pub mod TX {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD2 {
-        pub const offset: u32 = 20;
-        pub const mask: u32 = 0x3f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Controls the edge-rate of the current sensing transistors used in HS transmit"]
     pub mod USBPHY_TX_EDGECTRL {
         pub const offset: u32 = 26;
-        pub const mask: u32 = 0x07 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD5 {
-        pub const offset: u32 = 29;
         pub const mask: u32 = 0x07 << offset;
         pub mod R {}
         pub mod W {}
@@ -467,25 +339,9 @@ pub mod TX_SET {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved. Note: This bit should remain clear."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 4;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Decode to select a 45-Ohm resistance to the USB_DN output pin"]
     pub mod TXCAL45DN {
         pub const offset: u32 = 8;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved. Note: This bit should remain clear."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 12;
         pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
@@ -499,25 +355,9 @@ pub mod TX_SET {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD2 {
-        pub const offset: u32 = 20;
-        pub const mask: u32 = 0x3f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Controls the edge-rate of the current sensing transistors used in HS transmit"]
     pub mod USBPHY_TX_EDGECTRL {
         pub const offset: u32 = 26;
-        pub const mask: u32 = 0x07 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD5 {
-        pub const offset: u32 = 29;
         pub const mask: u32 = 0x07 << offset;
         pub mod R {}
         pub mod W {}
@@ -534,25 +374,9 @@ pub mod TX_CLR {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved. Note: This bit should remain clear."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 4;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Decode to select a 45-Ohm resistance to the USB_DN output pin"]
     pub mod TXCAL45DN {
         pub const offset: u32 = 8;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved. Note: This bit should remain clear."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 12;
         pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
@@ -566,25 +390,9 @@ pub mod TX_CLR {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD2 {
-        pub const offset: u32 = 20;
-        pub const mask: u32 = 0x3f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Controls the edge-rate of the current sensing transistors used in HS transmit"]
     pub mod USBPHY_TX_EDGECTRL {
         pub const offset: u32 = 26;
-        pub const mask: u32 = 0x07 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD5 {
-        pub const offset: u32 = 29;
         pub const mask: u32 = 0x07 << offset;
         pub mod R {}
         pub mod W {}
@@ -601,25 +409,9 @@ pub mod TX_TOG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved. Note: This bit should remain clear."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 4;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Decode to select a 45-Ohm resistance to the USB_DN output pin"]
     pub mod TXCAL45DN {
         pub const offset: u32 = 8;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved. Note: This bit should remain clear."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 12;
         pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
@@ -633,25 +425,9 @@ pub mod TX_TOG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD2 {
-        pub const offset: u32 = 20;
-        pub const mask: u32 = 0x3f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Controls the edge-rate of the current sensing transistors used in HS transmit"]
     pub mod USBPHY_TX_EDGECTRL {
         pub const offset: u32 = 26;
-        pub const mask: u32 = 0x07 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD5 {
-        pub const offset: u32 = 29;
         pub const mask: u32 = 0x07 << offset;
         pub mod R {}
         pub mod W {}
@@ -668,14 +444,6 @@ pub mod RX {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 3;
-        pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "The DISCONADJ field adjusts the trip point for the disconnect detector: 000 = Trip-Level Voltage is 0"]
     pub mod DISCONADJ {
         pub const offset: u32 = 4;
@@ -684,26 +452,10 @@ pub mod RX {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 7;
-        pub const mask: u32 = 0x7fff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "0 = Normal operation"]
     pub mod RXDBYPASS {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD2 {
-        pub const offset: u32 = 23;
-        pub const mask: u32 = 0x01ff << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -719,14 +471,6 @@ pub mod RX_SET {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 3;
-        pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "The DISCONADJ field adjusts the trip point for the disconnect detector: 000 = Trip-Level Voltage is 0"]
     pub mod DISCONADJ {
         pub const offset: u32 = 4;
@@ -735,26 +479,10 @@ pub mod RX_SET {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 7;
-        pub const mask: u32 = 0x7fff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "0 = Normal operation"]
     pub mod RXDBYPASS {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD2 {
-        pub const offset: u32 = 23;
-        pub const mask: u32 = 0x01ff << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -770,14 +498,6 @@ pub mod RX_CLR {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 3;
-        pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "The DISCONADJ field adjusts the trip point for the disconnect detector: 000 = Trip-Level Voltage is 0"]
     pub mod DISCONADJ {
         pub const offset: u32 = 4;
@@ -786,26 +506,10 @@ pub mod RX_CLR {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 7;
-        pub const mask: u32 = 0x7fff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "0 = Normal operation"]
     pub mod RXDBYPASS {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD2 {
-        pub const offset: u32 = 23;
-        pub const mask: u32 = 0x01ff << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -821,14 +525,6 @@ pub mod RX_TOG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 3;
-        pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "The DISCONADJ field adjusts the trip point for the disconnect detector: 000 = Trip-Level Voltage is 0"]
     pub mod DISCONADJ {
         pub const offset: u32 = 4;
@@ -837,26 +533,10 @@ pub mod RX_TOG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 7;
-        pub const mask: u32 = 0x7fff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "0 = Normal operation"]
     pub mod RXDBYPASS {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD2 {
-        pub const offset: u32 = 23;
-        pub const mask: u32 = 0x01ff << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -1060,14 +740,6 @@ pub mod CTRL {
     pub mod FSDLL_RST_EN {
         pub const offset: u32 = 24;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 25;
-        pub const mask: u32 = 0x03 << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -1315,14 +987,6 @@ pub mod CTRL_SET {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 25;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Almost same as OTGID_STATUS in USBPHYx_STATUS Register"]
     pub mod OTG_ID_VALUE {
         pub const offset: u32 = 27;
@@ -1562,14 +1226,6 @@ pub mod CTRL_CLR {
     pub mod FSDLL_RST_EN {
         pub const offset: u32 = 24;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 25;
-        pub const mask: u32 = 0x03 << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -1817,14 +1473,6 @@ pub mod CTRL_TOG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 25;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Almost same as OTGID_STATUS in USBPHYx_STATUS Register"]
     pub mod OTG_ID_VALUE {
         pub const offset: u32 = 27;
@@ -1868,14 +1516,6 @@ pub mod CTRL_TOG {
 }
 #[doc = "USB PHY Status Register"]
 pub mod STATUS {
-    #[doc = "Reserved."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 0;
-        pub const mask: u32 = 0x07 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Indicates that the device has disconnected while in high-speed host mode."]
     pub mod HOSTDISCONDETECT_STATUS {
         pub const offset: u32 = 3;
@@ -1884,25 +1524,9 @@ pub mod STATUS {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 4;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Indicates that the device has been connected on the USB_DP and USB_DM lines."]
     pub mod DEVPLUGIN_STATUS {
         pub const offset: u32 = 6;
-        pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD2 {
-        pub const offset: u32 = 7;
         pub const mask: u32 = 0x01 << offset;
         pub mod R {}
         pub mod W {}
@@ -1916,26 +1540,10 @@ pub mod STATUS {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD3 {
-        pub const offset: u32 = 9;
-        pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Indicates that the host is sending a wake-up after suspend and has triggered an interrupt."]
     pub mod RESUME_STATUS {
         pub const offset: u32 = 10;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD4 {
-        pub const offset: u32 = 11;
-        pub const mask: u32 = 0x001f_ffff << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -1975,14 +1583,6 @@ pub mod DEBUG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 6;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Delay in between the end of transmit to the beginning of receive"]
     pub mod TX2RXCOUNT {
         pub const offset: u32 = 8;
@@ -1999,26 +1599,10 @@ pub mod DEBUG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 13;
-        pub const mask: u32 = 0x07 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Delay in between the detection of squelch to the reset of high-speed RX."]
     pub mod SQUELCHRESETCOUNT {
         pub const offset: u32 = 16;
         pub const mask: u32 = 0x1f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD2 {
-        pub const offset: u32 = 21;
-        pub const mask: u32 = 0x07 << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -2050,14 +1634,6 @@ pub mod DEBUG {
     #[doc = "Gate Test Clocks"]
     pub mod CLKGATE {
         pub const offset: u32 = 30;
-        pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD3 {
-        pub const offset: u32 = 31;
         pub const mask: u32 = 0x01 << offset;
         pub mod R {}
         pub mod W {}
@@ -2098,14 +1674,6 @@ pub mod DEBUG_SET {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 6;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Delay in between the end of transmit to the beginning of receive"]
     pub mod TX2RXCOUNT {
         pub const offset: u32 = 8;
@@ -2122,26 +1690,10 @@ pub mod DEBUG_SET {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 13;
-        pub const mask: u32 = 0x07 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Delay in between the detection of squelch to the reset of high-speed RX."]
     pub mod SQUELCHRESETCOUNT {
         pub const offset: u32 = 16;
         pub const mask: u32 = 0x1f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD2 {
-        pub const offset: u32 = 21;
-        pub const mask: u32 = 0x07 << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -2173,14 +1725,6 @@ pub mod DEBUG_SET {
     #[doc = "Gate Test Clocks"]
     pub mod CLKGATE {
         pub const offset: u32 = 30;
-        pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD3 {
-        pub const offset: u32 = 31;
         pub const mask: u32 = 0x01 << offset;
         pub mod R {}
         pub mod W {}
@@ -2221,14 +1765,6 @@ pub mod DEBUG_CLR {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 6;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Delay in between the end of transmit to the beginning of receive"]
     pub mod TX2RXCOUNT {
         pub const offset: u32 = 8;
@@ -2245,26 +1781,10 @@ pub mod DEBUG_CLR {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 13;
-        pub const mask: u32 = 0x07 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Delay in between the detection of squelch to the reset of high-speed RX."]
     pub mod SQUELCHRESETCOUNT {
         pub const offset: u32 = 16;
         pub const mask: u32 = 0x1f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD2 {
-        pub const offset: u32 = 21;
-        pub const mask: u32 = 0x07 << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -2296,14 +1816,6 @@ pub mod DEBUG_CLR {
     #[doc = "Gate Test Clocks"]
     pub mod CLKGATE {
         pub const offset: u32 = 30;
-        pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD3 {
-        pub const offset: u32 = 31;
         pub const mask: u32 = 0x01 << offset;
         pub mod R {}
         pub mod W {}
@@ -2344,14 +1856,6 @@ pub mod DEBUG_TOG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 6;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Delay in between the end of transmit to the beginning of receive"]
     pub mod TX2RXCOUNT {
         pub const offset: u32 = 8;
@@ -2368,26 +1872,10 @@ pub mod DEBUG_TOG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 13;
-        pub const mask: u32 = 0x07 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Delay in between the detection of squelch to the reset of high-speed RX."]
     pub mod SQUELCHRESETCOUNT {
         pub const offset: u32 = 16;
         pub const mask: u32 = 0x1f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD2 {
-        pub const offset: u32 = 21;
-        pub const mask: u32 = 0x07 << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -2424,14 +1912,6 @@ pub mod DEBUG_TOG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved."]
-    pub mod RSVD3 {
-        pub const offset: u32 = 31;
-        pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "UTMI Debug Status Register 0"]
 pub mod DEBUG0_STATUS {
@@ -2462,26 +1942,10 @@ pub mod DEBUG0_STATUS {
 }
 #[doc = "UTMI Debug Status Register 1"]
 pub mod DEBUG1 {
-    #[doc = "Reserved. Note: This bit should remain clear."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 0;
-        pub const mask: u32 = 0x1fff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Delay increment of the rise of squelch: 00 = Delay is nominal 01 = Delay is +20% 10 = Delay is -20% 11 = Delay is -40%"]
     pub mod ENTAILADJVD {
         pub const offset: u32 = 13;
         pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 15;
-        pub const mask: u32 = 0x0001_ffff << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -2489,26 +1953,10 @@ pub mod DEBUG1 {
 }
 #[doc = "UTMI Debug Status Register 1"]
 pub mod DEBUG1_SET {
-    #[doc = "Reserved. Note: This bit should remain clear."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 0;
-        pub const mask: u32 = 0x1fff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Delay increment of the rise of squelch: 00 = Delay is nominal 01 = Delay is +20% 10 = Delay is -20% 11 = Delay is -40%"]
     pub mod ENTAILADJVD {
         pub const offset: u32 = 13;
         pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 15;
-        pub const mask: u32 = 0x0001_ffff << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -2516,26 +1964,10 @@ pub mod DEBUG1_SET {
 }
 #[doc = "UTMI Debug Status Register 1"]
 pub mod DEBUG1_CLR {
-    #[doc = "Reserved. Note: This bit should remain clear."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 0;
-        pub const mask: u32 = 0x1fff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Delay increment of the rise of squelch: 00 = Delay is nominal 01 = Delay is +20% 10 = Delay is -20% 11 = Delay is -40%"]
     pub mod ENTAILADJVD {
         pub const offset: u32 = 13;
         pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 15;
-        pub const mask: u32 = 0x0001_ffff << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -2543,26 +1975,10 @@ pub mod DEBUG1_CLR {
 }
 #[doc = "UTMI Debug Status Register 1"]
 pub mod DEBUG1_TOG {
-    #[doc = "Reserved. Note: This bit should remain clear."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 0;
-        pub const mask: u32 = 0x1fff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Delay increment of the rise of squelch: 00 = Delay is nominal 01 = Delay is +20% 10 = Delay is -20% 11 = Delay is -40%"]
     pub mod ENTAILADJVD {
         pub const offset: u32 = 13;
         pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 15;
-        pub const mask: u32 = 0x0001_ffff << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}

--- a/src/blocks/imxrt1052/pxp.rs
+++ b/src/blocks/imxrt1052/pxp.rs
@@ -151,14 +151,6 @@ pub mod CTRL {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 5;
-        pub const mask: u32 = 0x07 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Indicates the clockwise rotation to be applied at the output buffer"]
     pub mod ROTATE {
         pub const offset: u32 = 8;
@@ -192,14 +184,6 @@ pub mod CTRL {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 12;
-        pub const mask: u32 = 0x03ff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "This bit controls where rotation will occur in the PXP datapath"]
     pub mod ROT_POS {
         pub const offset: u32 = 22;
@@ -221,25 +205,9 @@ pub mod CTRL {
             pub const _16X16: u32 = 0x01;
         }
     }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD3 {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Enable the PXP to run continuously"]
     pub mod EN_REPEAT {
         pub const offset: u32 = 28;
-        pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD4 {
-        pub const offset: u32 = 29;
         pub const mask: u32 = 0x01 << offset;
         pub mod R {}
         pub mod W {}
@@ -296,14 +264,6 @@ pub mod CTRL_SET {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 5;
-        pub const mask: u32 = 0x07 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Indicates the clockwise rotation to be applied at the output buffer"]
     pub mod ROTATE {
         pub const offset: u32 = 8;
@@ -337,14 +297,6 @@ pub mod CTRL_SET {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 12;
-        pub const mask: u32 = 0x03ff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "This bit controls where rotation will occur in the PXP datapath"]
     pub mod ROT_POS {
         pub const offset: u32 = 22;
@@ -366,25 +318,9 @@ pub mod CTRL_SET {
             pub const _16X16: u32 = 0x01;
         }
     }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD3 {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Enable the PXP to run continuously"]
     pub mod EN_REPEAT {
         pub const offset: u32 = 28;
-        pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD4 {
-        pub const offset: u32 = 29;
         pub const mask: u32 = 0x01 << offset;
         pub mod R {}
         pub mod W {}
@@ -441,14 +377,6 @@ pub mod CTRL_CLR {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 5;
-        pub const mask: u32 = 0x07 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Indicates the clockwise rotation to be applied at the output buffer"]
     pub mod ROTATE {
         pub const offset: u32 = 8;
@@ -482,14 +410,6 @@ pub mod CTRL_CLR {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 12;
-        pub const mask: u32 = 0x03ff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "This bit controls where rotation will occur in the PXP datapath"]
     pub mod ROT_POS {
         pub const offset: u32 = 22;
@@ -511,25 +431,9 @@ pub mod CTRL_CLR {
             pub const _16X16: u32 = 0x01;
         }
     }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD3 {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Enable the PXP to run continuously"]
     pub mod EN_REPEAT {
         pub const offset: u32 = 28;
-        pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD4 {
-        pub const offset: u32 = 29;
         pub const mask: u32 = 0x01 << offset;
         pub mod R {}
         pub mod W {}
@@ -586,14 +490,6 @@ pub mod CTRL_TOG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 5;
-        pub const mask: u32 = 0x07 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Indicates the clockwise rotation to be applied at the output buffer"]
     pub mod ROTATE {
         pub const offset: u32 = 8;
@@ -627,14 +523,6 @@ pub mod CTRL_TOG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 12;
-        pub const mask: u32 = 0x03ff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "This bit controls where rotation will occur in the PXP datapath"]
     pub mod ROT_POS {
         pub const offset: u32 = 22;
@@ -656,25 +544,9 @@ pub mod CTRL_TOG {
             pub const _16X16: u32 = 0x01;
         }
     }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD3 {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Enable the PXP to run continuously"]
     pub mod EN_REPEAT {
         pub const offset: u32 = 28;
-        pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD4 {
-        pub const offset: u32 = 29;
         pub const mask: u32 = 0x01 << offset;
         pub mod R {}
         pub mod W {}
@@ -747,14 +619,6 @@ pub mod STAT {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD2 {
-        pub const offset: u32 = 9;
-        pub const mask: u32 = 0x7f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Indicates the X coordinate of the block currently being rendered."]
     pub mod BLOCKY {
         pub const offset: u32 = 16;
@@ -818,14 +682,6 @@ pub mod STAT_SET {
     pub mod LUT_DMA_LOAD_DONE_IRQ {
         pub const offset: u32 = 8;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD2 {
-        pub const offset: u32 = 9;
-        pub const mask: u32 = 0x7f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -897,14 +753,6 @@ pub mod STAT_CLR {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD2 {
-        pub const offset: u32 = 9;
-        pub const mask: u32 = 0x7f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Indicates the X coordinate of the block currently being rendered."]
     pub mod BLOCKY {
         pub const offset: u32 = 16;
@@ -972,14 +820,6 @@ pub mod STAT_TOG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD2 {
-        pub const offset: u32 = 9;
-        pub const mask: u32 = 0x7f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Indicates the X coordinate of the block currently being rendered."]
     pub mod BLOCKY {
         pub const offset: u32 = 16;
@@ -1042,14 +882,6 @@ pub mod OUT_CTRL {
             pub const YVU2P420: u32 = 0x1b;
         }
     }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 5;
-        pub const mask: u32 = 0x07 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Determines how the PXP writes it's output data"]
     pub mod INTERLACED_OUTPUT {
         pub const offset: u32 = 8;
@@ -1066,14 +898,6 @@ pub mod OUT_CTRL {
             #[doc = "Interlaced output: data for field 0 is written to OUTBUF and data for field 1 is written to OUTBUF2."]
             pub const INTERLACED: u32 = 0x03;
         }
-    }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 10;
-        pub const mask: u32 = 0x1fff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
     }
     #[doc = "Indicates that alpha component in output buffer pixels should be overwritten by PXP_OUT_CTRL\\[ALPHA\\]"]
     pub mod ALPHA_OUTPUT {
@@ -1137,14 +961,6 @@ pub mod OUT_CTRL_SET {
             pub const YVU2P420: u32 = 0x1b;
         }
     }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 5;
-        pub const mask: u32 = 0x07 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Determines how the PXP writes it's output data"]
     pub mod INTERLACED_OUTPUT {
         pub const offset: u32 = 8;
@@ -1161,14 +977,6 @@ pub mod OUT_CTRL_SET {
             #[doc = "Interlaced output: data for field 0 is written to OUTBUF and data for field 1 is written to OUTBUF2."]
             pub const INTERLACED: u32 = 0x03;
         }
-    }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 10;
-        pub const mask: u32 = 0x1fff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
     }
     #[doc = "Indicates that alpha component in output buffer pixels should be overwritten by PXP_OUT_CTRL\\[ALPHA\\]"]
     pub mod ALPHA_OUTPUT {
@@ -1232,14 +1040,6 @@ pub mod OUT_CTRL_CLR {
             pub const YVU2P420: u32 = 0x1b;
         }
     }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 5;
-        pub const mask: u32 = 0x07 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Determines how the PXP writes it's output data"]
     pub mod INTERLACED_OUTPUT {
         pub const offset: u32 = 8;
@@ -1256,14 +1056,6 @@ pub mod OUT_CTRL_CLR {
             #[doc = "Interlaced output: data for field 0 is written to OUTBUF and data for field 1 is written to OUTBUF2."]
             pub const INTERLACED: u32 = 0x03;
         }
-    }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 10;
-        pub const mask: u32 = 0x1fff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
     }
     #[doc = "Indicates that alpha component in output buffer pixels should be overwritten by PXP_OUT_CTRL\\[ALPHA\\]"]
     pub mod ALPHA_OUTPUT {
@@ -1327,14 +1119,6 @@ pub mod OUT_CTRL_TOG {
             pub const YVU2P420: u32 = 0x1b;
         }
     }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 5;
-        pub const mask: u32 = 0x07 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Determines how the PXP writes it's output data"]
     pub mod INTERLACED_OUTPUT {
         pub const offset: u32 = 8;
@@ -1351,14 +1135,6 @@ pub mod OUT_CTRL_TOG {
             #[doc = "Interlaced output: data for field 0 is written to OUTBUF and data for field 1 is written to OUTBUF2."]
             pub const INTERLACED: u32 = 0x03;
         }
-    }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 10;
-        pub const mask: u32 = 0x1fff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
     }
     #[doc = "Indicates that alpha component in output buffer pixels should be overwritten by PXP_OUT_CTRL\\[ALPHA\\]"]
     pub mod ALPHA_OUTPUT {
@@ -1409,14 +1185,6 @@ pub mod OUT_PITCH {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD {
-        pub const offset: u32 = 16;
-        pub const mask: u32 = 0xffff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "Output Surface Lower Right Coordinate"]
 pub mod OUT_LRC {
@@ -1428,26 +1196,10 @@ pub mod OUT_LRC {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 14;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Indicates number of horizontal PIXELS in the output surface (non-rotated)"]
     pub mod X {
         pub const offset: u32 = 16;
         pub const mask: u32 = 0x3fff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 30;
-        pub const mask: u32 = 0x03 << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -1463,26 +1215,10 @@ pub mod OUT_PS_ULC {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 14;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "This field indicates the upper left X-coordinate (in pixels) of the processed surface (PS) in the output buffer"]
     pub mod X {
         pub const offset: u32 = 16;
         pub const mask: u32 = 0x3fff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 30;
-        pub const mask: u32 = 0x03 << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -1498,26 +1234,10 @@ pub mod OUT_PS_LRC {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 14;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "This field indicates the lower right X-coordinate (in pixels) of the processed surface (PS) in the output frame buffer"]
     pub mod X {
         pub const offset: u32 = 16;
         pub const mask: u32 = 0x3fff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 30;
-        pub const mask: u32 = 0x03 << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -1533,26 +1253,10 @@ pub mod OUT_AS_ULC {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 14;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "This field indicates the upper left X-coordinate (in pixels) of the alpha surface (AS) in the output frame buffer"]
     pub mod X {
         pub const offset: u32 = 16;
         pub const mask: u32 = 0x3fff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 30;
-        pub const mask: u32 = 0x03 << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -1568,26 +1272,10 @@ pub mod OUT_AS_LRC {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 14;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "This field indicates the lower right X-coordinate (in pixels) of the alpha surface (AS) in the output frame buffer"]
     pub mod X {
         pub const offset: u32 = 16;
         pub const mask: u32 = 0x3fff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 30;
-        pub const mask: u32 = 0x03 << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -1642,14 +1330,6 @@ pub mod PS_CTRL {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 6;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Verticle pre decimation filter control."]
     pub mod DECY {
         pub const offset: u32 = 8;
@@ -1683,14 +1363,6 @@ pub mod PS_CTRL {
             #[doc = "Decimate PS by 8."]
             pub const DECX8: u32 = 0x03;
         }
-    }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 12;
-        pub const mask: u32 = 0x000f_ffff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
     }
 }
 #[doc = "Processed Surface (PS) Control Register"]
@@ -1742,14 +1414,6 @@ pub mod PS_CTRL_SET {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 6;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Verticle pre decimation filter control."]
     pub mod DECY {
         pub const offset: u32 = 8;
@@ -1783,14 +1447,6 @@ pub mod PS_CTRL_SET {
             #[doc = "Decimate PS by 8."]
             pub const DECX8: u32 = 0x03;
         }
-    }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 12;
-        pub const mask: u32 = 0x000f_ffff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
     }
 }
 #[doc = "Processed Surface (PS) Control Register"]
@@ -1842,14 +1498,6 @@ pub mod PS_CTRL_CLR {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 6;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Verticle pre decimation filter control."]
     pub mod DECY {
         pub const offset: u32 = 8;
@@ -1883,14 +1531,6 @@ pub mod PS_CTRL_CLR {
             #[doc = "Decimate PS by 8."]
             pub const DECX8: u32 = 0x03;
         }
-    }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 12;
-        pub const mask: u32 = 0x000f_ffff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
     }
 }
 #[doc = "Processed Surface (PS) Control Register"]
@@ -1942,14 +1582,6 @@ pub mod PS_CTRL_TOG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 6;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Verticle pre decimation filter control."]
     pub mod DECY {
         pub const offset: u32 = 8;
@@ -1983,14 +1615,6 @@ pub mod PS_CTRL_TOG {
             #[doc = "Decimate PS by 8."]
             pub const DECX8: u32 = 0x03;
         }
-    }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 12;
-        pub const mask: u32 = 0x000f_ffff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
     }
 }
 #[doc = "PS Input Buffer Address"]
@@ -2036,14 +1660,6 @@ pub mod PS_PITCH {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD {
-        pub const offset: u32 = 16;
-        pub const mask: u32 = 0xffff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "PS Background Color"]
 pub mod PS_BACKGROUND {
@@ -2051,14 +1667,6 @@ pub mod PS_BACKGROUND {
     pub mod COLOR {
         pub const offset: u32 = 0;
         pub const mask: u32 = 0x00ff_ffff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0xff << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -2074,26 +1682,10 @@ pub mod PS_SCALE {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 15;
-        pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "This is a two bit integer and 12 bit fractional representation (##"]
     pub mod YSCALE {
         pub const offset: u32 = 16;
         pub const mask: u32 = 0x7fff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD2 {
-        pub const offset: u32 = 31;
-        pub const mask: u32 = 0x01 << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -2109,26 +1701,10 @@ pub mod PS_OFFSET {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 12;
-        pub const mask: u32 = 0x0f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "This is a 12 bit fractional representation (0"]
     pub mod YOFFSET {
         pub const offset: u32 = 16;
         pub const mask: u32 = 0x0fff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD2 {
-        pub const offset: u32 = 28;
-        pub const mask: u32 = 0x0f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -2144,14 +1720,6 @@ pub mod PS_CLRKEYLOW {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0xff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "PS Color Key High"]
 pub mod PS_CLRKEYHIGH {
@@ -2163,25 +1731,9 @@ pub mod PS_CLRKEYHIGH {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0xff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "Alpha Surface Control"]
 pub mod AS_CTRL {
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 0;
-        pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Determines how the alpha value is constructed for this alpha surface"]
     pub mod ALPHA_CTRL {
         pub const offset: u32 = 1;
@@ -2279,14 +1831,6 @@ pub mod AS_CTRL {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 21;
-        pub const mask: u32 = 0x07ff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "Alpha Surface Buffer Pointer"]
 pub mod AS_BUF {
@@ -2309,14 +1853,6 @@ pub mod AS_PITCH {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD {
-        pub const offset: u32 = 16;
-        pub const mask: u32 = 0xffff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "Overlay Color Key Low"]
 pub mod AS_CLRKEYLOW {
@@ -2328,14 +1864,6 @@ pub mod AS_CLRKEYLOW {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0xff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "Overlay Color Key High"]
 pub mod AS_CLRKEYHIGH {
@@ -2343,14 +1871,6 @@ pub mod AS_CLRKEYHIGH {
     pub mod PIXEL {
         pub const offset: u32 = 0;
         pub const mask: u32 = 0x00ff_ffff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 24;
-        pub const mask: u32 = 0xff << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -2382,14 +1902,6 @@ pub mod CSC1_COEF0 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 29;
-        pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Bypass the CSC unit in the scaling engine"]
     pub mod BYPASS {
         pub const offset: u32 = 30;
@@ -2417,26 +1929,10 @@ pub mod CSC1_COEF1 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 11;
-        pub const mask: u32 = 0x1f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Two's compliment Red V/Cr multiplier coefficient. YUV=0x123 (1.140) YCbCr=0x198 (1.596)"]
     pub mod C1 {
         pub const offset: u32 = 16;
         pub const mask: u32 = 0x07ff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 27;
-        pub const mask: u32 = 0x1f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -2452,26 +1948,10 @@ pub mod CSC1_COEF2 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD0 {
-        pub const offset: u32 = 11;
-        pub const mask: u32 = 0x1f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "Two's complement Green V/Cr multiplier coefficient. YUV=0x76B (-0.581) YCbCr=0x730 (-0.813)"]
     pub mod C2 {
         pub const offset: u32 = 16;
         pub const mask: u32 = 0x07ff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD1 {
-        pub const offset: u32 = 27;
-        pub const mask: u32 = 0x1f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -2510,14 +1990,6 @@ pub mod NEXT {
     #[doc = "Indicates that the \"next frame\" functionality has been enabled"]
     pub mod ENABLED {
         pub const offset: u32 = 0;
-        pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved, always set to zero."]
-    pub mod RSVD {
-        pub const offset: u32 = 1;
         pub const mask: u32 = 0x01 << offset;
         pub mod R {}
         pub mod W {}

--- a/src/blocks/imxrt1061/ccm.rs
+++ b/src/blocks/imxrt1061/ccm.rs
@@ -2749,7 +2749,7 @@ pub mod CCGR0 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "sim_m_clk_r_clk_enable"]
+    #[doc = "sim_m or sim_main register access clock (sim_m_mainclk_r_enable)"]
     pub mod CG4 {
         pub const offset: u32 = 8;
         pub const mask: u32 = 0x03 << offset;
@@ -3214,7 +3214,7 @@ pub mod CCGR3 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "ocram clock (ocram_clk_enable)"]
+    #[doc = "The OCRAM clock cannot be turned off when the CM cache is running on this device."]
     pub mod CG14 {
         pub const offset: u32 = 28;
         pub const mask: u32 = 0x03 << offset;
@@ -3575,7 +3575,7 @@ pub mod CCGR6 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "sim_per clock (sim_per_clk_enable)"]
+    #[doc = "sim_axbs_p_clk_enable"]
     pub mod CG10 {
         pub const offset: u32 = 20;
         pub const mask: u32 = 0x03 << offset;

--- a/src/blocks/imxrt1061/ccm.rs
+++ b/src/blocks/imxrt1061/ccm.rs
@@ -2773,7 +2773,7 @@ pub mod CCGR0 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "can1 clock (can1_clk_enable)"]
     pub mod CG7 {
         pub const offset: u32 = 14;
         pub const mask: u32 = 0x03 << offset;
@@ -2781,7 +2781,7 @@ pub mod CCGR0 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "can1_serial clock (can1_serial_clk_enable)"]
     pub mod CG8 {
         pub const offset: u32 = 16;
         pub const mask: u32 = 0x03 << offset;
@@ -2789,7 +2789,7 @@ pub mod CCGR0 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "can2 clock (can2_clk_enable)"]
     pub mod CG9 {
         pub const offset: u32 = 18;
         pub const mask: u32 = 0x03 << offset;
@@ -2797,7 +2797,7 @@ pub mod CCGR0 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "can2_serial clock (can2_serial_clk_enable)"]
     pub mod CG10 {
         pub const offset: u32 = 20;
         pub const mask: u32 = 0x03 << offset;
@@ -2864,7 +2864,7 @@ pub mod CCGR1 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "lpspi3 clocks (lpspi3_clk_enable)"]
     pub mod CG2 {
         pub const offset: u32 = 4;
         pub const mask: u32 = 0x03 << offset;
@@ -2872,7 +2872,7 @@ pub mod CCGR1 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "lpspi4 clocks (lpspi4_clk_enable)"]
     pub mod CG3 {
         pub const offset: u32 = 6;
         pub const mask: u32 = 0x03 << offset;
@@ -2880,7 +2880,7 @@ pub mod CCGR1 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "adc2 clock (adc2_clk_enable)"]
     pub mod CG4 {
         pub const offset: u32 = 8;
         pub const mask: u32 = 0x03 << offset;
@@ -2888,7 +2888,7 @@ pub mod CCGR1 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "enet clock (enet_clk_enable)"]
     pub mod CG5 {
         pub const offset: u32 = 10;
         pub const mask: u32 = 0x03 << offset;
@@ -2904,7 +2904,7 @@ pub mod CCGR1 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "aoi2 clocks (aoi2_clk_enable)"]
     pub mod CG7 {
         pub const offset: u32 = 14;
         pub const mask: u32 = 0x03 << offset;
@@ -2920,7 +2920,7 @@ pub mod CCGR1 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "semc_exsc clock (semc_exsc_clk_enable)"]
     pub mod CG9 {
         pub const offset: u32 = 18;
         pub const mask: u32 = 0x03 << offset;
@@ -2968,14 +2968,6 @@ pub mod CCGR1 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "gpio5 clock (gpio5_clk_enable)"]
-    pub mod CG15 {
-        pub const offset: u32 = 30;
-        pub const mask: u32 = 0x03 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "CCM Clock Gating Register 2"]
 pub mod CCGR2 {
@@ -2987,7 +2979,7 @@ pub mod CCGR2 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "csi clock (csi_clk_enable)"]
     pub mod CG1 {
         pub const offset: u32 = 2;
         pub const mask: u32 = 0x03 << offset;
@@ -3019,7 +3011,7 @@ pub mod CCGR2 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "lpi2c3 clock (lpi2c3_clk_enable)"]
     pub mod CG5 {
         pub const offset: u32 = 10;
         pub const mask: u32 = 0x03 << offset;
@@ -3035,7 +3027,7 @@ pub mod CCGR2 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "xbar3 clock (xbar3_clk_enable)"]
     pub mod CG7 {
         pub const offset: u32 = 14;
         pub const mask: u32 = 0x03 << offset;
@@ -3043,7 +3035,7 @@ pub mod CCGR2 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "ipmux1 clock (ipmux1_clk_enable)"]
     pub mod CG8 {
         pub const offset: u32 = 16;
         pub const mask: u32 = 0x03 << offset;
@@ -3051,7 +3043,7 @@ pub mod CCGR2 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "ipmux2 clock (ipmux2_clk_enable)"]
     pub mod CG9 {
         pub const offset: u32 = 18;
         pub const mask: u32 = 0x03 << offset;
@@ -3059,7 +3051,7 @@ pub mod CCGR2 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "ipmux3 clock (ipmux3_clk_enable)"]
     pub mod CG10 {
         pub const offset: u32 = 20;
         pub const mask: u32 = 0x03 << offset;
@@ -3075,7 +3067,7 @@ pub mod CCGR2 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "xbar2 clock (xbar2_clk_enable)"]
     pub mod CG12 {
         pub const offset: u32 = 24;
         pub const mask: u32 = 0x03 << offset;
@@ -3083,7 +3075,7 @@ pub mod CCGR2 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "gpio3 clock (gpio3_clk_enable)"]
     pub mod CG13 {
         pub const offset: u32 = 26;
         pub const mask: u32 = 0x03 << offset;
@@ -3091,7 +3083,7 @@ pub mod CCGR2 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "lcd clocks (lcd_clk_enable)"]
     pub mod CG14 {
         pub const offset: u32 = 28;
         pub const mask: u32 = 0x03 << offset;
@@ -3099,7 +3091,7 @@ pub mod CCGR2 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "pxp clocks (pxp_clk_enable)"]
     pub mod CG15 {
         pub const offset: u32 = 30;
         pub const mask: u32 = 0x03 << offset;
@@ -3110,7 +3102,7 @@ pub mod CCGR2 {
 }
 #[doc = "CCM Clock Gating Register 3"]
 pub mod CCGR3 {
-    #[doc = "Reserved"]
+    #[doc = "flexio2 clocks (flexio2_clk_enable)"]
     pub mod CG0 {
         pub const offset: u32 = 0;
         pub const mask: u32 = 0x03 << offset;
@@ -3118,7 +3110,7 @@ pub mod CCGR3 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "lpuart5 clock (lpuart5_clk_enable)"]
     pub mod CG1 {
         pub const offset: u32 = 2;
         pub const mask: u32 = 0x03 << offset;
@@ -3126,7 +3118,7 @@ pub mod CCGR3 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "semc clocks (semc_clk_enable)"]
     pub mod CG2 {
         pub const offset: u32 = 4;
         pub const mask: u32 = 0x03 << offset;
@@ -3134,7 +3126,7 @@ pub mod CCGR3 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "lpuart6 clock (lpuart6_clk_enable)"]
     pub mod CG3 {
         pub const offset: u32 = 6;
         pub const mask: u32 = 0x03 << offset;
@@ -3150,7 +3142,7 @@ pub mod CCGR3 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "lcdif pix clock (lcdif_pix_clk_enable)"]
     pub mod CG5 {
         pub const offset: u32 = 10;
         pub const mask: u32 = 0x03 << offset;
@@ -3158,7 +3150,7 @@ pub mod CCGR3 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "gpio4 clock (gpio4_clk_enable)"]
     pub mod CG6 {
         pub const offset: u32 = 12;
         pub const mask: u32 = 0x03 << offset;
@@ -3190,7 +3182,7 @@ pub mod CCGR3 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "acmp1 clocks (acmp1_clk_enable)"]
     pub mod CG10 {
         pub const offset: u32 = 20;
         pub const mask: u32 = 0x03 << offset;
@@ -3198,7 +3190,7 @@ pub mod CCGR3 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "acmp2 clocks (acmp2_clk_enable)"]
     pub mod CG11 {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x03 << offset;
@@ -3206,7 +3198,7 @@ pub mod CCGR3 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "acmp3 clocks (acmp3_clk_enable)"]
     pub mod CG12 {
         pub const offset: u32 = 24;
         pub const mask: u32 = 0x03 << offset;
@@ -3214,7 +3206,7 @@ pub mod CCGR3 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "acmp4 clocks (acmp4_clk_enable)"]
     pub mod CG13 {
         pub const offset: u32 = 26;
         pub const mask: u32 = 0x03 << offset;
@@ -3222,7 +3214,7 @@ pub mod CCGR3 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "The OCRAM clock cannot be turned off when the CM cache is running on this device."]
+    #[doc = "ocram clock (ocram_clk_enable)"]
     pub mod CG14 {
         pub const offset: u32 = 28;
         pub const mask: u32 = 0x03 << offset;
@@ -3241,7 +3233,7 @@ pub mod CCGR3 {
 }
 #[doc = "CCM Clock Gating Register 4"]
 pub mod CCGR4 {
-    #[doc = "sim_m7_clk_r_enable"]
+    #[doc = "sim_m7 register access clock (sim_m7_mainclk_r_enable)"]
     pub mod CG0 {
         pub const offset: u32 = 0;
         pub const mask: u32 = 0x03 << offset;
@@ -3265,7 +3257,7 @@ pub mod CCGR4 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "bee clock(bee_clk_enable)"]
     pub mod CG3 {
         pub const offset: u32 = 6;
         pub const mask: u32 = 0x03 << offset;
@@ -3281,7 +3273,7 @@ pub mod CCGR4 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "tsc_dig clock (tsc_clk_enable)"]
     pub mod CG5 {
         pub const offset: u32 = 10;
         pub const mask: u32 = 0x03 << offset;
@@ -3313,7 +3305,7 @@ pub mod CCGR4 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "pwm2 clocks (pwm2_clk_enable)"]
     pub mod CG9 {
         pub const offset: u32 = 18;
         pub const mask: u32 = 0x03 << offset;
@@ -3321,7 +3313,7 @@ pub mod CCGR4 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "pwm3 clocks (pwm3_clk_enable)"]
     pub mod CG10 {
         pub const offset: u32 = 20;
         pub const mask: u32 = 0x03 << offset;
@@ -3329,7 +3321,7 @@ pub mod CCGR4 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "pwm4 clocks (pwm4_clk_enable)"]
     pub mod CG11 {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x03 << offset;
@@ -3337,7 +3329,7 @@ pub mod CCGR4 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "enc1 clocks (enc1_clk_enable)"]
     pub mod CG12 {
         pub const offset: u32 = 24;
         pub const mask: u32 = 0x03 << offset;
@@ -3345,7 +3337,7 @@ pub mod CCGR4 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "enc2 clocks (enc2_clk_enable)"]
     pub mod CG13 {
         pub const offset: u32 = 26;
         pub const mask: u32 = 0x03 << offset;
@@ -3353,7 +3345,7 @@ pub mod CCGR4 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "enc3 clocks (enc3_clk_enable)"]
     pub mod CG14 {
         pub const offset: u32 = 28;
         pub const mask: u32 = 0x03 << offset;
@@ -3361,7 +3353,7 @@ pub mod CCGR4 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "dma_ps clocks (dma_ps_clk_enable)"]
+    #[doc = "enc4 clocks (enc4_clk_enable)"]
     pub mod CG15 {
         pub const offset: u32 = 30;
         pub const mask: u32 = 0x03 << offset;
@@ -3420,7 +3412,7 @@ pub mod CCGR5 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "aipstz4 clocks (aips_tz4_clk_enable)"]
     pub mod CG6 {
         pub const offset: u32 = 12;
         pub const mask: u32 = 0x03 << offset;
@@ -3436,7 +3428,7 @@ pub mod CCGR5 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "sim_main clock (sim_main_clk_enable)"]
     pub mod CG8 {
         pub const offset: u32 = 16;
         pub const mask: u32 = 0x03 << offset;
@@ -3452,7 +3444,7 @@ pub mod CCGR5 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "sai2 clock (sai2_clk_enable)"]
     pub mod CG10 {
         pub const offset: u32 = 20;
         pub const mask: u32 = 0x03 << offset;
@@ -3476,7 +3468,7 @@ pub mod CCGR5 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "lpuart7 clock (lpuart7_clk_enable)"]
     pub mod CG13 {
         pub const offset: u32 = 26;
         pub const mask: u32 = 0x03 << offset;
@@ -3511,7 +3503,7 @@ pub mod CCGR6 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "usdhc1 clocks (usdhc1_clk_enable)"]
     pub mod CG1 {
         pub const offset: u32 = 2;
         pub const mask: u32 = 0x03 << offset;
@@ -3519,7 +3511,7 @@ pub mod CCGR6 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "usdhc2 clocks (usdhc2_clk_enable)"]
     pub mod CG2 {
         pub const offset: u32 = 4;
         pub const mask: u32 = 0x03 << offset;
@@ -3535,7 +3527,7 @@ pub mod CCGR6 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "ipmux4 clock (ipmux4_clk_enable)"]
     pub mod CG4 {
         pub const offset: u32 = 8;
         pub const mask: u32 = 0x03 << offset;
@@ -3559,7 +3551,7 @@ pub mod CCGR6 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "lpuart8 clocks (lpuart8_clk_enable)"]
     pub mod CG7 {
         pub const offset: u32 = 14;
         pub const mask: u32 = 0x03 << offset;
@@ -3567,7 +3559,7 @@ pub mod CCGR6 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "timer4 clocks (timer4_clk_enable)"]
     pub mod CG8 {
         pub const offset: u32 = 16;
         pub const mask: u32 = 0x03 << offset;
@@ -3575,7 +3567,7 @@ pub mod CCGR6 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "aips_tz3 clock (aips_tz3_clk_enable)"]
     pub mod CG9 {
         pub const offset: u32 = 18;
         pub const mask: u32 = 0x03 << offset;
@@ -3599,7 +3591,7 @@ pub mod CCGR6 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "lpi2c4 serial clock (lpi2c4_serial_clk_enable)"]
     pub mod CG12 {
         pub const offset: u32 = 24;
         pub const mask: u32 = 0x03 << offset;
@@ -3607,7 +3599,7 @@ pub mod CCGR6 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "timer1 clocks (timer1_clk_enable)"]
     pub mod CG13 {
         pub const offset: u32 = 26;
         pub const mask: u32 = 0x03 << offset;
@@ -3615,7 +3607,7 @@ pub mod CCGR6 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "timer2 clocks (timer2_clk_enable)"]
     pub mod CG14 {
         pub const offset: u32 = 28;
         pub const mask: u32 = 0x03 << offset;
@@ -3623,7 +3615,7 @@ pub mod CCGR6 {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
+    #[doc = "timer3 clocks (timer3_clk_enable)"]
     pub mod CG15 {
         pub const offset: u32 = 30;
         pub const mask: u32 = 0x03 << offset;

--- a/src/blocks/imxrt1061/ccm.rs
+++ b/src/blocks/imxrt1061/ccm.rs
@@ -2968,6 +2968,14 @@ pub mod CCGR1 {
         pub mod W {}
         pub mod RW {}
     }
+    #[doc = "gpio5 clock (gpio5_clk_enable)"]
+    pub mod CG15 {
+        pub const offset: u32 = 30;
+        pub const mask: u32 = 0x03 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
 }
 #[doc = "CCM Clock Gating Register 2"]
 pub mod CCGR2 {

--- a/src/blocks/imxrt1061/ccm_analog.rs
+++ b/src/blocks/imxrt1061/ccm_analog.rs
@@ -167,14 +167,6 @@ pub mod PLL_ARM {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod PLL_SEL {
-        pub const offset: u32 = 19;
-        pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "1 - PLL is currently locked. 0 - PLL is not currently locked."]
     pub mod LOCK {
         pub const offset: u32 = 31;
@@ -226,14 +218,6 @@ pub mod PLL_ARM_SET {
     #[doc = "Bypass the PLL."]
     pub mod BYPASS {
         pub const offset: u32 = 16;
-        pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod PLL_SEL {
-        pub const offset: u32 = 19;
         pub const mask: u32 = 0x01 << offset;
         pub mod R {}
         pub mod W {}
@@ -295,14 +279,6 @@ pub mod PLL_ARM_CLR {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod PLL_SEL {
-        pub const offset: u32 = 19;
-        pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
     #[doc = "1 - PLL is currently locked. 0 - PLL is not currently locked."]
     pub mod LOCK {
         pub const offset: u32 = 31;
@@ -354,14 +330,6 @@ pub mod PLL_ARM_TOG {
     #[doc = "Bypass the PLL."]
     pub mod BYPASS {
         pub const offset: u32 = 16;
-        pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod PLL_SEL {
-        pub const offset: u32 = 19;
         pub const mask: u32 = 0x01 << offset;
         pub mod R {}
         pub mod W {}

--- a/src/blocks/imxrt1061/iomuxc.rs
+++ b/src/blocks/imxrt1061/iomuxc.rs
@@ -1120,15 +1120,15 @@ pub mod SW_MUX_CTL_PAD_GPIO_EMC_04 {
         pub mod RW {
             #[doc = "Select mux mode: ALT0 mux port: SEMC_DATA04 of instance: semc"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: XBAR1_INOUT04 of instance: xbar1"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXPWM4_PWMA02 of instance: flexpwm4"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: SPDIF_OUT of instance: spdif"]
+            #[doc = "Select mux mode: ALT2 mux port: SAI2_TX_DATA of instance: sai2"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI2_TX_BCLK of instance: sai2"]
+            #[doc = "Select mux mode: ALT3 mux port: XBAR1_INOUT06 of instance: xbar1"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO16 of instance: flexio1"]
+            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO04 of instance: flexio1"]
             pub const ALT4: u32 = 0x04;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO2_IO04 of instance: gpio2"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO4_IO04 of instance: gpio4"]
             pub const ALT5: u32 = 0x05;
         }
     }
@@ -1157,15 +1157,15 @@ pub mod SW_MUX_CTL_PAD_GPIO_EMC_05 {
         pub mod RW {
             #[doc = "Select mux mode: ALT0 mux port: SEMC_DATA05 of instance: semc"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: XBAR1_INOUT05 of instance: xbar1"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXPWM4_PWMB02 of instance: flexpwm4"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: SPDIF_IN of instance: spdif"]
+            #[doc = "Select mux mode: ALT2 mux port: SAI2_TX_SYNC of instance: sai2"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI2_TX_SYNC of instance: sai2"]
+            #[doc = "Select mux mode: ALT3 mux port: XBAR1_INOUT07 of instance: xbar1"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO17 of instance: flexio1"]
+            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO05 of instance: flexio1"]
             pub const ALT4: u32 = 0x04;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO2_IO05 of instance: gpio2"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO4_IO05 of instance: gpio4"]
             pub const ALT5: u32 = 0x05;
         }
     }
@@ -1194,15 +1194,15 @@ pub mod SW_MUX_CTL_PAD_GPIO_EMC_06 {
         pub mod RW {
             #[doc = "Select mux mode: ALT0 mux port: SEMC_DATA06 of instance: semc"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: XBAR1_INOUT06 of instance: xbar1"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXPWM2_PWMA00 of instance: flexpwm2"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: LPUART3_TX of instance: lpuart3"]
+            #[doc = "Select mux mode: ALT2 mux port: SAI2_TX_BCLK of instance: sai2"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI2_TX_DATA of instance: sai2"]
+            #[doc = "Select mux mode: ALT3 mux port: XBAR1_INOUT08 of instance: xbar1"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO18 of instance: flexio1"]
+            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO06 of instance: flexio1"]
             pub const ALT4: u32 = 0x04;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO2_IO06 of instance: gpio2"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO4_IO06 of instance: gpio4"]
             pub const ALT5: u32 = 0x05;
         }
     }
@@ -1231,15 +1231,15 @@ pub mod SW_MUX_CTL_PAD_GPIO_EMC_07 {
         pub mod RW {
             #[doc = "Select mux mode: ALT0 mux port: SEMC_DATA07 of instance: semc"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: XBAR1_INOUT07 of instance: xbar1"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXPWM2_PWMB00 of instance: flexpwm2"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: LPUART3_RX of instance: lpuart3"]
+            #[doc = "Select mux mode: ALT2 mux port: SAI2_MCLK of instance: sai2"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI2_RX_SYNC of instance: sai2"]
+            #[doc = "Select mux mode: ALT3 mux port: XBAR1_INOUT09 of instance: xbar1"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO19 of instance: flexio1"]
+            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO07 of instance: flexio1"]
             pub const ALT4: u32 = 0x04;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO2_IO07 of instance: gpio2"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO4_IO07 of instance: gpio4"]
             pub const ALT5: u32 = 0x05;
         }
     }
@@ -1268,15 +1268,15 @@ pub mod SW_MUX_CTL_PAD_GPIO_EMC_08 {
         pub mod RW {
             #[doc = "Select mux mode: ALT0 mux port: SEMC_DM00 of instance: semc"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: XBAR1_INOUT08 of instance: xbar1"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXPWM2_PWMA01 of instance: flexpwm2"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: FLEXCAN2_TX of instance: flexcan2"]
+            #[doc = "Select mux mode: ALT2 mux port: SAI2_RX_DATA of instance: sai2"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI2_RX_DATA of instance: sai2"]
+            #[doc = "Select mux mode: ALT3 mux port: XBAR1_INOUT17 of instance: xbar1"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO20 of instance: flexio1"]
+            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO08 of instance: flexio1"]
             pub const ALT4: u32 = 0x04;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO2_IO08 of instance: gpio2"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO4_IO08 of instance: gpio4"]
             pub const ALT5: u32 = 0x05;
         }
     }
@@ -1652,19 +1652,19 @@ pub mod SW_MUX_CTL_PAD_GPIO_EMC_18 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: SEMC_ADDR02 of instance: semc"]
+            #[doc = "Select mux mode: ALT0 mux port: SEMC_ADDR09 of instance: semc"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: XBAR1_INOUT16 of instance: xbar1"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXPWM4_PWMB03 of instance: flexpwm4"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: LPI2C2_SDA of instance: lpi2c2"]
+            #[doc = "Select mux mode: ALT2 mux port: LPUART4_RTS_B of instance: lpuart4"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI1_RX_SYNC of instance: sai1"]
+            #[doc = "Select mux mode: ALT3 mux port: FLEXCAN1_RX of instance: flexcan1"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO22 of instance: flexio1"]
+            #[doc = "Select mux mode: ALT4 mux port: QTIMER3_TIMER3 of instance: qtimer3"]
             pub const ALT4: u32 = 0x04;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO2_IO18 of instance: gpio2"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO4_IO18 of instance: gpio4"]
             pub const ALT5: u32 = 0x05;
-            #[doc = "Select mux mode: ALT6 mux port: SRC_BT_CFG00 of instance: src"]
+            #[doc = "Select mux mode: ALT6 mux port: SNVS_VIO_5_CTL of instance: snvs_hp"]
             pub const ALT6: u32 = 0x06;
         }
     }
@@ -1691,19 +1691,19 @@ pub mod SW_MUX_CTL_PAD_GPIO_EMC_19 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: SEMC_ADDR03 of instance: semc"]
+            #[doc = "Select mux mode: ALT0 mux port: SEMC_ADDR11 of instance: semc"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: XBAR1_INOUT17 of instance: xbar1"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXPWM2_PWMA03 of instance: flexpwm2"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: LPI2C2_SCL of instance: lpi2c2"]
+            #[doc = "Select mux mode: ALT2 mux port: LPUART4_TX of instance: lpuart4"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI1_RX_BCLK of instance: sai1"]
+            #[doc = "Select mux mode: ALT3 mux port: ENET_RDATA01 of instance: enet"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO23 of instance: flexio1"]
+            #[doc = "Select mux mode: ALT4 mux port: QTIMER2_TIMER0 of instance: qtimer2"]
             pub const ALT4: u32 = 0x04;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO2_IO19 of instance: gpio2"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO4_IO19 of instance: gpio4"]
             pub const ALT5: u32 = 0x05;
-            #[doc = "Select mux mode: ALT6 mux port: SRC_BT_CFG01 of instance: src"]
+            #[doc = "Select mux mode: ALT6 mux port: SNVS_VIO_5 of instance: snvs_hp"]
             pub const ALT6: u32 = 0x06;
         }
     }
@@ -2727,21 +2727,21 @@ pub mod SW_MUX_CTL_PAD_GPIO_AD_B0_03 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: JTAG_TDI of instance: jtag_mux"]
+            #[doc = "Select mux mode: ALT0 mux port: FLEXCAN2_RX of instance: flexcan2"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: USDHC2_CD_B of instance: usdhc2"]
+            #[doc = "Select mux mode: ALT1 mux port: XBAR1_INOUT17 of instance: xbar1"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: WDOG1_B of instance: wdog1"]
+            #[doc = "Select mux mode: ALT2 mux port: LPUART6_RX of instance: lpuart6"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI1_MCLK of instance: sai1"]
+            #[doc = "Select mux mode: ALT3 mux port: USB_OTG1_OC of instance: usb"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: USDHC1_WP of instance: usdhc1"]
+            #[doc = "Select mux mode: ALT4 mux port: FLEXPWM1_PWMX01 of instance: flexpwm1"]
             pub const ALT4: u32 = 0x04;
             #[doc = "Select mux mode: ALT5 mux port: GPIO1_IO03 of instance: gpio1"]
             pub const ALT5: u32 = 0x05;
-            #[doc = "Select mux mode: ALT6 mux port: USB_OTG1_OC of instance: usb"]
+            #[doc = "Select mux mode: ALT6 mux port: REF_CLK_24M of instance: anatop"]
             pub const ALT6: u32 = 0x06;
-            #[doc = "Select mux mode: ALT7 mux port: CCM_PMIC_RDY of instance: ccm"]
+            #[doc = "Select mux mode: ALT7 mux port: LPSPI3_PCS0 of instance: lpspi3"]
             pub const ALT7: u32 = 0x07;
         }
     }
@@ -2768,21 +2768,21 @@ pub mod SW_MUX_CTL_PAD_GPIO_AD_B0_04 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: JTAG_TDO of instance: jtag_mux"]
+            #[doc = "Select mux mode: ALT0 mux port: SRC_BOOT_MODE00 of instance: src"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: FLEXCAN1_TX of instance: flexcan1"]
+            #[doc = "Select mux mode: ALT1 mux port: MQS_RIGHT of instance: mqs"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: USDHC1_WP of instance: usdhc1"]
+            #[doc = "Select mux mode: ALT2 mux port: ENET_TX_DATA03 of instance: enet"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: QTIMER2_TIMER0 of instance: qtimer2"]
+            #[doc = "Select mux mode: ALT3 mux port: SAI2_TX_SYNC of instance: sai2"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: ENET_MDIO of instance: enet"]
+            #[doc = "Select mux mode: ALT4 mux port: CSI_DATA09 of instance: csi"]
             pub const ALT4: u32 = 0x04;
             #[doc = "Select mux mode: ALT5 mux port: GPIO1_IO04 of instance: gpio1"]
             pub const ALT5: u32 = 0x05;
-            #[doc = "Select mux mode: ALT6 mux port: USB_OTG1_PWR of instance: usb"]
+            #[doc = "Select mux mode: ALT6 mux port: PIT_TRIGGER00 of instance: pit"]
             pub const ALT6: u32 = 0x06;
-            #[doc = "Select mux mode: ALT7 mux port: EWM_OUT_B of instance: ewm"]
+            #[doc = "Select mux mode: ALT7 mux port: LPSPI3_PCS1 of instance: lpspi3"]
             pub const ALT7: u32 = 0x07;
         }
     }
@@ -2809,21 +2809,21 @@ pub mod SW_MUX_CTL_PAD_GPIO_AD_B0_05 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: JTAG_TRSTB of instance: jtag_mux"]
+            #[doc = "Select mux mode: ALT0 mux port: SRC_BOOT_MODE01 of instance: src"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: FLEXCAN1_RX of instance: flexcan1"]
+            #[doc = "Select mux mode: ALT1 mux port: MQS_LEFT of instance: mqs"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: USDHC1_CD_B of instance: usdhc1"]
+            #[doc = "Select mux mode: ALT2 mux port: ENET_TX_DATA02 of instance: enet"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: QTIMER2_TIMER1 of instance: qtimer2"]
+            #[doc = "Select mux mode: ALT3 mux port: SAI2_TX_BCLK of instance: sai2"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: ENET_MDC of instance: enet"]
+            #[doc = "Select mux mode: ALT4 mux port: CSI_DATA08 of instance: csi"]
             pub const ALT4: u32 = 0x04;
             #[doc = "Select mux mode: ALT5 mux port: GPIO1_IO05 of instance: gpio1"]
             pub const ALT5: u32 = 0x05;
-            #[doc = "Select mux mode: ALT6 mux port: USB_OTG1_ID of instance: anatop"]
+            #[doc = "Select mux mode: ALT6 mux port: XBAR1_INOUT17 of instance: xbar1"]
             pub const ALT6: u32 = 0x06;
-            #[doc = "Select mux mode: ALT7 mux port: NMI_GLUE_NMI of instance: nmi_glue"]
+            #[doc = "Select mux mode: ALT7 mux port: LPSPI3_PCS2 of instance: lpspi3"]
             pub const ALT7: u32 = 0x07;
         }
     }
@@ -3106,21 +3106,21 @@ pub mod SW_MUX_CTL_PAD_GPIO_AD_B0_12 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: ENET_RX_ER of instance: enet"]
+            #[doc = "Select mux mode: ALT0 mux port: LPI2C4_SCL of instance: lpi2c4"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: LPSPI1_SDO of instance: lpspi1"]
+            #[doc = "Select mux mode: ALT1 mux port: CCM_PMIC_READY of instance: ccm"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: LPUART3_CTS_B of instance: lpuart3"]
+            #[doc = "Select mux mode: ALT2 mux port: LPUART1_TX of instance: lpuart1"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: KPP_COL02 of instance: kpp"]
+            #[doc = "Select mux mode: ALT3 mux port: WDOG2_WDOG_B of instance: wdog2"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: FLEXPWM2_PWMA01 of instance: flexpwm2"]
+            #[doc = "Select mux mode: ALT4 mux port: FLEXPWM1_PWMX02 of instance: flexpwm1"]
             pub const ALT4: u32 = 0x04;
             #[doc = "Select mux mode: ALT5 mux port: GPIO1_IO12 of instance: gpio1"]
             pub const ALT5: u32 = 0x05;
-            #[doc = "Select mux mode: ALT6 mux port: ARM_CM7_TRACE00 of instance: cm7_mxrt"]
+            #[doc = "Select mux mode: ALT6 mux port: ENET_1588_EVENT1_OUT of instance: enet"]
             pub const ALT6: u32 = 0x06;
-            #[doc = "Select mux mode: ALT7 mux port: SNVS_HP_VIO_5_CTL of instance: snvs_hp"]
+            #[doc = "Select mux mode: ALT7 mux port: NMI_GLUE_NMI of instance: nmi_glue"]
             pub const ALT7: u32 = 0x07;
         }
     }
@@ -3147,21 +3147,21 @@ pub mod SW_MUX_CTL_PAD_GPIO_AD_B0_13 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: ENET_TX_EN of instance: enet"]
+            #[doc = "Select mux mode: ALT0 mux port: LPI2C4_SDA of instance: lpi2c4"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: LPSPI1_SDI of instance: lpspi1"]
+            #[doc = "Select mux mode: ALT1 mux port: GPT1_CLK of instance: gpt1"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: LPUART3_RTS_B of instance: lpuart3"]
+            #[doc = "Select mux mode: ALT2 mux port: LPUART1_RX of instance: lpuart1"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: KPP_ROW02 of instance: kpp"]
+            #[doc = "Select mux mode: ALT3 mux port: EWM_OUT_B of instance: ewm"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: FLEXPWM2_PWMB01 of instance: flexpwm2"]
+            #[doc = "Select mux mode: ALT4 mux port: FLEXPWM1_PWMX03 of instance: flexpwm1"]
             pub const ALT4: u32 = 0x04;
             #[doc = "Select mux mode: ALT5 mux port: GPIO1_IO13 of instance: gpio1"]
             pub const ALT5: u32 = 0x05;
-            #[doc = "Select mux mode: ALT6 mux port: ARM_CM7_TRACE01 of instance: cm7_mxrt"]
+            #[doc = "Select mux mode: ALT6 mux port: ENET_1588_EVENT1_IN of instance: enet"]
             pub const ALT6: u32 = 0x06;
-            #[doc = "Select mux mode: ALT7 mux port: SNVS_HP_VIO_5_B of instance: snvs_hp"]
+            #[doc = "Select mux mode: ALT7 mux port: REF_CLK_24M of instance: anatop"]
             pub const ALT7: u32 = 0x07;
         }
     }
@@ -5847,17 +5847,17 @@ pub mod SW_MUX_CTL_PAD_GPIO_SD_B1_07 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: USDHC2_RESET_B of instance: usdhc2"]
+            #[doc = "Select mux mode: ALT0 mux port: SEMC_CSX01 of instance: semc"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: FLEXSPI_A_SCLK of instance: flexspi_bus2bit"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXSPIA_SCLK of instance: flexspi"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: ENET_RX_EN of instance: enet"]
+            #[doc = "Select mux mode: ALT2 mux port: LPUART7_RTS_B of instance: lpuart7"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI3_TX_SYNC of instance: sai3"]
+            #[doc = "Select mux mode: ALT3 mux port: SAI1_TX_DATA00 of instance: sai1"]
             pub const ALT3: u32 = 0x03;
             #[doc = "Select mux mode: ALT4 mux port: LPSPI2_SCK of instance: lpspi2"]
             pub const ALT4: u32 = 0x04;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO3_IO27 of instance: gpio3"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO3_IO07 of instance: gpio3"]
             pub const ALT5: u32 = 0x05;
         }
     }
@@ -5925,15 +5925,15 @@ pub mod SW_MUX_CTL_PAD_GPIO_SD_B1_09 {
         pub mod RW {
             #[doc = "Select mux mode: ALT0 mux port: USDHC2_DATA5 of instance: usdhc2"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: FLEXSPI_A_DATA02 of instance: flexspi_bus2bit"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXSPIA_DATA01 of instance: flexspi"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: ENET_TX_EN of instance: enet"]
+            #[doc = "Select mux mode: ALT2 mux port: LPUART7_RX of instance: lpuart7"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI3_RX_BCLK of instance: sai3"]
+            #[doc = "Select mux mode: ALT3 mux port: SAI1_TX_SYNC of instance: sai1"]
             pub const ALT3: u32 = 0x03;
             #[doc = "Select mux mode: ALT4 mux port: LPSPI2_SDI of instance: lpspi2"]
             pub const ALT4: u32 = 0x04;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO3_IO29 of instance: gpio3"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO3_IO09 of instance: gpio3"]
             pub const ALT5: u32 = 0x05;
         }
     }
@@ -5962,15 +5962,15 @@ pub mod SW_MUX_CTL_PAD_GPIO_SD_B1_10 {
         pub mod RW {
             #[doc = "Select mux mode: ALT0 mux port: USDHC2_DATA6 of instance: usdhc2"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: FLEXSPI_A_DATA01 of instance: flexspi_bus2bit"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXSPIA_DATA02 of instance: flexspi"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: ENET_TDATA00 of instance: enet"]
+            #[doc = "Select mux mode: ALT2 mux port: LPUART2_RX of instance: lpuart2"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI3_RX_SYNC of instance: sai3"]
+            #[doc = "Select mux mode: ALT3 mux port: LPI2C2_SDA of instance: lpi2c2"]
             pub const ALT3: u32 = 0x03;
             #[doc = "Select mux mode: ALT4 mux port: LPSPI2_PCS2 of instance: lpspi2"]
             pub const ALT4: u32 = 0x04;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO3_IO30 of instance: gpio3"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO3_IO10 of instance: gpio3"]
             pub const ALT5: u32 = 0x05;
         }
     }
@@ -5999,15 +5999,15 @@ pub mod SW_MUX_CTL_PAD_GPIO_SD_B1_11 {
         pub mod RW {
             #[doc = "Select mux mode: ALT0 mux port: USDHC2_DATA7 of instance: usdhc2"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: FLEXSPI_A_SS0_B of instance: flexspi_bus2bit"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXSPIA_DATA03 of instance: flexspi"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: ENET_TDATA01 of instance: enet"]
+            #[doc = "Select mux mode: ALT2 mux port: LPUART2_TX of instance: lpuart2"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI3_RX_DATA of instance: sai3"]
+            #[doc = "Select mux mode: ALT3 mux port: LPI2C2_SCL of instance: lpi2c2"]
             pub const ALT3: u32 = 0x03;
             #[doc = "Select mux mode: ALT4 mux port: LPSPI2_PCS3 of instance: lpspi2"]
             pub const ALT4: u32 = 0x04;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO3_IO31 of instance: gpio3"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO3_IO11 of instance: gpio3"]
             pub const ALT5: u32 = 0x05;
         }
     }

--- a/src/blocks/imxrt1061/iomuxc_gpr.rs
+++ b/src/blocks/imxrt1061/iomuxc_gpr.rs
@@ -125,7 +125,7 @@ pub mod GPR1 {
         pub mod RW {
             #[doc = "ccm.spdif0_clk_root"]
             pub const SAI1_MCLK3_SEL_0: u32 = 0;
-            #[doc = "SPDIF_EXT_CLK"]
+            #[doc = "iomux.spdif_tx_clk2"]
             pub const SAI1_MCLK3_SEL_1: u32 = 0x01;
             #[doc = "spdif.spdif_srclk"]
             pub const SAI1_MCLK3_SEL_2: u32 = 0x02;
@@ -142,7 +142,7 @@ pub mod GPR1 {
         pub mod RW {
             #[doc = "ccm.spdif0_clk_root"]
             pub const SAI2_MCLK3_SEL_0: u32 = 0;
-            #[doc = "SPDIF_EXT_CLK"]
+            #[doc = "iomux.spdif_tx_clk2"]
             pub const SAI2_MCLK3_SEL_1: u32 = 0x01;
             #[doc = "spdif.spdif_srclk"]
             pub const SAI2_MCLK3_SEL_2: u32 = 0x02;
@@ -159,7 +159,7 @@ pub mod GPR1 {
         pub mod RW {
             #[doc = "ccm.spdif0_clk_root"]
             pub const SAI3_MCLK3_SEL_0: u32 = 0;
-            #[doc = "SPDIF_EXT_CLK"]
+            #[doc = "iomux.spdif_tx_clk2"]
             pub const SAI3_MCLK3_SEL_1: u32 = 0x01;
             #[doc = "spdif.spdif_srclk"]
             pub const SAI3_MCLK3_SEL_2: u32 = 0x02;
@@ -187,7 +187,7 @@ pub mod GPR1 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "ENET1 TX reference clock driven by ref_enetpll."]
+            #[doc = "ENET1 TX reference clock driven by ref_enetpll. This clock is also output to pins via the IOMUX. ENET_REF_CLK1 function."]
             pub const ENET1_CLK_SEL_0: u32 = 0;
             #[doc = "Gets ENET1 TX reference clock from the ENET1_TX_CLK pin. In this use case, an external OSC provides the clock for both the external PHY and the internal controller."]
             pub const ENET1_CLK_SEL_1: u32 = 0x01;
@@ -293,7 +293,7 @@ pub mod GPR1 {
         pub mod RW {
             #[doc = "OKAY response"]
             pub const EXC_MON_0: u32 = 0;
-            #[doc = "SLVError response"]
+            #[doc = "SLVError response (default)"]
             pub const EXC_MON_1: u32 = 0x01;
         }
     }
@@ -317,9 +317,9 @@ pub mod GPR1 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "AHB clock is not running (gated) when CM7 is sleeping and TCM is not accessible."]
+            #[doc = "AHB clock is not running (gated)"]
             pub const CM7_FORCE_HCLK_EN_0: u32 = 0;
-            #[doc = "AHB clock is running (enabled) when CM7 is sleeping and TCM is accessible."]
+            #[doc = "AHB clock is running (enabled)"]
             pub const CM7_FORCE_HCLK_EN_1: u32 = 0x01;
         }
     }
@@ -424,9 +424,9 @@ pub mod GPR2 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Enters power saving mode only when chip is in SUSPEND mode"]
+            #[doc = "none memory power saving features enabled, SHUTDOWN/DEEPSLEEP/LIGHTSLEEP will have no effect"]
             pub const L2_MEM_EN_POWERSAVING_0: u32 = 0;
-            #[doc = "Controlled by L2_MEM_DEEPSLEEP bitfield"]
+            #[doc = "memory power saving features enabled, set SHUTDOWN/DEEPSLEEP/LIGHTSLEEP (priority high to low) to enable power saving levels"]
             pub const L2_MEM_EN_POWERSAVING_1: u32 = 0x01;
         }
     }
@@ -450,9 +450,9 @@ pub mod GPR2 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "No force sleep control supported, memory deep sleep mode only entered when whole system in stop mode (OCRAM in normal mode)"]
+            #[doc = "no force sleep control supported, memory deep sleep mode only entered when whole system in stop mode"]
             pub const L2_MEM_DEEPSLEEP_0: u32 = 0;
-            #[doc = "Force memory into deep sleep mode (OCRAM in power saving mode)"]
+            #[doc = "force memory into deep sleep mode"]
             pub const L2_MEM_DEEPSLEEP_1: u32 = 0x01;
         }
     }
@@ -1023,9 +1023,9 @@ pub mod GPR2 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Timer counter works normally"]
+            #[doc = "timer counter work normally"]
             pub const QTIMER1_TMR_CNTS_FREEZE_0: u32 = 0;
-            #[doc = "Reset counter and ouput flags"]
+            #[doc = "reset counter and ouput flags"]
             pub const QTIMER1_TMR_CNTS_FREEZE_1: u32 = 0x01;
         }
     }
@@ -1086,9 +1086,9 @@ pub mod GPR3 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select \\[127:0\\] from SNVS Master Key as DCP key"]
+            #[doc = "Select \\[127:0\\] from snvs/ocotp key as dcp key"]
             pub const DCP_KEY_SEL_0: u32 = 0;
-            #[doc = "Select \\[255:128\\] from SNVS Master Key as DCP key"]
+            #[doc = "Select \\[255:128\\] from snvs/ocotp key as dcp key"]
             pub const DCP_KEY_SEL_1: u32 = 0x01;
         }
     }
@@ -1412,9 +1412,9 @@ pub mod GPR4 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "ENET stop acknowledge is not asserted"]
+            #[doc = "ENET1 stop acknowledge is not asserted"]
             pub const ENET_STOP_ACK_0: u32 = 0;
-            #[doc = "ENET stop acknowledge is asserted"]
+            #[doc = "ENET1 stop acknowledge is asserted"]
             pub const ENET_STOP_ACK_1: u32 = 0x01;
         }
     }
@@ -2974,7 +2974,7 @@ pub mod GPR10 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select key from SNVS Master Key."]
+            #[doc = "Select key from Key MUX (SNVS/OTPMK)."]
             pub const DCPKEY_OCOTP_OR_KEYMUX_0: u32 = 0;
             #[doc = "Select key from OCOTP (SW_GP2)."]
             pub const DCPKEY_OCOTP_OR_KEYMUX_1: u32 = 0x01;

--- a/src/blocks/imxrt1064/iomuxc.rs
+++ b/src/blocks/imxrt1064/iomuxc.rs
@@ -1056,15 +1056,15 @@ pub mod SW_MUX_CTL_PAD_GPIO_EMC_04 {
         pub mod RW {
             #[doc = "Select mux mode: ALT0 mux port: SEMC_DATA04 of instance: semc"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: XBAR1_INOUT04 of instance: xbar1"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXPWM4_PWMA02 of instance: flexpwm4"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: SPDIF_OUT of instance: spdif"]
+            #[doc = "Select mux mode: ALT2 mux port: SAI2_TX_DATA of instance: sai2"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI2_TX_BCLK of instance: sai2"]
+            #[doc = "Select mux mode: ALT3 mux port: XBAR1_INOUT06 of instance: xbar1"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO16 of instance: flexio1"]
+            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO04 of instance: flexio1"]
             pub const ALT4: u32 = 0x04;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO2_IO04 of instance: gpio2"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO4_IO04 of instance: gpio4"]
             pub const ALT5: u32 = 0x05;
         }
     }
@@ -1093,15 +1093,15 @@ pub mod SW_MUX_CTL_PAD_GPIO_EMC_05 {
         pub mod RW {
             #[doc = "Select mux mode: ALT0 mux port: SEMC_DATA05 of instance: semc"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: XBAR1_INOUT05 of instance: xbar1"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXPWM4_PWMB02 of instance: flexpwm4"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: SPDIF_IN of instance: spdif"]
+            #[doc = "Select mux mode: ALT2 mux port: SAI2_TX_SYNC of instance: sai2"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI2_TX_SYNC of instance: sai2"]
+            #[doc = "Select mux mode: ALT3 mux port: XBAR1_INOUT07 of instance: xbar1"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO17 of instance: flexio1"]
+            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO05 of instance: flexio1"]
             pub const ALT4: u32 = 0x04;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO2_IO05 of instance: gpio2"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO4_IO05 of instance: gpio4"]
             pub const ALT5: u32 = 0x05;
         }
     }
@@ -1130,15 +1130,15 @@ pub mod SW_MUX_CTL_PAD_GPIO_EMC_06 {
         pub mod RW {
             #[doc = "Select mux mode: ALT0 mux port: SEMC_DATA06 of instance: semc"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: XBAR1_INOUT06 of instance: xbar1"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXPWM2_PWMA00 of instance: flexpwm2"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: LPUART3_TX of instance: lpuart3"]
+            #[doc = "Select mux mode: ALT2 mux port: SAI2_TX_BCLK of instance: sai2"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI2_TX_DATA of instance: sai2"]
+            #[doc = "Select mux mode: ALT3 mux port: XBAR1_INOUT08 of instance: xbar1"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO18 of instance: flexio1"]
+            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO06 of instance: flexio1"]
             pub const ALT4: u32 = 0x04;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO2_IO06 of instance: gpio2"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO4_IO06 of instance: gpio4"]
             pub const ALT5: u32 = 0x05;
         }
     }
@@ -1167,15 +1167,15 @@ pub mod SW_MUX_CTL_PAD_GPIO_EMC_07 {
         pub mod RW {
             #[doc = "Select mux mode: ALT0 mux port: SEMC_DATA07 of instance: semc"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: XBAR1_INOUT07 of instance: xbar1"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXPWM2_PWMB00 of instance: flexpwm2"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: LPUART3_RX of instance: lpuart3"]
+            #[doc = "Select mux mode: ALT2 mux port: SAI2_MCLK of instance: sai2"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI2_RX_SYNC of instance: sai2"]
+            #[doc = "Select mux mode: ALT3 mux port: XBAR1_INOUT09 of instance: xbar1"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO19 of instance: flexio1"]
+            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO07 of instance: flexio1"]
             pub const ALT4: u32 = 0x04;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO2_IO07 of instance: gpio2"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO4_IO07 of instance: gpio4"]
             pub const ALT5: u32 = 0x05;
         }
     }
@@ -1204,15 +1204,15 @@ pub mod SW_MUX_CTL_PAD_GPIO_EMC_08 {
         pub mod RW {
             #[doc = "Select mux mode: ALT0 mux port: SEMC_DM00 of instance: semc"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: XBAR1_INOUT08 of instance: xbar1"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXPWM2_PWMA01 of instance: flexpwm2"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: FLEXCAN2_TX of instance: flexcan2"]
+            #[doc = "Select mux mode: ALT2 mux port: SAI2_RX_DATA of instance: sai2"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI2_RX_DATA of instance: sai2"]
+            #[doc = "Select mux mode: ALT3 mux port: XBAR1_INOUT17 of instance: xbar1"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO20 of instance: flexio1"]
+            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO08 of instance: flexio1"]
             pub const ALT4: u32 = 0x04;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO2_IO08 of instance: gpio2"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO4_IO08 of instance: gpio4"]
             pub const ALT5: u32 = 0x05;
         }
     }
@@ -1239,17 +1239,17 @@ pub mod SW_MUX_CTL_PAD_GPIO_EMC_09 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: SEMC_WE of instance: semc"]
+            #[doc = "Select mux mode: ALT0 mux port: SEMC_ADDR00 of instance: semc"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: XBAR1_INOUT09 of instance: xbar1"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXPWM2_PWMB01 of instance: flexpwm2"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: FLEXCAN2_RX of instance: flexcan2"]
+            #[doc = "Select mux mode: ALT2 mux port: SAI2_RX_SYNC of instance: sai2"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI2_RX_BCLK of instance: sai2"]
+            #[doc = "Select mux mode: ALT3 mux port: FLEXCAN2_TX of instance: flexcan2"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO21 of instance: flexio1"]
+            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO09 of instance: flexio1"]
             pub const ALT4: u32 = 0x04;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO2_IO09 of instance: gpio2"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO4_IO09 of instance: gpio4"]
             pub const ALT5: u32 = 0x05;
         }
     }
@@ -1572,19 +1572,19 @@ pub mod SW_MUX_CTL_PAD_GPIO_EMC_18 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: SEMC_ADDR02 of instance: semc"]
+            #[doc = "Select mux mode: ALT0 mux port: SEMC_ADDR09 of instance: semc"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: XBAR1_INOUT16 of instance: xbar1"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXPWM4_PWMB03 of instance: flexpwm4"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: LPI2C2_SDA of instance: lpi2c2"]
+            #[doc = "Select mux mode: ALT2 mux port: LPUART4_RTS_B of instance: lpuart4"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI1_RX_SYNC of instance: sai1"]
+            #[doc = "Select mux mode: ALT3 mux port: FLEXCAN1_RX of instance: flexcan1"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO22 of instance: flexio1"]
+            #[doc = "Select mux mode: ALT4 mux port: QTIMER3_TIMER3 of instance: qtimer3"]
             pub const ALT4: u32 = 0x04;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO2_IO18 of instance: gpio2"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO4_IO18 of instance: gpio4"]
             pub const ALT5: u32 = 0x05;
-            #[doc = "Select mux mode: ALT6 mux port: SRC_BT_CFG00 of instance: src"]
+            #[doc = "Select mux mode: ALT6 mux port: SNVS_VIO_5_CTL of instance: snvs_hp"]
             pub const ALT6: u32 = 0x06;
         }
     }
@@ -1611,19 +1611,19 @@ pub mod SW_MUX_CTL_PAD_GPIO_EMC_19 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: SEMC_ADDR03 of instance: semc"]
+            #[doc = "Select mux mode: ALT0 mux port: SEMC_ADDR11 of instance: semc"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: XBAR1_INOUT17 of instance: xbar1"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXPWM2_PWMA03 of instance: flexpwm2"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: LPI2C2_SCL of instance: lpi2c2"]
+            #[doc = "Select mux mode: ALT2 mux port: LPUART4_TX of instance: lpuart4"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI1_RX_BCLK of instance: sai1"]
+            #[doc = "Select mux mode: ALT3 mux port: ENET_RDATA01 of instance: enet"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: FLEXIO1_FLEXIO23 of instance: flexio1"]
+            #[doc = "Select mux mode: ALT4 mux port: QTIMER2_TIMER0 of instance: qtimer2"]
             pub const ALT4: u32 = 0x04;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO2_IO19 of instance: gpio2"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO4_IO19 of instance: gpio4"]
             pub const ALT5: u32 = 0x05;
-            #[doc = "Select mux mode: ALT6 mux port: SRC_BT_CFG01 of instance: src"]
+            #[doc = "Select mux mode: ALT6 mux port: SNVS_VIO_5 of instance: snvs_hp"]
             pub const ALT6: u32 = 0x06;
         }
     }
@@ -2631,21 +2631,21 @@ pub mod SW_MUX_CTL_PAD_GPIO_AD_B0_03 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: JTAG_TDI of instance: jtag_mux"]
+            #[doc = "Select mux mode: ALT0 mux port: FLEXCAN2_RX of instance: flexcan2"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: USDHC2_CD_B of instance: usdhc2"]
+            #[doc = "Select mux mode: ALT1 mux port: XBAR1_INOUT17 of instance: xbar1"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: WDOG1_B of instance: wdog1"]
+            #[doc = "Select mux mode: ALT2 mux port: LPUART6_RX of instance: lpuart6"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI1_MCLK of instance: sai1"]
+            #[doc = "Select mux mode: ALT3 mux port: USB_OTG1_OC of instance: usb"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: USDHC1_WP of instance: usdhc1"]
+            #[doc = "Select mux mode: ALT4 mux port: FLEXPWM1_PWMX01 of instance: flexpwm1"]
             pub const ALT4: u32 = 0x04;
             #[doc = "Select mux mode: ALT5 mux port: GPIO1_IO03 of instance: gpio1"]
             pub const ALT5: u32 = 0x05;
-            #[doc = "Select mux mode: ALT6 mux port: USB_OTG1_OC of instance: usb"]
+            #[doc = "Select mux mode: ALT6 mux port: REF_CLK_24M of instance: anatop"]
             pub const ALT6: u32 = 0x06;
-            #[doc = "Select mux mode: ALT7 mux port: CCM_PMIC_RDY of instance: ccm"]
+            #[doc = "Select mux mode: ALT7 mux port: LPSPI3_PCS0 of instance: lpspi3"]
             pub const ALT7: u32 = 0x07;
         }
     }
@@ -2672,21 +2672,21 @@ pub mod SW_MUX_CTL_PAD_GPIO_AD_B0_04 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: JTAG_TDO of instance: jtag_mux"]
+            #[doc = "Select mux mode: ALT0 mux port: SRC_BOOT_MODE00 of instance: src"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: FLEXCAN1_TX of instance: flexcan1"]
+            #[doc = "Select mux mode: ALT1 mux port: MQS_RIGHT of instance: mqs"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: USDHC1_WP of instance: usdhc1"]
+            #[doc = "Select mux mode: ALT2 mux port: ENET_TX_DATA03 of instance: enet"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: QTIMER2_TIMER0 of instance: qtimer2"]
+            #[doc = "Select mux mode: ALT3 mux port: SAI2_TX_SYNC of instance: sai2"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: ENET_MDIO of instance: enet"]
+            #[doc = "Select mux mode: ALT4 mux port: CSI_DATA09 of instance: csi"]
             pub const ALT4: u32 = 0x04;
             #[doc = "Select mux mode: ALT5 mux port: GPIO1_IO04 of instance: gpio1"]
             pub const ALT5: u32 = 0x05;
-            #[doc = "Select mux mode: ALT6 mux port: USB_OTG1_PWR of instance: usb"]
+            #[doc = "Select mux mode: ALT6 mux port: PIT_TRIGGER00 of instance: pit"]
             pub const ALT6: u32 = 0x06;
-            #[doc = "Select mux mode: ALT7 mux port: EWM_OUT_B of instance: ewm"]
+            #[doc = "Select mux mode: ALT7 mux port: LPSPI3_PCS1 of instance: lpspi3"]
             pub const ALT7: u32 = 0x07;
         }
     }
@@ -2713,21 +2713,21 @@ pub mod SW_MUX_CTL_PAD_GPIO_AD_B0_05 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: JTAG_TRSTB of instance: jtag_mux"]
+            #[doc = "Select mux mode: ALT0 mux port: SRC_BOOT_MODE01 of instance: src"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: FLEXCAN1_RX of instance: flexcan1"]
+            #[doc = "Select mux mode: ALT1 mux port: MQS_LEFT of instance: mqs"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: USDHC1_CD_B of instance: usdhc1"]
+            #[doc = "Select mux mode: ALT2 mux port: ENET_TX_DATA02 of instance: enet"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: QTIMER2_TIMER1 of instance: qtimer2"]
+            #[doc = "Select mux mode: ALT3 mux port: SAI2_TX_BCLK of instance: sai2"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: ENET_MDC of instance: enet"]
+            #[doc = "Select mux mode: ALT4 mux port: CSI_DATA08 of instance: csi"]
             pub const ALT4: u32 = 0x04;
             #[doc = "Select mux mode: ALT5 mux port: GPIO1_IO05 of instance: gpio1"]
             pub const ALT5: u32 = 0x05;
-            #[doc = "Select mux mode: ALT6 mux port: USB_OTG1_ID of instance: anatop"]
+            #[doc = "Select mux mode: ALT6 mux port: XBAR1_INOUT17 of instance: xbar1"]
             pub const ALT6: u32 = 0x06;
-            #[doc = "Select mux mode: ALT7 mux port: NMI_GLUE_NMI of instance: nmi_glue"]
+            #[doc = "Select mux mode: ALT7 mux port: LPSPI3_PCS2 of instance: lpspi3"]
             pub const ALT7: u32 = 0x07;
         }
     }
@@ -3010,21 +3010,21 @@ pub mod SW_MUX_CTL_PAD_GPIO_AD_B0_12 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: ENET_RX_ER of instance: enet"]
+            #[doc = "Select mux mode: ALT0 mux port: LPI2C4_SCL of instance: lpi2c4"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: LPSPI1_SDO of instance: lpspi1"]
+            #[doc = "Select mux mode: ALT1 mux port: CCM_PMIC_READY of instance: ccm"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: LPUART3_CTS_B of instance: lpuart3"]
+            #[doc = "Select mux mode: ALT2 mux port: LPUART1_TX of instance: lpuart1"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: KPP_COL02 of instance: kpp"]
+            #[doc = "Select mux mode: ALT3 mux port: WDOG2_WDOG_B of instance: wdog2"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: FLEXPWM2_PWMA01 of instance: flexpwm2"]
+            #[doc = "Select mux mode: ALT4 mux port: FLEXPWM1_PWMX02 of instance: flexpwm1"]
             pub const ALT4: u32 = 0x04;
             #[doc = "Select mux mode: ALT5 mux port: GPIO1_IO12 of instance: gpio1"]
             pub const ALT5: u32 = 0x05;
-            #[doc = "Select mux mode: ALT6 mux port: ARM_CM7_TRACE00 of instance: cm7_mxrt"]
+            #[doc = "Select mux mode: ALT6 mux port: ENET_1588_EVENT1_OUT of instance: enet"]
             pub const ALT6: u32 = 0x06;
-            #[doc = "Select mux mode: ALT7 mux port: SNVS_HP_VIO_5_CTL of instance: snvs_hp"]
+            #[doc = "Select mux mode: ALT7 mux port: NMI_GLUE_NMI of instance: nmi_glue"]
             pub const ALT7: u32 = 0x07;
         }
     }
@@ -3051,21 +3051,21 @@ pub mod SW_MUX_CTL_PAD_GPIO_AD_B0_13 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: ENET_TX_EN of instance: enet"]
+            #[doc = "Select mux mode: ALT0 mux port: LPI2C4_SDA of instance: lpi2c4"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: LPSPI1_SDI of instance: lpspi1"]
+            #[doc = "Select mux mode: ALT1 mux port: GPT1_CLK of instance: gpt1"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: LPUART3_RTS_B of instance: lpuart3"]
+            #[doc = "Select mux mode: ALT2 mux port: LPUART1_RX of instance: lpuart1"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: KPP_ROW02 of instance: kpp"]
+            #[doc = "Select mux mode: ALT3 mux port: EWM_OUT_B of instance: ewm"]
             pub const ALT3: u32 = 0x03;
-            #[doc = "Select mux mode: ALT4 mux port: FLEXPWM2_PWMB01 of instance: flexpwm2"]
+            #[doc = "Select mux mode: ALT4 mux port: FLEXPWM1_PWMX03 of instance: flexpwm1"]
             pub const ALT4: u32 = 0x04;
             #[doc = "Select mux mode: ALT5 mux port: GPIO1_IO13 of instance: gpio1"]
             pub const ALT5: u32 = 0x05;
-            #[doc = "Select mux mode: ALT6 mux port: ARM_CM7_TRACE01 of instance: cm7_mxrt"]
+            #[doc = "Select mux mode: ALT6 mux port: ENET_1588_EVENT1_IN of instance: enet"]
             pub const ALT6: u32 = 0x06;
-            #[doc = "Select mux mode: ALT7 mux port: SNVS_HP_VIO_5_B of instance: snvs_hp"]
+            #[doc = "Select mux mode: ALT7 mux port: REF_CLK_24M of instance: anatop"]
             pub const ALT7: u32 = 0x07;
         }
     }
@@ -5751,17 +5751,17 @@ pub mod SW_MUX_CTL_PAD_GPIO_SD_B1_07 {
         pub mod R {}
         pub mod W {}
         pub mod RW {
-            #[doc = "Select mux mode: ALT0 mux port: USDHC2_RESET_B of instance: usdhc2"]
+            #[doc = "Select mux mode: ALT0 mux port: SEMC_CSX01 of instance: semc"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: FLEXSPI_A_SCLK of instance: flexspi_bus2bit"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXSPIA_SCLK of instance: flexspi"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: ENET_RX_EN of instance: enet"]
+            #[doc = "Select mux mode: ALT2 mux port: LPUART7_RTS_B of instance: lpuart7"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI3_TX_SYNC of instance: sai3"]
+            #[doc = "Select mux mode: ALT3 mux port: SAI1_TX_DATA00 of instance: sai1"]
             pub const ALT3: u32 = 0x03;
             #[doc = "Select mux mode: ALT4 mux port: LPSPI2_SCK of instance: lpspi2"]
             pub const ALT4: u32 = 0x04;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO3_IO27 of instance: gpio3"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO3_IO07 of instance: gpio3"]
             pub const ALT5: u32 = 0x05;
         }
     }
@@ -5829,15 +5829,15 @@ pub mod SW_MUX_CTL_PAD_GPIO_SD_B1_09 {
         pub mod RW {
             #[doc = "Select mux mode: ALT0 mux port: USDHC2_DATA5 of instance: usdhc2"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: FLEXSPI_A_DATA02 of instance: flexspi_bus2bit"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXSPIA_DATA01 of instance: flexspi"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: ENET_TX_EN of instance: enet"]
+            #[doc = "Select mux mode: ALT2 mux port: LPUART7_RX of instance: lpuart7"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI3_RX_BCLK of instance: sai3"]
+            #[doc = "Select mux mode: ALT3 mux port: SAI1_TX_SYNC of instance: sai1"]
             pub const ALT3: u32 = 0x03;
             #[doc = "Select mux mode: ALT4 mux port: LPSPI2_SDI of instance: lpspi2"]
             pub const ALT4: u32 = 0x04;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO3_IO29 of instance: gpio3"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO3_IO09 of instance: gpio3"]
             pub const ALT5: u32 = 0x05;
         }
     }
@@ -5866,15 +5866,15 @@ pub mod SW_MUX_CTL_PAD_GPIO_SD_B1_10 {
         pub mod RW {
             #[doc = "Select mux mode: ALT0 mux port: USDHC2_DATA6 of instance: usdhc2"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: FLEXSPI_A_DATA01 of instance: flexspi_bus2bit"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXSPIA_DATA02 of instance: flexspi"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: ENET_TDATA00 of instance: enet"]
+            #[doc = "Select mux mode: ALT2 mux port: LPUART2_RX of instance: lpuart2"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI3_RX_SYNC of instance: sai3"]
+            #[doc = "Select mux mode: ALT3 mux port: LPI2C2_SDA of instance: lpi2c2"]
             pub const ALT3: u32 = 0x03;
             #[doc = "Select mux mode: ALT4 mux port: LPSPI2_PCS2 of instance: lpspi2"]
             pub const ALT4: u32 = 0x04;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO3_IO30 of instance: gpio3"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO3_IO10 of instance: gpio3"]
             pub const ALT5: u32 = 0x05;
         }
     }
@@ -5903,15 +5903,15 @@ pub mod SW_MUX_CTL_PAD_GPIO_SD_B1_11 {
         pub mod RW {
             #[doc = "Select mux mode: ALT0 mux port: USDHC2_DATA7 of instance: usdhc2"]
             pub const ALT0: u32 = 0;
-            #[doc = "Select mux mode: ALT1 mux port: FLEXSPI_A_SS0_B of instance: flexspi_bus2bit"]
+            #[doc = "Select mux mode: ALT1 mux port: FLEXSPIA_DATA03 of instance: flexspi"]
             pub const ALT1: u32 = 0x01;
-            #[doc = "Select mux mode: ALT2 mux port: ENET_TDATA01 of instance: enet"]
+            #[doc = "Select mux mode: ALT2 mux port: LPUART2_TX of instance: lpuart2"]
             pub const ALT2: u32 = 0x02;
-            #[doc = "Select mux mode: ALT3 mux port: SAI3_RX_DATA of instance: sai3"]
+            #[doc = "Select mux mode: ALT3 mux port: LPI2C2_SCL of instance: lpi2c2"]
             pub const ALT3: u32 = 0x03;
             #[doc = "Select mux mode: ALT4 mux port: LPSPI2_PCS3 of instance: lpspi2"]
             pub const ALT4: u32 = 0x04;
-            #[doc = "Select mux mode: ALT5 mux port: GPIO3_IO31 of instance: gpio3"]
+            #[doc = "Select mux mode: ALT5 mux port: GPIO3_IO11 of instance: gpio3"]
             pub const ALT5: u32 = 0x05;
         }
     }

--- a/src/blocks/imxrt1176_cm4/flexram.rs
+++ b/src/blocks/imxrt1176_cm4/flexram.rs
@@ -113,14 +113,6 @@ pub mod TCM_CTRL {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod RESERVED {
-        pub const offset: u32 = 3;
-        pub const mask: u32 = 0x1fff_ffff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "OCRAM Magic Address Register"]
 pub mod OCRAM_MAGIC_ADDR {
@@ -141,14 +133,6 @@ pub mod OCRAM_MAGIC_ADDR {
     pub mod OCRAM_MAGIC_ADDR {
         pub const offset: u32 = 1;
         pub const mask: u32 = 0x0001_ffff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod RESERVED {
-        pub const offset: u32 = 18;
-        pub const mask: u32 = 0x3fff << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -177,14 +161,6 @@ pub mod DTCM_MAGIC_ADDR {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod RESERVED {
-        pub const offset: u32 = 17;
-        pub const mask: u32 = 0x7fff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "ITCM Magic Address Register"]
 pub mod ITCM_MAGIC_ADDR {
@@ -205,14 +181,6 @@ pub mod ITCM_MAGIC_ADDR {
     pub mod ITCM_MAGIC_ADDR {
         pub const offset: u32 = 1;
         pub const mask: u32 = 0xffff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod RESERVED {
-        pub const offset: u32 = 17;
-        pub const mask: u32 = 0x7fff << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -454,14 +422,6 @@ pub mod INT_STATUS {
             pub const OCRAM_PARTIAL_WR_INT_S_1: u32 = 0x01;
         }
     }
-    #[doc = "Reserved"]
-    pub mod RESERVED {
-        pub const offset: u32 = 18;
-        pub const mask: u32 = 0x3fff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "Interrupt Status Enable Register"]
 pub mod INT_STAT_EN {
@@ -698,14 +658,6 @@ pub mod INT_STAT_EN {
             #[doc = "Enabled"]
             pub const OCRAM_PARTIAL_WR_INT_S_EN_1: u32 = 0x01;
         }
-    }
-    #[doc = "Reserved"]
-    pub mod RESERVED {
-        pub const offset: u32 = 18;
-        pub const mask: u32 = 0x3fff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
     }
 }
 #[doc = "Interrupt Enable Register"]
@@ -944,14 +896,6 @@ pub mod INT_SIG_EN {
             pub const OCRAM_PARTIAL_WR_INT_SIG_EN_1: u32 = 0x01;
         }
     }
-    #[doc = "Reserved"]
-    pub mod RESERVED {
-        pub const offset: u32 = 18;
-        pub const mask: u32 = 0x3fff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "OCRAM single-bit ECC Error Information Register"]
 pub mod OCRAM_ECC_SINGLE_ERROR_INFO {
@@ -967,14 +911,6 @@ pub mod OCRAM_ECC_SINGLE_ERROR_INFO {
     pub mod OCRAM_ECCS_ERRED_SYN {
         pub const offset: u32 = 8;
         pub const mask: u32 = 0xff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod RESERVED {
-        pub const offset: u32 = 16;
-        pub const mask: u32 = 0xffff << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -1019,14 +955,6 @@ pub mod OCRAM_ECC_MULTI_ERROR_INFO {
     pub mod OCRAM_ECCM_ERRED_ECC {
         pub const offset: u32 = 0;
         pub const mask: u32 = 0xff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod RESERVED {
-        pub const offset: u32 = 8;
-        pub const mask: u32 = 0x00ff_ffff << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -1107,14 +1035,6 @@ pub mod ITCM_ECC_SINGLE_ERROR_INFO {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod RESERVED {
-        pub const offset: u32 = 20;
-        pub const mask: u32 = 0x0fff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "ITCM single-bit ECC Error Address Register"]
 pub mod ITCM_ECC_SINGLE_ERROR_ADDR {
@@ -1187,14 +1107,6 @@ pub mod ITCM_ECC_MULTI_ERROR_INFO {
     pub mod ITCM_ECCM_EFSYN {
         pub const offset: u32 = 12;
         pub const mask: u32 = 0xff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod RESERVED {
-        pub const offset: u32 = 20;
-        pub const mask: u32 = 0x0fff << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -1275,14 +1187,6 @@ pub mod D0TCM_ECC_SINGLE_ERROR_INFO {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod RESERVED {
-        pub const offset: u32 = 19;
-        pub const mask: u32 = 0x1fff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "D0TCM single-bit ECC Error Address Register"]
 pub mod D0TCM_ECC_SINGLE_ERROR_ADDR {
@@ -1344,14 +1248,6 @@ pub mod D0TCM_ECC_MULTI_ERROR_INFO {
     pub mod D0TCM_ECCM_EFSYN {
         pub const offset: u32 = 12;
         pub const mask: u32 = 0x7f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod RESERVED {
-        pub const offset: u32 = 19;
-        pub const mask: u32 = 0x1fff << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -1421,14 +1317,6 @@ pub mod D1TCM_ECC_SINGLE_ERROR_INFO {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod RESERVED {
-        pub const offset: u32 = 19;
-        pub const mask: u32 = 0x1fff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "D1TCM single-bit ECC Error Address Register"]
 pub mod D1TCM_ECC_SINGLE_ERROR_ADDR {
@@ -1490,14 +1378,6 @@ pub mod D1TCM_ECC_MULTI_ERROR_INFO {
     pub mod D1TCM_ECCM_EFSYN {
         pub const offset: u32 = 12;
         pub const mask: u32 = 0x7f << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod RESERVED {
-        pub const offset: u32 = 19;
-        pub const mask: u32 = 0x1fff << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -1575,14 +1455,6 @@ pub mod FLEXRAM_CTRL {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod RESERVED {
-        pub const offset: u32 = 6;
-        pub const mask: u32 = 0x03ff_ffff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "OCRAM Pipeline Status register"]
 pub mod OCRAM_PIPELINE_STATUS {
@@ -1614,14 +1486,6 @@ pub mod OCRAM_PIPELINE_STATUS {
     pub mod OCRAM_WRADDR_PIPELINE_EN_UPDATA_PENDING {
         pub const offset: u32 = 3;
         pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod RESERVED {
-        pub const offset: u32 = 4;
-        pub const mask: u32 = 0x0fff_ffff << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}

--- a/src/blocks/imxrt1176_cm4/usbphy.rs
+++ b/src/blocks/imxrt1176_cm4/usbphy.rs
@@ -218,7 +218,7 @@ pub mod PWD {
 }
 #[doc = "USB PHY Power-Down Register"]
 pub mod PWD_SET {
-    #[doc = "TXPWDFS"]
+    #[doc = "0 = Normal operation"]
     pub mod TXPWDFS {
         pub const offset: u32 = 10;
         pub const mask: u32 = 0x01 << offset;
@@ -226,7 +226,7 @@ pub mod PWD_SET {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "TXPWDIBIAS"]
+    #[doc = "0 = Normal operation"]
     pub mod TXPWDIBIAS {
         pub const offset: u32 = 11;
         pub const mask: u32 = 0x01 << offset;
@@ -234,7 +234,7 @@ pub mod PWD_SET {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "TXPWDV2I"]
+    #[doc = "0 = Normal operation"]
     pub mod TXPWDV2I {
         pub const offset: u32 = 12;
         pub const mask: u32 = 0x01 << offset;
@@ -242,7 +242,7 @@ pub mod PWD_SET {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "RXPWDENV"]
+    #[doc = "0 = Normal operation"]
     pub mod RXPWDENV {
         pub const offset: u32 = 17;
         pub const mask: u32 = 0x01 << offset;
@@ -250,7 +250,7 @@ pub mod PWD_SET {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "RXPWD1PT1"]
+    #[doc = "0 = Normal operation"]
     pub mod RXPWD1PT1 {
         pub const offset: u32 = 18;
         pub const mask: u32 = 0x01 << offset;
@@ -258,7 +258,7 @@ pub mod PWD_SET {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "RXPWDDIFF"]
+    #[doc = "0 = Normal operation"]
     pub mod RXPWDDIFF {
         pub const offset: u32 = 19;
         pub const mask: u32 = 0x01 << offset;
@@ -266,7 +266,7 @@ pub mod PWD_SET {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "RXPWDRX"]
+    #[doc = "0 = Normal operation"]
     pub mod RXPWDRX {
         pub const offset: u32 = 20;
         pub const mask: u32 = 0x01 << offset;
@@ -277,7 +277,7 @@ pub mod PWD_SET {
 }
 #[doc = "USB PHY Power-Down Register"]
 pub mod PWD_CLR {
-    #[doc = "TXPWDFS"]
+    #[doc = "0 = Normal operation"]
     pub mod TXPWDFS {
         pub const offset: u32 = 10;
         pub const mask: u32 = 0x01 << offset;
@@ -285,7 +285,7 @@ pub mod PWD_CLR {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "TXPWDIBIAS"]
+    #[doc = "0 = Normal operation"]
     pub mod TXPWDIBIAS {
         pub const offset: u32 = 11;
         pub const mask: u32 = 0x01 << offset;
@@ -293,7 +293,7 @@ pub mod PWD_CLR {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "TXPWDV2I"]
+    #[doc = "0 = Normal operation"]
     pub mod TXPWDV2I {
         pub const offset: u32 = 12;
         pub const mask: u32 = 0x01 << offset;
@@ -301,7 +301,7 @@ pub mod PWD_CLR {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "RXPWDENV"]
+    #[doc = "0 = Normal operation"]
     pub mod RXPWDENV {
         pub const offset: u32 = 17;
         pub const mask: u32 = 0x01 << offset;
@@ -309,7 +309,7 @@ pub mod PWD_CLR {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "RXPWD1PT1"]
+    #[doc = "0 = Normal operation"]
     pub mod RXPWD1PT1 {
         pub const offset: u32 = 18;
         pub const mask: u32 = 0x01 << offset;
@@ -317,7 +317,7 @@ pub mod PWD_CLR {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "RXPWDDIFF"]
+    #[doc = "0 = Normal operation"]
     pub mod RXPWDDIFF {
         pub const offset: u32 = 19;
         pub const mask: u32 = 0x01 << offset;
@@ -325,7 +325,7 @@ pub mod PWD_CLR {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "RXPWDRX"]
+    #[doc = "0 = Normal operation"]
     pub mod RXPWDRX {
         pub const offset: u32 = 20;
         pub const mask: u32 = 0x01 << offset;
@@ -336,7 +336,7 @@ pub mod PWD_CLR {
 }
 #[doc = "USB PHY Power-Down Register"]
 pub mod PWD_TOG {
-    #[doc = "TXPWDFS"]
+    #[doc = "0 = Normal operation"]
     pub mod TXPWDFS {
         pub const offset: u32 = 10;
         pub const mask: u32 = 0x01 << offset;
@@ -344,7 +344,7 @@ pub mod PWD_TOG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "TXPWDIBIAS"]
+    #[doc = "0 = Normal operation"]
     pub mod TXPWDIBIAS {
         pub const offset: u32 = 11;
         pub const mask: u32 = 0x01 << offset;
@@ -352,7 +352,7 @@ pub mod PWD_TOG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "TXPWDV2I"]
+    #[doc = "0 = Normal operation"]
     pub mod TXPWDV2I {
         pub const offset: u32 = 12;
         pub const mask: u32 = 0x01 << offset;
@@ -360,7 +360,7 @@ pub mod PWD_TOG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "RXPWDENV"]
+    #[doc = "0 = Normal operation"]
     pub mod RXPWDENV {
         pub const offset: u32 = 17;
         pub const mask: u32 = 0x01 << offset;
@@ -368,7 +368,7 @@ pub mod PWD_TOG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "RXPWD1PT1"]
+    #[doc = "0 = Normal operation"]
     pub mod RXPWD1PT1 {
         pub const offset: u32 = 18;
         pub const mask: u32 = 0x01 << offset;
@@ -376,7 +376,7 @@ pub mod PWD_TOG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "RXPWDDIFF"]
+    #[doc = "0 = Normal operation"]
     pub mod RXPWDDIFF {
         pub const offset: u32 = 19;
         pub const mask: u32 = 0x01 << offset;
@@ -384,7 +384,7 @@ pub mod PWD_TOG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "RXPWDRX"]
+    #[doc = "0 = Normal operation"]
     pub mod RXPWDRX {
         pub const offset: u32 = 20;
         pub const mask: u32 = 0x01 << offset;
@@ -560,7 +560,7 @@ pub mod RX {
 }
 #[doc = "USB PHY Receiver Control Register"]
 pub mod RX_SET {
-    #[doc = "ENVADJ"]
+    #[doc = "The ENVADJ field adjusts the trip point for the envelope detector"]
     pub mod ENVADJ {
         pub const offset: u32 = 0;
         pub const mask: u32 = 0x07 << offset;
@@ -568,7 +568,7 @@ pub mod RX_SET {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "DISCONADJ"]
+    #[doc = "The DISCONADJ field adjusts the trip point for the disconnect detector: 000 = Trip-Level Voltage is 0"]
     pub mod DISCONADJ {
         pub const offset: u32 = 4;
         pub const mask: u32 = 0x07 << offset;
@@ -576,7 +576,7 @@ pub mod RX_SET {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "RXDBYPASS"]
+    #[doc = "0 = Normal operation"]
     pub mod RXDBYPASS {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x01 << offset;
@@ -587,7 +587,7 @@ pub mod RX_SET {
 }
 #[doc = "USB PHY Receiver Control Register"]
 pub mod RX_CLR {
-    #[doc = "ENVADJ"]
+    #[doc = "The ENVADJ field adjusts the trip point for the envelope detector"]
     pub mod ENVADJ {
         pub const offset: u32 = 0;
         pub const mask: u32 = 0x07 << offset;
@@ -595,7 +595,7 @@ pub mod RX_CLR {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "DISCONADJ"]
+    #[doc = "The DISCONADJ field adjusts the trip point for the disconnect detector: 000 = Trip-Level Voltage is 0"]
     pub mod DISCONADJ {
         pub const offset: u32 = 4;
         pub const mask: u32 = 0x07 << offset;
@@ -603,7 +603,7 @@ pub mod RX_CLR {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "RXDBYPASS"]
+    #[doc = "0 = Normal operation"]
     pub mod RXDBYPASS {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x01 << offset;
@@ -614,7 +614,7 @@ pub mod RX_CLR {
 }
 #[doc = "USB PHY Receiver Control Register"]
 pub mod RX_TOG {
-    #[doc = "ENVADJ"]
+    #[doc = "The ENVADJ field adjusts the trip point for the envelope detector"]
     pub mod ENVADJ {
         pub const offset: u32 = 0;
         pub const mask: u32 = 0x07 << offset;
@@ -622,7 +622,7 @@ pub mod RX_TOG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "DISCONADJ"]
+    #[doc = "The DISCONADJ field adjusts the trip point for the disconnect detector: 000 = Trip-Level Voltage is 0"]
     pub mod DISCONADJ {
         pub const offset: u32 = 4;
         pub const mask: u32 = 0x07 << offset;
@@ -630,7 +630,7 @@ pub mod RX_TOG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "RXDBYPASS"]
+    #[doc = "0 = Normal operation"]
     pub mod RXDBYPASS {
         pub const offset: u32 = 22;
         pub const mask: u32 = 0x01 << offset;
@@ -1631,7 +1631,7 @@ pub mod STATUS {
 }
 #[doc = "USB PHY Debug Register"]
 pub mod DEBUG {
-    #[doc = "OTGIDPIOLOCK"]
+    #[doc = "Once OTG ID from USBPHYx_STATUS_OTGID_STATUS, use this to hold the value"]
     pub mod OTGIDPIOLOCK {
         pub const offset: u32 = 0;
         pub const mask: u32 = 0x01 << offset;
@@ -1639,7 +1639,7 @@ pub mod DEBUG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "DEBUG_INTERFACE_HOLD"]
+    #[doc = "Use holding registers to assist in timing for external UTMI interface."]
     pub mod DEBUG_INTERFACE_HOLD {
         pub const offset: u32 = 1;
         pub const mask: u32 = 0x01 << offset;
@@ -1647,7 +1647,7 @@ pub mod DEBUG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "HSTPULLDOWN"]
+    #[doc = "Set bit 3 to 1 to pull down 15-KOhm on USB_DP line"]
     pub mod HSTPULLDOWN {
         pub const offset: u32 = 2;
         pub const mask: u32 = 0x03 << offset;
@@ -1655,7 +1655,7 @@ pub mod DEBUG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "ENHSTPULLDOWN"]
+    #[doc = "Set bit 5 to 1 to override the control of the USB_DP 15-KOhm pulldown"]
     pub mod ENHSTPULLDOWN {
         pub const offset: u32 = 4;
         pub const mask: u32 = 0x03 << offset;
@@ -1663,7 +1663,7 @@ pub mod DEBUG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "TX2RXCOUNT"]
+    #[doc = "Delay in between the end of transmit to the beginning of receive"]
     pub mod TX2RXCOUNT {
         pub const offset: u32 = 8;
         pub const mask: u32 = 0x0f << offset;
@@ -1671,7 +1671,7 @@ pub mod DEBUG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "ENTX2RXCOUNT"]
+    #[doc = "Set this bit to allow a countdown to transition in between TX and RX."]
     pub mod ENTX2RXCOUNT {
         pub const offset: u32 = 12;
         pub const mask: u32 = 0x01 << offset;
@@ -1679,7 +1679,7 @@ pub mod DEBUG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "SQUELCHRESETCOUNT"]
+    #[doc = "Delay in between the detection of squelch to the reset of high-speed RX."]
     pub mod SQUELCHRESETCOUNT {
         pub const offset: u32 = 16;
         pub const mask: u32 = 0x1f << offset;
@@ -1687,7 +1687,7 @@ pub mod DEBUG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "ENSQUELCHRESET"]
+    #[doc = "Set bit to allow squelch to reset high-speed receive."]
     pub mod ENSQUELCHRESET {
         pub const offset: u32 = 24;
         pub const mask: u32 = 0x01 << offset;
@@ -1695,7 +1695,7 @@ pub mod DEBUG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "SQUELCHRESETLENGTH"]
+    #[doc = "Duration of RESET in terms of the number of 480-MHz cycles."]
     pub mod SQUELCHRESETLENGTH {
         pub const offset: u32 = 25;
         pub const mask: u32 = 0x0f << offset;
@@ -1703,7 +1703,7 @@ pub mod DEBUG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "HOST_RESUME_DEBUG"]
+    #[doc = "Choose to trigger the host resume SE0 with HOST_FORCE_LS_SE0 = 0 or UTMI_SUSPEND = 1."]
     pub mod HOST_RESUME_DEBUG {
         pub const offset: u32 = 29;
         pub const mask: u32 = 0x01 << offset;
@@ -1711,7 +1711,7 @@ pub mod DEBUG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "CLKGATE"]
+    #[doc = "Gate Test Clocks"]
     pub mod CLKGATE {
         pub const offset: u32 = 30;
         pub const mask: u32 = 0x01 << offset;
@@ -1722,7 +1722,7 @@ pub mod DEBUG {
 }
 #[doc = "USB PHY Debug Register"]
 pub mod DEBUG_SET {
-    #[doc = "OTGIDPIOLOCK"]
+    #[doc = "Once OTG ID from USBPHYx_STATUS_OTGID_STATUS, use this to hold the value"]
     pub mod OTGIDPIOLOCK {
         pub const offset: u32 = 0;
         pub const mask: u32 = 0x01 << offset;
@@ -1730,7 +1730,7 @@ pub mod DEBUG_SET {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "DEBUG_INTERFACE_HOLD"]
+    #[doc = "Use holding registers to assist in timing for external UTMI interface."]
     pub mod DEBUG_INTERFACE_HOLD {
         pub const offset: u32 = 1;
         pub const mask: u32 = 0x01 << offset;
@@ -1738,7 +1738,7 @@ pub mod DEBUG_SET {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "HSTPULLDOWN"]
+    #[doc = "Set bit 3 to 1 to pull down 15-KOhm on USB_DP line"]
     pub mod HSTPULLDOWN {
         pub const offset: u32 = 2;
         pub const mask: u32 = 0x03 << offset;
@@ -1746,7 +1746,7 @@ pub mod DEBUG_SET {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "ENHSTPULLDOWN"]
+    #[doc = "Set bit 5 to 1 to override the control of the USB_DP 15-KOhm pulldown"]
     pub mod ENHSTPULLDOWN {
         pub const offset: u32 = 4;
         pub const mask: u32 = 0x03 << offset;
@@ -1754,7 +1754,7 @@ pub mod DEBUG_SET {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "TX2RXCOUNT"]
+    #[doc = "Delay in between the end of transmit to the beginning of receive"]
     pub mod TX2RXCOUNT {
         pub const offset: u32 = 8;
         pub const mask: u32 = 0x0f << offset;
@@ -1762,7 +1762,7 @@ pub mod DEBUG_SET {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "ENTX2RXCOUNT"]
+    #[doc = "Set this bit to allow a countdown to transition in between TX and RX."]
     pub mod ENTX2RXCOUNT {
         pub const offset: u32 = 12;
         pub const mask: u32 = 0x01 << offset;
@@ -1770,7 +1770,7 @@ pub mod DEBUG_SET {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "SQUELCHRESETCOUNT"]
+    #[doc = "Delay in between the detection of squelch to the reset of high-speed RX."]
     pub mod SQUELCHRESETCOUNT {
         pub const offset: u32 = 16;
         pub const mask: u32 = 0x1f << offset;
@@ -1778,7 +1778,7 @@ pub mod DEBUG_SET {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "ENSQUELCHRESET"]
+    #[doc = "Set bit to allow squelch to reset high-speed receive."]
     pub mod ENSQUELCHRESET {
         pub const offset: u32 = 24;
         pub const mask: u32 = 0x01 << offset;
@@ -1786,7 +1786,7 @@ pub mod DEBUG_SET {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "SQUELCHRESETLENGTH"]
+    #[doc = "Duration of RESET in terms of the number of 480-MHz cycles."]
     pub mod SQUELCHRESETLENGTH {
         pub const offset: u32 = 25;
         pub const mask: u32 = 0x0f << offset;
@@ -1794,7 +1794,7 @@ pub mod DEBUG_SET {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "HOST_RESUME_DEBUG"]
+    #[doc = "Choose to trigger the host resume SE0 with HOST_FORCE_LS_SE0 = 0 or UTMI_SUSPEND = 1."]
     pub mod HOST_RESUME_DEBUG {
         pub const offset: u32 = 29;
         pub const mask: u32 = 0x01 << offset;
@@ -1802,7 +1802,7 @@ pub mod DEBUG_SET {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "CLKGATE"]
+    #[doc = "Gate Test Clocks"]
     pub mod CLKGATE {
         pub const offset: u32 = 30;
         pub const mask: u32 = 0x01 << offset;
@@ -1813,7 +1813,7 @@ pub mod DEBUG_SET {
 }
 #[doc = "USB PHY Debug Register"]
 pub mod DEBUG_CLR {
-    #[doc = "OTGIDPIOLOCK"]
+    #[doc = "Once OTG ID from USBPHYx_STATUS_OTGID_STATUS, use this to hold the value"]
     pub mod OTGIDPIOLOCK {
         pub const offset: u32 = 0;
         pub const mask: u32 = 0x01 << offset;
@@ -1821,7 +1821,7 @@ pub mod DEBUG_CLR {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "DEBUG_INTERFACE_HOLD"]
+    #[doc = "Use holding registers to assist in timing for external UTMI interface."]
     pub mod DEBUG_INTERFACE_HOLD {
         pub const offset: u32 = 1;
         pub const mask: u32 = 0x01 << offset;
@@ -1829,7 +1829,7 @@ pub mod DEBUG_CLR {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "HSTPULLDOWN"]
+    #[doc = "Set bit 3 to 1 to pull down 15-KOhm on USB_DP line"]
     pub mod HSTPULLDOWN {
         pub const offset: u32 = 2;
         pub const mask: u32 = 0x03 << offset;
@@ -1837,7 +1837,7 @@ pub mod DEBUG_CLR {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "ENHSTPULLDOWN"]
+    #[doc = "Set bit 5 to 1 to override the control of the USB_DP 15-KOhm pulldown"]
     pub mod ENHSTPULLDOWN {
         pub const offset: u32 = 4;
         pub const mask: u32 = 0x03 << offset;
@@ -1845,7 +1845,7 @@ pub mod DEBUG_CLR {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "TX2RXCOUNT"]
+    #[doc = "Delay in between the end of transmit to the beginning of receive"]
     pub mod TX2RXCOUNT {
         pub const offset: u32 = 8;
         pub const mask: u32 = 0x0f << offset;
@@ -1853,7 +1853,7 @@ pub mod DEBUG_CLR {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "ENTX2RXCOUNT"]
+    #[doc = "Set this bit to allow a countdown to transition in between TX and RX."]
     pub mod ENTX2RXCOUNT {
         pub const offset: u32 = 12;
         pub const mask: u32 = 0x01 << offset;
@@ -1861,7 +1861,7 @@ pub mod DEBUG_CLR {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "SQUELCHRESETCOUNT"]
+    #[doc = "Delay in between the detection of squelch to the reset of high-speed RX."]
     pub mod SQUELCHRESETCOUNT {
         pub const offset: u32 = 16;
         pub const mask: u32 = 0x1f << offset;
@@ -1869,7 +1869,7 @@ pub mod DEBUG_CLR {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "ENSQUELCHRESET"]
+    #[doc = "Set bit to allow squelch to reset high-speed receive."]
     pub mod ENSQUELCHRESET {
         pub const offset: u32 = 24;
         pub const mask: u32 = 0x01 << offset;
@@ -1877,7 +1877,7 @@ pub mod DEBUG_CLR {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "SQUELCHRESETLENGTH"]
+    #[doc = "Duration of RESET in terms of the number of 480-MHz cycles."]
     pub mod SQUELCHRESETLENGTH {
         pub const offset: u32 = 25;
         pub const mask: u32 = 0x0f << offset;
@@ -1885,7 +1885,7 @@ pub mod DEBUG_CLR {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "HOST_RESUME_DEBUG"]
+    #[doc = "Choose to trigger the host resume SE0 with HOST_FORCE_LS_SE0 = 0 or UTMI_SUSPEND = 1."]
     pub mod HOST_RESUME_DEBUG {
         pub const offset: u32 = 29;
         pub const mask: u32 = 0x01 << offset;
@@ -1893,7 +1893,7 @@ pub mod DEBUG_CLR {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "CLKGATE"]
+    #[doc = "Gate Test Clocks"]
     pub mod CLKGATE {
         pub const offset: u32 = 30;
         pub const mask: u32 = 0x01 << offset;
@@ -1904,7 +1904,7 @@ pub mod DEBUG_CLR {
 }
 #[doc = "USB PHY Debug Register"]
 pub mod DEBUG_TOG {
-    #[doc = "OTGIDPIOLOCK"]
+    #[doc = "Once OTG ID from USBPHYx_STATUS_OTGID_STATUS, use this to hold the value"]
     pub mod OTGIDPIOLOCK {
         pub const offset: u32 = 0;
         pub const mask: u32 = 0x01 << offset;
@@ -1912,7 +1912,7 @@ pub mod DEBUG_TOG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "DEBUG_INTERFACE_HOLD"]
+    #[doc = "Use holding registers to assist in timing for external UTMI interface."]
     pub mod DEBUG_INTERFACE_HOLD {
         pub const offset: u32 = 1;
         pub const mask: u32 = 0x01 << offset;
@@ -1920,7 +1920,7 @@ pub mod DEBUG_TOG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "HSTPULLDOWN"]
+    #[doc = "Set bit 3 to 1 to pull down 15-KOhm on USB_DP line"]
     pub mod HSTPULLDOWN {
         pub const offset: u32 = 2;
         pub const mask: u32 = 0x03 << offset;
@@ -1928,7 +1928,7 @@ pub mod DEBUG_TOG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "ENHSTPULLDOWN"]
+    #[doc = "Set bit 5 to 1 to override the control of the USB_DP 15-KOhm pulldown"]
     pub mod ENHSTPULLDOWN {
         pub const offset: u32 = 4;
         pub const mask: u32 = 0x03 << offset;
@@ -1936,7 +1936,7 @@ pub mod DEBUG_TOG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "TX2RXCOUNT"]
+    #[doc = "Delay in between the end of transmit to the beginning of receive"]
     pub mod TX2RXCOUNT {
         pub const offset: u32 = 8;
         pub const mask: u32 = 0x0f << offset;
@@ -1944,7 +1944,7 @@ pub mod DEBUG_TOG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "ENTX2RXCOUNT"]
+    #[doc = "Set this bit to allow a countdown to transition in between TX and RX."]
     pub mod ENTX2RXCOUNT {
         pub const offset: u32 = 12;
         pub const mask: u32 = 0x01 << offset;
@@ -1952,7 +1952,7 @@ pub mod DEBUG_TOG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "SQUELCHRESETCOUNT"]
+    #[doc = "Delay in between the detection of squelch to the reset of high-speed RX."]
     pub mod SQUELCHRESETCOUNT {
         pub const offset: u32 = 16;
         pub const mask: u32 = 0x1f << offset;
@@ -1960,7 +1960,7 @@ pub mod DEBUG_TOG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "ENSQUELCHRESET"]
+    #[doc = "Set bit to allow squelch to reset high-speed receive."]
     pub mod ENSQUELCHRESET {
         pub const offset: u32 = 24;
         pub const mask: u32 = 0x01 << offset;
@@ -1968,7 +1968,7 @@ pub mod DEBUG_TOG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "SQUELCHRESETLENGTH"]
+    #[doc = "Duration of RESET in terms of the number of 480-MHz cycles."]
     pub mod SQUELCHRESETLENGTH {
         pub const offset: u32 = 25;
         pub const mask: u32 = 0x0f << offset;
@@ -1976,7 +1976,7 @@ pub mod DEBUG_TOG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "HOST_RESUME_DEBUG"]
+    #[doc = "Choose to trigger the host resume SE0 with HOST_FORCE_LS_SE0 = 0 or UTMI_SUSPEND = 1."]
     pub mod HOST_RESUME_DEBUG {
         pub const offset: u32 = 29;
         pub const mask: u32 = 0x01 << offset;
@@ -1984,7 +1984,7 @@ pub mod DEBUG_TOG {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "CLKGATE"]
+    #[doc = "Gate Test Clocks"]
     pub mod CLKGATE {
         pub const offset: u32 = 30;
         pub const mask: u32 = 0x01 << offset;

--- a/src/blocks/imxrt1176_cm4/xecc_flexspi.rs
+++ b/src/blocks/imxrt1176_cm4/xecc_flexspi.rs
@@ -131,14 +131,6 @@ pub mod ERR_STATUS {
             pub const MULTI_ERR_1: u32 = 0x01;
         }
     }
-    #[doc = "Reserved"]
-    pub mod RESERVED1 {
-        pub const offset: u32 = 2;
-        pub const mask: u32 = 0x3fff_ffff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "Error Interrupt Status Enable Register"]
 pub mod ERR_STAT_EN {
@@ -168,14 +160,6 @@ pub mod ERR_STAT_EN {
             pub const MULIT_ERR_STAT_EN_1: u32 = 0x01;
         }
     }
-    #[doc = "Reserved"]
-    pub mod RESERVED1 {
-        pub const offset: u32 = 2;
-        pub const mask: u32 = 0x3fff_ffff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "Error Interrupt Enable Register"]
 pub mod ERR_SIG_EN {
@@ -204,14 +188,6 @@ pub mod ERR_SIG_EN {
             #[doc = "Enabled"]
             pub const MULTI_ERR_SIG_EN_1: u32 = 0x01;
         }
-    }
-    #[doc = "Reserved"]
-    pub mod RESERVED1 {
-        pub const offset: u32 = 2;
-        pub const mask: u32 = 0x3fff_ffff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
     }
 }
 #[doc = "Error Injection On Write Data"]
@@ -290,14 +266,6 @@ pub mod SINGLE_ERR_BIT_FIELD {
         pub mod W {}
         pub mod RW {}
     }
-    #[doc = "Reserved"]
-    pub mod RESERVED1 {
-        pub const offset: u32 = 8;
-        pub const mask: u32 = 0x00ff_ffff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
 }
 #[doc = "Multiple Error Address"]
 pub mod MULTI_ERR_ADDR {
@@ -338,14 +306,6 @@ pub mod MULTI_ERR_BIT_FIELD {
     pub mod MULTI_ERR_BIT_FIELD {
         pub const offset: u32 = 0;
         pub const mask: u32 = 0xff << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {}
-    }
-    #[doc = "Reserved"]
-    pub mod RESERVED1 {
-        pub const offset: u32 = 8;
-        pub const mask: u32 = 0x00ff_ffff << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}

--- a/src/blocks/imxrt1176_cm7/system_control.rs
+++ b/src/blocks/imxrt1176_cm7/system_control.rs
@@ -1176,19 +1176,6 @@ pub mod HFSR {
             pub const FORCED_1: u32 = 0x01;
         }
     }
-    #[doc = "Reserved for Debug use. When writing to the register you must write 0 to this bit, otherwise behavior is Unpredictable."]
-    pub mod DEBUGEVT {
-        pub const offset: u32 = 31;
-        pub const mask: u32 = 0x01 << offset;
-        pub mod R {}
-        pub mod W {}
-        pub mod RW {
-            #[doc = "No Debug event has occurred."]
-            pub const DEBUGEVT_0: u32 = 0;
-            #[doc = "Debug event has occurred. The Debug Fault Status Register has been updated."]
-            pub const DEBUGEVT_1: u32 = 0x01;
-        }
-    }
 }
 #[doc = "Debug Fault Status Register"]
 pub mod DFSR {


### PR DESCRIPTION
By aggressively combining IR elements, the combiner could create peripherals that have incorrect documentation. This multi-faceted PR addresses some invalid documentation in the RAL.

First, we remove specific cases of reserved registers. Users shouldn't touch them anyway, and it's nice to remove code. It also forces the combiner to treat fieldsets for CCM clock gates differently. This corrects most of the documentation issues presented in #32, but not all.

To fix all of the clock gate documentation, we build on #34 and introduce a new combiner configuration. A "never combine" configuration should prevent any kind of IR element from combining. It's tested with the CCM clock gate fieldsets.

But there's still documentation inconsistencies in IOMUXC, and I couldn't find a way to express the corrections in terms of "never combine" configurations. So there's another combiner configuration that requires the _documentation_ of an enum variant to match across chips. This fixes IOMUXC documentation.