### PR TITLE
Fix FlexIO register mistakes on 106x

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: install
-          args: svdtools --version=0.2.6
+          args: svdtools --version=0.2.8
       - name: Generate RAL
         run: make ci
       - name: Ensure RAL is consistent with checked-in code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@
 **BREAKING** The `flexio1` module is now called `flexio` for the 1010,
 1015, and 1020 families.
 
+Fix FlexIO register fields that describe pin counts, ensuring that they can
+represent the 32 pins available for FlexIO2 and FlexIO3. Note that this
+increases the field width for FlexIO1, even though this instance only supports
+16 pins. FlexIO1 users should take care to only access the lower four bits of
+such fields.
+
+Fix the FlexIO timer and shifter counts from four to eight, permitting access
+to all available components.
+
 ## [0.5.0] 2022-12-27
 
 Add support for NXP's i.MX RT 1176 dual-core MCUs. An `"imxrt1176_cm7"` feature

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ You'll need  a Rust installation, at least Rust 1.64, possibly later. To be safe
 
 To generate the RAL,
 
-1. Install `svdtools`: `cargo install svdtools`.
+1. Install `svdtools`: `cargo install svdtools --version=0.2.8`.
 2. Run `make`.
 
 If everything went well, you should find that the `src` directory is updated with Rust files. If you made changes to SVD patches, `raltool` transforms, or `raltool` itself, you should see those changes reflected in the Rust files. The RAL can build by itself: `cargo check --features imxrt1062`.

--- a/devices/common_patches/flexio_106x.yaml
+++ b/devices/common_patches/flexio_106x.yaml
@@ -1,0 +1,59 @@
+# Fix FlexIO bit widths.
+#
+# In the 1061 SVD, FLEXIO1 PINSEL has 4 bits, and FLEXIO2 and FLEXIO3
+# are derived from it.
+# In reality, FLEXIO2 and FLEXIO3 PINSEL have 5 bits.
+# It shouldn't hurt to make FLEXIO1 5 bits as well.
+#
+# The same is true for the other registers.
+#
+# The second problem with FlexIO is that all the register arrays have
+# a dimension of 4, while they should have a dimension of 8.
+FLEXIO*:
+  _modify:
+    _registers:
+      SHIFTCTL*:
+        dim: 8
+      SHIFTCFG*:
+        dim: 8
+      SHIFTBUF*:
+        dim: 8
+      SHIFTBUFBIS*:
+        dim: 8
+      SHIFTBUFBYS*:
+        dim: 8
+      SHIFTBUFBBS*:
+        dim: 8
+      SHIFTBUFNBS*:
+        dim: 8
+      SHIFTBUFHWS*:
+        dim: 8
+      SHIFTBUFNIS*:
+        dim: 8
+      TIMCTL*:
+        dim: 8
+      TIMCFG*:
+        dim: 8
+      TIMCMP*:
+        dim: 8
+
+  SHIFTCFG*:
+    _modify:
+      PWIDTH:
+        bitWidth: 5
+  SHIFTCTL*:
+    _modify:
+      PINSEL:
+        bitWidth: 5
+      TIMSEL:
+        bitWidth: 3
+  TIMCTL*:
+    _modify:
+      PINSEL:
+        bitWidth: 5
+      TRGSEL:
+        bitWidth: 6
+  PIN:
+    _modify:
+      PDI:
+        bitWidth: 32

--- a/devices/imxrt1061.yaml
+++ b/devices/imxrt1061.yaml
@@ -1,9 +1,10 @@
 _svd: "../svd/imxrt1061.svd"
 
-_include: 
+_include:
   - "common.yaml"
   - "common_patches/pwm1/submodule_cluster.yaml"
   - "common_patches/usb1.yaml"
   - "common_patches/dma0/tcd_cluster.yaml"
   - "common_patches/xbara.yaml"
   - "common_patches/instance_renames.yaml"
+  - "common_patches/flexio_106x.yaml"

--- a/devices/imxrt1062.yaml
+++ b/devices/imxrt1062.yaml
@@ -1,9 +1,10 @@
 _svd: "../svd/imxrt1062.svd"
 
-_include: 
+_include:
   - "common.yaml"
   - "common_patches/pwm1/submodule_cluster.yaml"
   - "common_patches/usb1.yaml"
   - "common_patches/dma0/tcd_cluster.yaml"
   - "common_patches/xbara.yaml"
   - "common_patches/instance_renames.yaml"
+  - "common_patches/flexio_106x.yaml"

--- a/devices/imxrt1064.yaml
+++ b/devices/imxrt1064.yaml
@@ -1,9 +1,10 @@
 _svd: "../svd/imxrt1064.svd"
 
-_include: 
+_include:
   - "common.yaml"
   - "common_patches/pwm1/submodule_cluster.yaml"
   - "common_patches/usb1.yaml"
   - "common_patches/dma0/tcd_cluster.yaml"
   - "common_patches/xbara.yaml"
   - "common_patches/instance_renames.yaml"
+  - "common_patches/flexio_106x.yaml"

