### PR TITLE
Release imxrt-ral v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,15 +17,6 @@ truly support multiple channels.
 **BREAKING** The `flexio1` module is now called `flexio` for the 1010,
 1015, and 1020 families.
 
-Fix FlexIO register fields that describe pin counts, ensuring that they can
-represent the 32 pins available for FlexIO2 and FlexIO3. Note that this
-increases the field width for FlexIO1, even though this instance only supports
-16 pins. FlexIO1 users should take care to only access the lower four bits of
-such fields.
-
-Fix the FlexIO timer and shifter counts from four to eight, permitting access
-to all available components.
-
 **BREAKING** Rename LPI2C.SIER field "AM1F" to "AM1IE".
 
 **BREAKING** Rename SRC.SRSR field "LOCKUP" to "LOCKUP_SYSRESETREQ" for 1011,
@@ -46,14 +37,7 @@ the 1176.
 As a result of this change, symbols for IOMUXC `SW_MUX_CTL*` and `*SW_PAD_CTL*`
 enum variants may have also changed.
 
-Add missing register fields:
-
-- SERCLKDIV in FlexSPI MCR0.
-- FILT_PRSC in ENC FILT.
-
-Exclude the interrupt vector table when we're building for a target with an
-operating system. This ensures you can build imxrt-ral in different contexts,
-like build scripts.
+**BREAKING** Remove deprecated items from the 0.5.1 release.
 
 Drop all register fields that are documented as "reserved" (first word of the
 description, all lowercase). Dropping these fields changes the combiner's
@@ -61,6 +45,43 @@ approach for combining fieldsets, enabling correct documentation for non-
 reserved fields.
 
 Fix the documentation associated with IOMUXC field values.
+
+## [0.5.3] 2023-08-21
+
+Exclude the interrupt vector table when we're building for a target with an
+operating system. This ensures you can build imxrt-ral in different contexts,
+like build scripts.
+
+## [0.5.2] 2023-08-02
+
+Add missing register fields:
+
+- SERCLKDIV in FlexSPI MCR0.
+- FILT_PRSC in ENC FILT.
+
+## [0.5.1] 2023-07-03
+
+*Deprecated* The following items will be renamed in the next breaking release:
+
+| Deprecated item | New item             | Notes                          |
+| --------------- | -------------------- | -------------------------------|
+|   `flexio1`     | `flexio`             | 1010, 1015, and 1020 families. |
+|   `AM1F`        | `AM1IE`              | LPI2C.SIER field.              |
+|   `LOCKUP`      | `LOCKUP_SYSRESETREQ` | SRC.SRSR field.                |
+|   `FLEXIO1_*`   | `FLEXIO2_*`          | CCM.CS1CDR fields.             |
+|   `GPIO_SEL`    | `GPIO_MUX1_GPIO_SEL` | 1060 IOMUXC_GPR.GPR26 field.   |
+| `PWR_GLITCH_EN` | `LVD_EN`             | 1170 SNVS.LPCR field.          |
+
+Fix the TRNG peripheral block for the 1015, 1021 families.
+
+Fix FlexIO register fields that describe pin counts, ensuring that they can
+represent the 32 pins available for FlexIO2 and FlexIO3. Note that this
+increases the field width for FlexIO1, even though this instance only supports
+16 pins. FlexIO1 users should take care to only access the lower four bits of
+such fields.
+
+Fix the FlexIO timer and shifter counts from four to eight, permitting access
+to all available components.
 
 ## [0.5.0] 2022-12-27
 
@@ -198,6 +219,9 @@ This release also removes mention of 'stm32ral' in the API documentation.
 Initial build and release of imxrt family of peripheral access crates
 
 [Unreleased]: https://github.com/imxrt-rs/imxrt-ral/compare/0.5.0...HEAD
+[0.5.3]: https://github.com/imxrt-rs/imxrt-ral/compare/0.5.2...0.5.3
+[0.5.2]: https://github.com/imxrt-rs/imxrt-ral/compare/0.5.1...0.5.2
+[0.5.1]: https://github.com/imxrt-rs/imxrt-ral/compare/0.5.0...0.5.1
 [0.5.0]: https://github.com/imxrt-rs/imxrt-ral/compare/0.4.4...0.5.0
 [0.4.4]: https://github.com/imxrt-rs/imxrt-ral/compare/0.4.3...0.4.4
 [0.4.3]: https://github.com/imxrt-rs/imxrt-ral/compare/0.4.2...0.4.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.6.0] 2024-12-02
+
 **BREAKING** Remove the NVIC and SCB peripherals from the 1176. If you need an
 API for Cortex-M registers, check out the
 [`cortex-m`][https://crates.io/crates/cortex-m] crate.
@@ -218,7 +220,8 @@ This release also removes mention of 'stm32ral' in the API documentation.
 
 Initial build and release of imxrt family of peripheral access crates
 
-[Unreleased]: https://github.com/imxrt-rs/imxrt-ral/compare/0.5.0...HEAD
+[Unreleased]: https://github.com/imxrt-rs/imxrt-ral/compare/0.6.0...HEAD
+[0.6.0]: https://github.com/imxrt-rs/imxrt-ral/compare/0.5.3...0.6.0
 [0.5.3]: https://github.com/imxrt-rs/imxrt-ral/compare/0.5.2...0.5.3
 [0.5.2]: https://github.com/imxrt-rs/imxrt-ral/compare/0.5.1...0.5.2
 [0.5.1]: https://github.com/imxrt-rs/imxrt-ral/compare/0.5.0...0.5.1

--- a/doc.md
+++ b/doc.md
@@ -59,7 +59,7 @@ see [`read_reg`], [`write_reg`], and [`modify_reg`]. Note that the documentation
 STM32 processor, and may demonstrate a different API for accessing instances.
 
 > Note: `imxrt-ral` does not yet support the `reset_reg` macro, and it does not expose reset
-structs.
+> structs.
 
 ## Resource management
 

--- a/raltool/src/combine.rs
+++ b/raltool/src/combine.rs
@@ -548,7 +548,7 @@ pub fn combine(irs: &[ir::IR], config: &Config) -> ir::IR {
                 for item in &mut block.items {
                     match &mut item.inner {
                         ir::BlockItemInner::Register(reg) => {
-                            for fieldset in &mut reg.fieldset {
+                            if let Some(fieldset) = &mut reg.fieldset {
                                 let version = versions.get_fieldset(ir, fieldset).unwrap();
                                 *fieldset =
                                     fieldsets.get(&RefHash(version.element())).unwrap().into()


### PR DESCRIPTION
v0.6.0 won't initially include 1180 support. See #51 for my thoughts. We can introduce 1180 support later, once we figure out matters like #52.

We have plenty of other breaking changes to release, affecting users who directly consume the RAL. Although its a proof-of-concept, https://github.com/imxrt-rs/imxrt-hal/pull/178 shows that imxrt-hal can build with this breaking imxrt-ral release.

I plan to release this early next week. Leave notes here if you have concerns or need to squeeze in another change.