### PR TITLE
Filter out nullptr peripheral instances

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -86,6 +86,7 @@ jobs:
           - "imxrt1021"
           - "imxrt1062,rt"
           - "imxrt1176_cm4"
+          - "imxrt1176_cm7"
           - "imxrt1189_cm33"
     steps:
     - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@
 Add support for NXP's i.MX RT 1189 dual-core MCUs. An `"imxrt1189_cm33"` feature
 targets the Cortex-M33, and an `"imxrt1189_cm7"` feature targets the Cortex-M7.
 
+## [0.6.1] 2024-12-19
+
+Remove the following peripheral instances from the 1176 API. The base address
+for these instances is incorrectly `NULL`.
+
+- OSC_RC_400M
+- PHY_LDO
+- TMPSNS
+- VMBANDGAP
+
+The register blocks remain part of the API. Users who rely on these instances
+may still use `offset_of!` to compute addresses for indirect accesses.
+
 ## [0.6.0] 2024-12-02
 
 **BREAKING** Remove the NVIC and SCB peripherals from the 1176. If you need an
@@ -50,6 +63,10 @@ approach for combining fieldsets, enabling correct documentation for non-
 reserved fields.
 
 Fix the documentation associated with IOMUXC field values.
+
+## [0.5.4] 2024-12-19
+
+See the 0.6.1 changelog entry.
 
 ## [0.5.3] 2023-08-21
 

