### PR TITLE
Bump ral-registers to 0.1.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ include = [
     "Cargo.toml",
     "doc.md",
 ]
-version = "0.5.3"
+version = "0.5.4"
 
 [package.metadata.docs.rs]
 features = ["imxrt1062"]
@@ -25,7 +25,7 @@ version = "0.7.2"
 optional = true
 
 [dependencies.ral-registers]
-version = "0.1"
+version = "0.1.3"
 
 [lib]
 bench = false


### PR DESCRIPTION
I'm in the process of setting up a min-versions check in my crate, and it seems a bunch of versions are not specific enough in `imxrt-hal`.

It seems that `ral-registers` should be `0.1.2`. But I bumped it to `0.1.3` to allow trailing commas in the register accessor macros.

This should be a patch release as this only changes the patch version of a dependency.

# Rationale

When performing a min-versions test, all packages get downgraded to their minimal possible semver version. That shows if all dependencies got upgraded properly in `Cargo.toml`.

In my case (talking about the CI of the crate `imxrt-uart-panic`), I need to specify the following dependendencies manually because they are incorrect in the `imxrt-hal` crate and dependencies:
```
imxrt-dma = { version = ">= 0.1.1", default-features = false }
ral-registers = { version = ">= 0.1.2", default-features = false }
embedded-hal = { version = "0.2.6", default-features = false }
bitflags = { version = "1.3.1", default-features = false }
```

The `ral-registers` could also be specified in `imxrt-hal` to fix that problem, but I thought it's better do do it here because `ral-registers` isn't mentioned in `imxrt-hal` yet at all.


---

This change is a requirement for https://github.com/imxrt-rs/imxrt-hal/pull/162.