--- a/src/blocks/imxrt1061/flexio.rs
+++ b/src/blocks/imxrt1061/flexio.rs
@@ -30,40 +30,40 @@ pub struct RegisterBlock {
     pub SHIFTSTATE: crate::RWRegister<u32>,
     _reserved3: [u8; 0x3c],
     #[doc = "Shifter Control N Register"]
-    pub SHIFTCTL: [crate::RWRegister<u32>; 4usize],
-    _reserved4: [u8; 0x70],
+    pub SHIFTCTL: [crate::RWRegister<u32>; 8usize],
+    _reserved4: [u8; 0x60],
     #[doc = "Shifter Configuration N Register"]
-    pub SHIFTCFG: [crate::RWRegister<u32>; 4usize],
-    _reserved5: [u8; 0xf0],
+    pub SHIFTCFG: [crate::RWRegister<u32>; 8usize],
+    _reserved5: [u8; 0xe0],
     #[doc = "Shifter Buffer N Register"]
-    pub SHIFTBUF: [crate::RWRegister<u32>; 4usize],
-    _reserved6: [u8; 0x70],
+    pub SHIFTBUF: [crate::RWRegister<u32>; 8usize],
+    _reserved6: [u8; 0x60],
     #[doc = "Shifter Buffer N Bit Swapped Register"]
-    pub SHIFTBUFBIS: [crate::RWRegister<u32>; 4usize],
-    _reserved7: [u8; 0x70],
+    pub SHIFTBUFBIS: [crate::RWRegister<u32>; 8usize],
+    _reserved7: [u8; 0x60],
     #[doc = "Shifter Buffer N Byte Swapped Register"]
-    pub SHIFTBUFBYS: [crate::RWRegister<u32>; 4usize],
-    _reserved8: [u8; 0x70],
+    pub SHIFTBUFBYS: [crate::RWRegister<u32>; 8usize],
+    _reserved8: [u8; 0x60],
     #[doc = "Shifter Buffer N Bit Byte Swapped Register"]
-    pub SHIFTBUFBBS: [crate::RWRegister<u32>; 4usize],
-    _reserved9: [u8; 0x70],
+    pub SHIFTBUFBBS: [crate::RWRegister<u32>; 8usize],
+    _reserved9: [u8; 0x60],
     #[doc = "Timer Control N Register"]
-    pub TIMCTL: [crate::RWRegister<u32>; 4usize],
-    _reserved10: [u8; 0x70],
+    pub TIMCTL: [crate::RWRegister<u32>; 8usize],
+    _reserved10: [u8; 0x60],
     #[doc = "Timer Configuration N Register"]
-    pub TIMCFG: [crate::RWRegister<u32>; 4usize],
-    _reserved11: [u8; 0x70],
+    pub TIMCFG: [crate::RWRegister<u32>; 8usize],
+    _reserved11: [u8; 0x60],
     #[doc = "Timer Compare N Register"]
-    pub TIMCMP: [crate::RWRegister<u32>; 4usize],
-    _reserved12: [u8; 0x0170],
+    pub TIMCMP: [crate::RWRegister<u32>; 8usize],
+    _reserved12: [u8; 0x0160],
     #[doc = "Shifter Buffer N Nibble Byte Swapped Register"]
-    pub SHIFTBUFNBS: [crate::RWRegister<u32>; 4usize],
-    _reserved13: [u8; 0x70],
+    pub SHIFTBUFNBS: [crate::RWRegister<u32>; 8usize],
+    _reserved13: [u8; 0x60],
     #[doc = "Shifter Buffer N Half Word Swapped Register"]
-    pub SHIFTBUFHWS: [crate::RWRegister<u32>; 4usize],
-    _reserved14: [u8; 0x70],
+    pub SHIFTBUFHWS: [crate::RWRegister<u32>; 8usize],
+    _reserved14: [u8; 0x60],
     #[doc = "Shifter Buffer N Nibble Swapped Register"]
-    pub SHIFTBUFNIS: [crate::RWRegister<u32>; 4usize],
+    pub SHIFTBUFNIS: [crate::RWRegister<u32>; 8usize],
 }
 #[doc = "Version ID Register"]
 pub mod VERID {
@@ -205,7 +205,7 @@ pub mod PIN {
     #[doc = "Pin Data Input"]
     pub mod PDI {
         pub const offset: u32 = 0;
-        pub const mask: u32 = 0xffff << offset;
+        pub const mask: u32 = 0xffff_ffff << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -340,7 +340,7 @@ pub mod SHIFTCTL {
     #[doc = "Shifter Pin Select"]
     pub mod PINSEL {
         pub const offset: u32 = 8;
-        pub const mask: u32 = 0x0f << offset;
+        pub const mask: u32 = 0x1f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -378,7 +378,7 @@ pub mod SHIFTCTL {
     #[doc = "Timer Select"]
     pub mod TIMSEL {
         pub const offset: u32 = 24;
-        pub const mask: u32 = 0x03 << offset;
+        pub const mask: u32 = 0x07 << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -434,7 +434,7 @@ pub mod SHIFTCFG {
     #[doc = "Parallel Width"]
     pub mod PWIDTH {
         pub const offset: u32 = 16;
-        pub const mask: u32 = 0x0f << offset;
+        pub const mask: u32 = 0x1f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -519,7 +519,7 @@ pub mod TIMCTL {
     #[doc = "Timer Pin Select"]
     pub mod PINSEL {
         pub const offset: u32 = 8;
-        pub const mask: u32 = 0x0f << offset;
+        pub const mask: u32 = 0x1f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}
@@ -570,7 +570,7 @@ pub mod TIMCTL {
     #[doc = "Trigger Select"]
     pub mod TRGSEL {
         pub const offset: u32 = 24;
-        pub const mask: u32 = 0x1f << offset;
+        pub const mask: u32 = 0x3f << offset;
         pub mod R {}
         pub mod W {}
         pub mod RW {}


### PR DESCRIPTION
Fixes #40 and #42.

Note that `svdtools` had to be updated to `0.2.8` to support the `dim` patches.