--- a/src/imxrt1176_cm4.rs
+++ b/src/imxrt1176_cm4.rs
@@ -3738,30 +3738,10 @@ pub mod ocotp {
 }
 #[path = "."]
 pub mod osc_rc_400m {
-    #[doc = "no description available"]
-    pub const OSC_RC_400M: *const RegisterBlock = 0 as *const RegisterBlock;
     #[path = "blocks/imxrt1176_cm4/osc_rc_400m.rs"]
     mod blocks;
     pub use blocks::*;
     pub type Instance<const N: u8> = crate::Instance<RegisterBlock, N>;
-    pub type OSC_RC_400M = Instance<{ crate::SOLE_INSTANCE }>;
-    impl crate::private::Sealed for OSC_RC_400M {}
-    impl crate::Valid for OSC_RC_400M {}
-    impl OSC_RC_400M {
-        #[doc = r" Acquire a vaild, but possibly aliased, instance."]
-        #[doc = r""]
-        #[doc = r" # Safety"]
-        #[doc = r""]
-        #[doc = r" See [the struct-level safety documentation](crate::Instance)."]
-        #[inline]
-        pub const unsafe fn instance() -> Self {
-            Instance::new(OSC_RC_400M)
-        }
-    }
-    #[doc = r" Returns the instance number `N` for a peripheral instance."]
-    pub fn number(rb: *const RegisterBlock) -> Option<u8> {
-        core::ptr::eq(rb, OSC_RC_400M).then_some(0)
-    }
 }
 #[path = "."]
 pub mod otfad {
@@ -4145,30 +4125,10 @@ pub mod pgmc_ppc0 {
 }
 #[path = "."]
 pub mod phy_ldo {
-    #[doc = "no description available"]
-    pub const PHY_LDO: *const RegisterBlock = 0 as *const RegisterBlock;
     #[path = "blocks/imxrt1176_cm4/phy_ldo.rs"]
     mod blocks;
     pub use blocks::*;
     pub type Instance<const N: u8> = crate::Instance<RegisterBlock, N>;
-    pub type PHY_LDO = Instance<{ crate::SOLE_INSTANCE }>;
-    impl crate::private::Sealed for PHY_LDO {}
-    impl crate::Valid for PHY_LDO {}
-    impl PHY_LDO {
-        #[doc = r" Acquire a vaild, but possibly aliased, instance."]
-        #[doc = r""]
-        #[doc = r" # Safety"]
-        #[doc = r""]
-        #[doc = r" See [the struct-level safety documentation](crate::Instance)."]
-        #[inline]
-        pub const unsafe fn instance() -> Self {
-            Instance::new(PHY_LDO)
-        }
-    }
-    #[doc = r" Returns the instance number `N` for a peripheral instance."]
-    pub fn number(rb: *const RegisterBlock) -> Option<u8> {
-        core::ptr::eq(rb, PHY_LDO).then_some(0)
-    }
 }
 #[path = "."]
 pub mod pit {
@@ -4736,30 +4696,10 @@ pub mod ssarc_lp {
 }
 #[path = "."]
 pub mod tmpsns {
-    #[doc = "Temperature Sensor Memory Map"]
-    pub const TMPSNS: *const RegisterBlock = 0 as *const RegisterBlock;
     #[path = "blocks/imxrt1176_cm4/tmpsns.rs"]
     mod blocks;
     pub use blocks::*;
     pub type Instance<const N: u8> = crate::Instance<RegisterBlock, N>;
-    pub type TMPSNS = Instance<{ crate::SOLE_INSTANCE }>;
-    impl crate::private::Sealed for TMPSNS {}
-    impl crate::Valid for TMPSNS {}
-    impl TMPSNS {
-        #[doc = r" Acquire a vaild, but possibly aliased, instance."]
-        #[doc = r""]
-        #[doc = r" # Safety"]
-        #[doc = r""]
-        #[doc = r" See [the struct-level safety documentation](crate::Instance)."]
-        #[inline]
-        pub const unsafe fn instance() -> Self {
-            Instance::new(TMPSNS)
-        }
-    }
-    #[doc = r" Returns the instance number `N` for a peripheral instance."]
-    pub fn number(rb: *const RegisterBlock) -> Option<u8> {
-        core::ptr::eq(rb, TMPSNS).then_some(0)
-    }
 }
 #[path = "."]
 pub mod tmr {
@@ -5096,30 +5036,10 @@ pub mod video_mux {
 }
 #[path = "."]
 pub mod vmbandgap {
-    #[doc = "no description available"]
-    pub const VMBANDGAP: *const RegisterBlock = 0 as *const RegisterBlock;
     #[path = "blocks/imxrt1176_cm4/vmbandgap.rs"]
     mod blocks;
     pub use blocks::*;
     pub type Instance<const N: u8> = crate::Instance<RegisterBlock, N>;
-    pub type VMBANDGAP = Instance<{ crate::SOLE_INSTANCE }>;
-    impl crate::private::Sealed for VMBANDGAP {}
-    impl crate::Valid for VMBANDGAP {}
-    impl VMBANDGAP {
-        #[doc = r" Acquire a vaild, but possibly aliased, instance."]
-        #[doc = r""]
-        #[doc = r" # Safety"]
-        #[doc = r""]
-        #[doc = r" See [the struct-level safety documentation](crate::Instance)."]
-        #[inline]
-        pub const unsafe fn instance() -> Self {
-            Instance::new(VMBANDGAP)
-        }
-    }
-    #[doc = r" Returns the instance number `N` for a peripheral instance."]
-    pub fn number(rb: *const RegisterBlock) -> Option<u8> {
-        core::ptr::eq(rb, VMBANDGAP).then_some(0)
-    }
 }
 #[path = "."]
 pub mod wdog {
@@ -5476,7 +5396,6 @@ pub struct Instances {
     pub MMCAU: mmcau::MMCAU,
     pub MUB: mub::MUB,
     pub OCOTP: ocotp::OCOTP,
-    pub OSC_RC_400M: osc_rc_400m::OSC_RC_400M,
     pub OTFAD1: otfad::OTFAD1,
     pub OTFAD2: otfad::OTFAD2,
     pub PDM: pdm::PDM,
@@ -5495,7 +5414,6 @@ pub struct Instances {
     pub PGMC_CPC_MIF10: pgmc_cpc0_mif::PGMC_CPC_MIF10,
     pub PGMC_CPC_MIF11: pgmc_cpc0_mif::PGMC_CPC_MIF11,
     pub PGMC_PPC0: pgmc_ppc0::PGMC_PPC0,
-    pub PHY_LDO: phy_ldo::PHY_LDO,
     pub PIT1: pit::PIT1,
     pub PIT2: pit::PIT2,
     pub PWM1: pwm::PWM1,
@@ -5520,7 +5438,6 @@ pub struct Instances {
     pub SRC: src::SRC,
     pub SSARC_HP: ssarc_hp::SSARC_HP,
     pub SSARC_LP: ssarc_lp::SSARC_LP,
-    pub TMPSNS: tmpsns::TMPSNS,
     pub TMR1: tmr::TMR1,
     pub TMR2: tmr::TMR2,
     pub TMR3: tmr::TMR3,
@@ -5536,7 +5453,6 @@ pub struct Instances {
     pub USDHC1: usdhc::USDHC1,
     pub USDHC2: usdhc::USDHC2,
     pub VIDEO_MUX: video_mux::VIDEO_MUX,
-    pub VMBANDGAP: vmbandgap::VMBANDGAP,
     pub WDOG1: wdog::WDOG1,
     pub WDOG2: wdog::WDOG2,
     pub XBARA1: xbara1::XBARA1,
@@ -5680,7 +5596,6 @@ impl Instances {
             MMCAU: mmcau::MMCAU::instance(),
             MUB: mub::MUB::instance(),
             OCOTP: ocotp::OCOTP::instance(),
-            OSC_RC_400M: osc_rc_400m::OSC_RC_400M::instance(),
             OTFAD1: otfad::OTFAD1::instance(),
             OTFAD2: otfad::OTFAD2::instance(),
             PDM: pdm::PDM::instance(),
@@ -5699,7 +5614,6 @@ impl Instances {
             PGMC_CPC_MIF10: pgmc_cpc0_mif::PGMC_CPC_MIF10::instance(),
             PGMC_CPC_MIF11: pgmc_cpc0_mif::PGMC_CPC_MIF11::instance(),
             PGMC_PPC0: pgmc_ppc0::PGMC_PPC0::instance(),
-            PHY_LDO: phy_ldo::PHY_LDO::instance(),
             PIT1: pit::PIT1::instance(),
             PIT2: pit::PIT2::instance(),
             PWM1: pwm::PWM1::instance(),
@@ -5724,7 +5638,6 @@ impl Instances {
             SRC: src::SRC::instance(),
             SSARC_HP: ssarc_hp::SSARC_HP::instance(),
             SSARC_LP: ssarc_lp::SSARC_LP::instance(),
-            TMPSNS: tmpsns::TMPSNS::instance(),
             TMR1: tmr::TMR1::instance(),
             TMR2: tmr::TMR2::instance(),
             TMR3: tmr::TMR3::instance(),
@@ -5740,7 +5653,6 @@ impl Instances {
             USDHC1: usdhc::USDHC1::instance(),
             USDHC2: usdhc::USDHC2::instance(),
             VIDEO_MUX: video_mux::VIDEO_MUX::instance(),
-            VMBANDGAP: vmbandgap::VMBANDGAP::instance(),
             WDOG1: wdog::WDOG1::instance(),
             WDOG2: wdog::WDOG2::instance(),
             XBARA1: xbara1::XBARA1::instance(),

--- a/src/imxrt1176_cm7.rs
+++ b/src/imxrt1176_cm7.rs
@@ -3731,30 +3731,10 @@ pub mod ocotp {
 }
 #[path = "."]
 pub mod osc_rc_400m {
-    #[doc = "no description available"]
-    pub const OSC_RC_400M: *const RegisterBlock = 0 as *const RegisterBlock;
     #[path = "blocks/imxrt1176_cm4/osc_rc_400m.rs"]
     mod blocks;
     pub use blocks::*;
     pub type Instance<const N: u8> = crate::Instance<RegisterBlock, N>;
-    pub type OSC_RC_400M = Instance<{ crate::SOLE_INSTANCE }>;
-    impl crate::private::Sealed for OSC_RC_400M {}
-    impl crate::Valid for OSC_RC_400M {}
-    impl OSC_RC_400M {
-        #[doc = r" Acquire a vaild, but possibly aliased, instance."]
-        #[doc = r""]
-        #[doc = r" # Safety"]
-        #[doc = r""]
-        #[doc = r" See [the struct-level safety documentation](crate::Instance)."]
-        #[inline]
-        pub const unsafe fn instance() -> Self {
-            Instance::new(OSC_RC_400M)
-        }
-    }
-    #[doc = r" Returns the instance number `N` for a peripheral instance."]
-    pub fn number(rb: *const RegisterBlock) -> Option<u8> {
-        core::ptr::eq(rb, OSC_RC_400M).then_some(0)
-    }
 }
 #[path = "."]
 pub mod otfad {
@@ -4138,30 +4118,10 @@ pub mod pgmc_ppc0 {
 }
 #[path = "."]
 pub mod phy_ldo {
-    #[doc = "no description available"]
-    pub const PHY_LDO: *const RegisterBlock = 0 as *const RegisterBlock;
     #[path = "blocks/imxrt1176_cm4/phy_ldo.rs"]
     mod blocks;
     pub use blocks::*;
     pub type Instance<const N: u8> = crate::Instance<RegisterBlock, N>;
-    pub type PHY_LDO = Instance<{ crate::SOLE_INSTANCE }>;
-    impl crate::private::Sealed for PHY_LDO {}
-    impl crate::Valid for PHY_LDO {}
-    impl PHY_LDO {
-        #[doc = r" Acquire a vaild, but possibly aliased, instance."]
-        #[doc = r""]
-        #[doc = r" # Safety"]
-        #[doc = r""]
-        #[doc = r" See [the struct-level safety documentation](crate::Instance)."]
-        #[inline]
-        pub const unsafe fn instance() -> Self {
-            Instance::new(PHY_LDO)
-        }
-    }
-    #[doc = r" Returns the instance number `N` for a peripheral instance."]
-    pub fn number(rb: *const RegisterBlock) -> Option<u8> {
-        core::ptr::eq(rb, PHY_LDO).then_some(0)
-    }
 }
 #[path = "."]
 pub mod pit {
@@ -4729,30 +4689,10 @@ pub mod ssarc_lp {
 }
 #[path = "."]
 pub mod tmpsns {
-    #[doc = "Temperature Sensor Memory Map"]
-    pub const TMPSNS: *const RegisterBlock = 0 as *const RegisterBlock;
     #[path = "blocks/imxrt1176_cm4/tmpsns.rs"]
     mod blocks;
     pub use blocks::*;
     pub type Instance<const N: u8> = crate::Instance<RegisterBlock, N>;
-    pub type TMPSNS = Instance<{ crate::SOLE_INSTANCE }>;
-    impl crate::private::Sealed for TMPSNS {}
-    impl crate::Valid for TMPSNS {}
-    impl TMPSNS {
-        #[doc = r" Acquire a vaild, but possibly aliased, instance."]
-        #[doc = r""]
-        #[doc = r" # Safety"]
-        #[doc = r""]
-        #[doc = r" See [the struct-level safety documentation](crate::Instance)."]
-        #[inline]
-        pub const unsafe fn instance() -> Self {
-            Instance::new(TMPSNS)
-        }
-    }
-    #[doc = r" Returns the instance number `N` for a peripheral instance."]
-    pub fn number(rb: *const RegisterBlock) -> Option<u8> {
-        core::ptr::eq(rb, TMPSNS).then_some(0)
-    }
 }
 #[path = "."]
 pub mod tmr {
@@ -5089,30 +5029,10 @@ pub mod video_mux {
 }
 #[path = "."]
 pub mod vmbandgap {
-    #[doc = "no description available"]
-    pub const VMBANDGAP: *const RegisterBlock = 0 as *const RegisterBlock;
     #[path = "blocks/imxrt1176_cm4/vmbandgap.rs"]
     mod blocks;
     pub use blocks::*;
     pub type Instance<const N: u8> = crate::Instance<RegisterBlock, N>;
-    pub type VMBANDGAP = Instance<{ crate::SOLE_INSTANCE }>;
-    impl crate::private::Sealed for VMBANDGAP {}
-    impl crate::Valid for VMBANDGAP {}
-    impl VMBANDGAP {
-        #[doc = r" Acquire a vaild, but possibly aliased, instance."]
-        #[doc = r""]
-        #[doc = r" # Safety"]
-        #[doc = r""]
-        #[doc = r" See [the struct-level safety documentation](crate::Instance)."]
-        #[inline]
-        pub const unsafe fn instance() -> Self {
-            Instance::new(VMBANDGAP)
-        }
-    }
-    #[doc = r" Returns the instance number `N` for a peripheral instance."]
-    pub fn number(rb: *const RegisterBlock) -> Option<u8> {
-        core::ptr::eq(rb, VMBANDGAP).then_some(0)
-    }
 }
 #[path = "."]
 pub mod wdog {
@@ -5469,7 +5389,6 @@ pub struct Instances {
     pub MIPI_CSI2RX: mipi_csi2rx::MIPI_CSI2RX,
     pub MUA: mua::MUA,
     pub OCOTP: ocotp::OCOTP,
-    pub OSC_RC_400M: osc_rc_400m::OSC_RC_400M,
     pub OTFAD1: otfad::OTFAD1,
     pub OTFAD2: otfad::OTFAD2,
     pub PDM: pdm::PDM,
@@ -5488,7 +5407,6 @@ pub struct Instances {
     pub PGMC_CPC_MIF10: pgmc_cpc0_mif::PGMC_CPC_MIF10,
     pub PGMC_CPC_MIF11: pgmc_cpc0_mif::PGMC_CPC_MIF11,
     pub PGMC_PPC0: pgmc_ppc0::PGMC_PPC0,
-    pub PHY_LDO: phy_ldo::PHY_LDO,
     pub PIT1: pit::PIT1,
     pub PIT2: pit::PIT2,
     pub PWM1: pwm::PWM1,
@@ -5513,7 +5431,6 @@ pub struct Instances {
     pub SRC: src::SRC,
     pub SSARC_HP: ssarc_hp::SSARC_HP,
     pub SSARC_LP: ssarc_lp::SSARC_LP,
-    pub TMPSNS: tmpsns::TMPSNS,
     pub TMR1: tmr::TMR1,
     pub TMR2: tmr::TMR2,
     pub TMR3: tmr::TMR3,
@@ -5529,7 +5446,6 @@ pub struct Instances {
     pub USDHC1: usdhc::USDHC1,
     pub USDHC2: usdhc::USDHC2,
     pub VIDEO_MUX: video_mux::VIDEO_MUX,
-    pub VMBANDGAP: vmbandgap::VMBANDGAP,
     pub WDOG1: wdog::WDOG1,
     pub WDOG2: wdog::WDOG2,
     pub XBARA1: xbara1::XBARA1,
@@ -5673,7 +5589,6 @@ impl Instances {
             MIPI_CSI2RX: mipi_csi2rx::MIPI_CSI2RX::instance(),
             MUA: mua::MUA::instance(),
             OCOTP: ocotp::OCOTP::instance(),
-            OSC_RC_400M: osc_rc_400m::OSC_RC_400M::instance(),
             OTFAD1: otfad::OTFAD1::instance(),
             OTFAD2: otfad::OTFAD2::instance(),
             PDM: pdm::PDM::instance(),
@@ -5692,7 +5607,6 @@ impl Instances {
             PGMC_CPC_MIF10: pgmc_cpc0_mif::PGMC_CPC_MIF10::instance(),
             PGMC_CPC_MIF11: pgmc_cpc0_mif::PGMC_CPC_MIF11::instance(),
             PGMC_PPC0: pgmc_ppc0::PGMC_PPC0::instance(),
-            PHY_LDO: phy_ldo::PHY_LDO::instance(),
             PIT1: pit::PIT1::instance(),
             PIT2: pit::PIT2::instance(),
             PWM1: pwm::PWM1::instance(),
@@ -5717,7 +5631,6 @@ impl Instances {
             SRC: src::SRC::instance(),
             SSARC_HP: ssarc_hp::SSARC_HP::instance(),
             SSARC_LP: ssarc_lp::SSARC_LP::instance(),
-            TMPSNS: tmpsns::TMPSNS::instance(),
             TMR1: tmr::TMR1::instance(),
             TMR2: tmr::TMR2::instance(),
             TMR3: tmr::TMR3::instance(),
@@ -5733,7 +5646,6 @@ impl Instances {
             USDHC1: usdhc::USDHC1::instance(),
             USDHC2: usdhc::USDHC2::instance(),
             VIDEO_MUX: video_mux::VIDEO_MUX::instance(),
-            VMBANDGAP: vmbandgap::VMBANDGAP::instance(),
             WDOG1: wdog::WDOG1::instance(),
             WDOG2: wdog::WDOG2::instance(),
             XBARA1: xbara1::XBARA1::instance(),

--- a/tests/instances.rs
+++ b/tests/instances.rs
@@ -1,0 +1,17 @@
+#![cfg(any(
+    feature = "imxrt1011",
+    feature = "imxrt1015",
+    feature = "imxrt1021",
+    feature = "imxrt1051",
+    feature = "imxrt1052",
+    feature = "imxrt1061",
+    feature = "imxrt1062",
+    feature = "imxrt1064",
+    feature = "imxrt1176_cm7",
+    feature = "imxrt1176_cm4",
+))]
+
+#[test]
+fn instances() {
+    let _instances = unsafe { imxrt_ral::Instances::instances() };
+}


### PR DESCRIPTION
There are a few peripheral instances that have `NULL` as their base address in the SVD. My guess is that `NULL` is a signal to humans to not use this address. If I remember correctly , the peripherals tagged with `NULL` require indirect access through ANATOP. Until this commit, we've generated those peripheral instances, despite the silly address.

However, a runtime check in `NonNull` will panic when the core library is built with debug assertions. Users may hit this panic if they build their firmware with this configuration, then try to acquire the individual peripheral instance or the `Instances` aggregate. The panic in the latter case is inconvenient, especially when the user doesn't care about these instances.

This commit removes these `NULL` instances from the public API. I'm keeping the register blocks; pairing `core::mem::offset_of!` with register blocks is useful.

For convenience / ease of implementation, I'm doing the filtering down in the codegen step of `raltool`. It would be better to implement this as a standard transform / cleanup step that kept the register block while discarding the instances. We can try this later.

I plan to release this breaking change in the 0.5 and 0.6 series. This will affect users who were relying on these incorrect symbols.