### PR TITLE
Exclude interrupt vector table from host build (e.g. in a build script)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ Add missing register fields:
 - SERCLKDIV in FlexSPI MCR0.
 - FILT_PRSC in ENC FILT.
 
+Exclude the interrupt vector table when we're building for a target with an
+operating system. This ensures you can build imxrt-ral in different contexts,
+like build scripts.
+
 ## [0.5.0] 2022-12-27
 
 Add support for NXP's i.MX RT 1176 dual-core MCUs. An `"imxrt1176_cm7"` feature

--- a/raltool/src/generate/device.rs
+++ b/raltool/src/generate/device.rs
@@ -200,7 +200,7 @@ name."#
             }
         }
 
-        #[cfg(feature = "rt")]
+        #[cfg(all(feature = "rt", target_os = "none"))]
         mod _vectors {
             extern "C" {
                 #(fn #names();)*

--- a/src/imxrt1011.rs
+++ b/src/imxrt1011.rs
@@ -156,7 +156,7 @@ unsafe impl cortex_m::interrupt::InterruptNumber for Interrupt {
         self as u16
     }
 }
-#[cfg(feature = "rt")]
+#[cfg(all(feature = "rt", target_os = "none"))]
 mod _vectors {
     extern "C" {
         fn DMA0();

--- a/src/imxrt1015.rs
+++ b/src/imxrt1015.rs
@@ -188,7 +188,7 @@ unsafe impl cortex_m::interrupt::InterruptNumber for Interrupt {
         self as u16
     }
 }
-#[cfg(feature = "rt")]
+#[cfg(all(feature = "rt", target_os = "none"))]
 mod _vectors {
     extern "C" {
         fn DMA0_DMA16();

--- a/src/imxrt1021.rs
+++ b/src/imxrt1021.rs
@@ -242,7 +242,7 @@ unsafe impl cortex_m::interrupt::InterruptNumber for Interrupt {
         self as u16
     }
 }
-#[cfg(feature = "rt")]
+#[cfg(all(feature = "rt", target_os = "none"))]
 mod _vectors {
     extern "C" {
         fn DMA0_DMA16();

--- a/src/imxrt1051.rs
+++ b/src/imxrt1051.rs
@@ -282,7 +282,7 @@ unsafe impl cortex_m::interrupt::InterruptNumber for Interrupt {
         self as u16
     }
 }
-#[cfg(feature = "rt")]
+#[cfg(all(feature = "rt", target_os = "none"))]
 mod _vectors {
     extern "C" {
         fn DMA0_DMA16();

--- a/src/imxrt1052.rs
+++ b/src/imxrt1052.rs
@@ -288,7 +288,7 @@ unsafe impl cortex_m::interrupt::InterruptNumber for Interrupt {
         self as u16
     }
 }
-#[cfg(feature = "rt")]
+#[cfg(all(feature = "rt", target_os = "none"))]
 mod _vectors {
     extern "C" {
         fn DMA0_DMA16();

--- a/src/imxrt1061.rs
+++ b/src/imxrt1061.rs
@@ -294,7 +294,7 @@ unsafe impl cortex_m::interrupt::InterruptNumber for Interrupt {
         self as u16
     }
 }
-#[cfg(feature = "rt")]
+#[cfg(all(feature = "rt", target_os = "none"))]
 mod _vectors {
     extern "C" {
         fn DMA0_DMA16();

--- a/src/imxrt1062.rs
+++ b/src/imxrt1062.rs
@@ -300,7 +300,7 @@ unsafe impl cortex_m::interrupt::InterruptNumber for Interrupt {
         self as u16
     }
 }
-#[cfg(feature = "rt")]
+#[cfg(all(feature = "rt", target_os = "none"))]
 mod _vectors {
     extern "C" {
         fn DMA0_DMA16();

--- a/src/imxrt1064.rs
+++ b/src/imxrt1064.rs
@@ -300,7 +300,7 @@ unsafe impl cortex_m::interrupt::InterruptNumber for Interrupt {
         self as u16
     }
 }
-#[cfg(feature = "rt")]
+#[cfg(all(feature = "rt", target_os = "none"))]
 mod _vectors {
     extern "C" {
         fn DMA0_DMA16();

--- a/src/imxrt1176_cm4.rs
+++ b/src/imxrt1176_cm4.rs
@@ -432,7 +432,7 @@ unsafe impl cortex_m::interrupt::InterruptNumber for Interrupt {
         self as u16
     }
 }
-#[cfg(feature = "rt")]
+#[cfg(all(feature = "rt", target_os = "none"))]
 mod _vectors {
     extern "C" {
         fn DMA0_DMA16();

--- a/src/imxrt1176_cm7.rs
+++ b/src/imxrt1176_cm7.rs
@@ -432,7 +432,7 @@ unsafe impl cortex_m::interrupt::InterruptNumber for Interrupt {
         self as u16
     }
 }
-#[cfg(feature = "rt")]
+#[cfg(all(feature = "rt", target_os = "none"))]
 mod _vectors {
     extern "C" {
         fn DMA0_DMA16();


### PR DESCRIPTION
# Background

I was trying to use `imxrt-hal` in the build script of my firmware crate. This creates a difficulty: I am using the `"rt"` feature in the firmware crate. When I include `imxrt-hal` in the build deps, because features are additive, the build script is also linked with the vector table, which now complains about the lack of IRQ handlers.

# Solution

I need a way to exclude the vector table from being linked into the build script.
Was going to try `target_arch = "arm"` and realized that it's possible for the host arch to be "arm" too.

Since the firmware is built with `target_os = "none"` and the build script is built on a non-bare-metal system, I went with this as the extra filter. It seems to be working.