### PR TITLE
Add the S3MUA to the 1189 RAL

### DIFF
--- a/raltool-cfg.yaml
+++ b/raltool-cfg.yaml
@@ -190,8 +190,6 @@ transforms:
   - Delete:
       from: mu2_mua::Mu2Mua
   - Delete:
-      from: mu_apps_s3mua::MuAppsS3mua
-  - Delete:
       from: sw0_global::Sw0Global
   - Delete:
       from: tstmr2_tstmra::Tstmr2Tstmra

--- a/src/blocks/imxrt1189_cm33/mu_apps_s3mua.rs
+++ b/src/blocks/imxrt1189_cm33/mu_apps_s3mua.rs
@@ -1,0 +1,179 @@
+#[doc = "S3MUA"]
+#[repr(C)]
+pub struct RegisterBlock {
+    #[doc = "Version ID Register"]
+    pub VER: crate::RORegister<u32>,
+    #[doc = "Parameter Register"]
+    pub PAR: crate::RORegister<u32>,
+    #[doc = "Unused Register 0"]
+    pub UNUSED0: crate::RORegister<u32>,
+    #[doc = "Status Register"]
+    pub SR: crate::RORegister<u32>,
+    _reserved0: [u8; 0x0110],
+    #[doc = "Transmit Control Register"]
+    pub TCR: crate::RWRegister<u32>,
+    #[doc = "Transmit Status Register"]
+    pub TSR: crate::RORegister<u32>,
+    #[doc = "Receive Control Register"]
+    pub RCR: crate::RWRegister<u32>,
+    #[doc = "Receive Status Register"]
+    pub RSR: crate::RORegister<u32>,
+    _reserved1: [u8; 0xcc],
+    #[doc = "Unused Register 1"]
+    pub UNUSED1: crate::RWRegister<u32>,
+    #[doc = "Transmit Register"]
+    pub TR: [crate::RWRegister<u32>; 8usize],
+    _reserved2: [u8; 0x60],
+    #[doc = "Receive Register"]
+    pub RR: [crate::RORegister<u32>; 4usize],
+}
+#[doc = "Version ID Register"]
+pub mod VER {
+    #[doc = "Feature Set Number"]
+    pub mod FEATURE {
+        pub const offset: u32 = 0;
+        pub const mask: u32 = 0xffff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {
+            #[doc = "Standard features are implemented."]
+            pub const STANDARD: u32 = 0;
+        }
+    }
+    #[doc = "Minor Version Number (0x00 )"]
+    pub mod MINOR {
+        pub const offset: u32 = 16;
+        pub const mask: u32 = 0xff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "Major Version Number (0x01 )"]
+    pub mod MAJOR {
+        pub const offset: u32 = 24;
+        pub const mask: u32 = 0xff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+}
+#[doc = "Parameter Register"]
+pub mod PAR {
+    #[doc = "Number of Transmit (TRn) registers (8)"]
+    pub mod TR_NUM {
+        pub const offset: u32 = 0;
+        pub const mask: u32 = 0xff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "Number of Receive (RRn) registers (4)"]
+    pub mod RR_NUM {
+        pub const offset: u32 = 8;
+        pub const mask: u32 = 0xff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+}
+#[doc = "Status Register"]
+pub mod SR {
+    #[doc = "Transmit Empty Pending"]
+    pub mod TEP {
+        pub const offset: u32 = 5;
+        pub const mask: u32 = 0x01 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+    #[doc = "Receive Full Pending Flag"]
+    pub mod RFP {
+        pub const offset: u32 = 6;
+        pub const mask: u32 = 0x01 << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {
+            #[doc = "No data is ready to be read. All RSR\\[RFn\\] bits are clear."]
+            pub const CLEAR: u32 = 0;
+            #[doc = "Data is ready to be read. One or more RSR\\[RFn\\] bits are set."]
+            pub const SET: u32 = 0x01;
+        }
+    }
+}
+#[doc = "Transmit Control Register"]
+pub mod TCR {
+    #[doc = "Transmit Register n Empty Interrupt Enable"]
+    pub mod TEIEN {
+        pub const offset: u32 = 0;
+        pub const mask: u32 = 0xff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+}
+#[doc = "Transmit Status Register"]
+pub mod TSR {
+    #[doc = "Transmit Register n Empty"]
+    pub mod TEN {
+        pub const offset: u32 = 0;
+        pub const mask: u32 = 0xff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+}
+#[doc = "Receive Control Register"]
+pub mod RCR {
+    #[doc = "Receive Register n Full Interrupt Enable"]
+    pub mod RFIEN {
+        pub const offset: u32 = 0;
+        pub const mask: u32 = 0x0f << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+}
+#[doc = "Receive Status Register"]
+pub mod RSR {
+    #[doc = "Receive Register n Full"]
+    pub mod RFN {
+        pub const offset: u32 = 0;
+        pub const mask: u32 = 0x0f << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+}
+#[doc = "Unused Register 1"]
+pub mod UNUSED1 {
+    #[doc = "Unused 16-bit Register"]
+    pub mod DATA16 {
+        pub const offset: u32 = 0;
+        pub const mask: u32 = 0xffff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+}
+#[doc = "Transmit Register"]
+pub mod TR {
+    #[doc = "Transmit Data"]
+    pub mod TR_DATA {
+        pub const offset: u32 = 0;
+        pub const mask: u32 = 0xffff_ffff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+}
+#[doc = "Receive Register"]
+pub mod RR {
+    #[doc = "Receive Data"]
+    pub mod RR_DATA {
+        pub const offset: u32 = 0;
+        pub const mask: u32 = 0xffff_ffff << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
+}

--- a/src/imxrt1189_cm33.rs
+++ b/src/imxrt1189_cm33.rs
@@ -3590,6 +3590,47 @@ pub mod msgintr {
     }
 }
 #[path = "."]
+pub mod mu_apps_s3mua {
+    #[doc = "S3MUA"]
+    pub const MU_APPS_S3MUA: *const RegisterBlock = 0x4752_0000 as *const RegisterBlock;
+    #[doc = "S3MUA"]
+    pub const MU_RT_S3MUA: *const RegisterBlock = 0x4754_0000 as *const RegisterBlock;
+    #[path = "blocks/imxrt1189_cm33/mu_apps_s3mua.rs"]
+    mod blocks;
+    pub use blocks::*;
+    pub type Instance<const N: u8> = crate::Instance<RegisterBlock, N>;
+    #[doc = r" The const generic instance N is meaningless."]
+    pub type MU_APPS_S3MUA = Instance<255u8>;
+    impl crate::private::Sealed for MU_APPS_S3MUA {}
+    impl crate::Valid for MU_APPS_S3MUA {}
+    impl MU_APPS_S3MUA {
+        #[doc = r" Acquire a vaild, but possibly aliased, instance."]
+        #[doc = r""]
+        #[doc = r" # Safety"]
+        #[doc = r""]
+        #[doc = r" See [the struct-level safety documentation](crate::Instance)."]
+        #[inline]
+        pub const unsafe fn instance() -> Self {
+            Instance::new(MU_APPS_S3MUA)
+        }
+    }
+    #[doc = r" The const generic instance N is meaningless."]
+    pub type MU_RT_S3MUA = Instance<254u8>;
+    impl crate::private::Sealed for MU_RT_S3MUA {}
+    impl crate::Valid for MU_RT_S3MUA {}
+    impl MU_RT_S3MUA {
+        #[doc = r" Acquire a vaild, but possibly aliased, instance."]
+        #[doc = r""]
+        #[doc = r" # Safety"]
+        #[doc = r""]
+        #[doc = r" See [the struct-level safety documentation](crate::Instance)."]
+        #[inline]
+        pub const unsafe fn instance() -> Self {
+            Instance::new(MU_RT_S3MUA)
+        }
+    }
+}
+#[path = "."]
 pub mod netc_f0_pci_hdr_type0 {
     #[doc = "NETC PCI Express ECAM PF config"]
     pub const NETC_F0_PCI_HDR_TYPE0: *const RegisterBlock = 0x6000_0000 as *const RegisterBlock;
@@ -5857,6 +5898,8 @@ pub struct Instances {
     pub MSGINTR4: msgintr::MSGINTR4,
     pub MSGINTR5: msgintr::MSGINTR5,
     pub MSGINTR6: msgintr::MSGINTR6,
+    pub MU_APPS_S3MUA: mu_apps_s3mua::MU_APPS_S3MUA,
+    pub MU_RT_S3MUA: mu_apps_s3mua::MU_RT_S3MUA,
     pub NETC_F0_PCI_HDR_TYPE0: netc_f0_pci_hdr_type0::NETC_F0_PCI_HDR_TYPE0,
     pub NETC_F1_PCI_HDR_TYPE0: netc_f1_pci_hdr_type0::NETC_F1_PCI_HDR_TYPE0,
     pub NETC_F2_PCI_HDR_TYPE0: netc_f2_pci_hdr_type0::NETC_F2_PCI_HDR_TYPE0,
@@ -6077,6 +6120,8 @@ impl Instances {
             MSGINTR4: msgintr::MSGINTR4::instance(),
             MSGINTR5: msgintr::MSGINTR5::instance(),
             MSGINTR6: msgintr::MSGINTR6::instance(),
+            MU_APPS_S3MUA: mu_apps_s3mua::MU_APPS_S3MUA::instance(),
+            MU_RT_S3MUA: mu_apps_s3mua::MU_RT_S3MUA::instance(),
             NETC_F0_PCI_HDR_TYPE0: netc_f0_pci_hdr_type0::NETC_F0_PCI_HDR_TYPE0::instance(),
             NETC_F1_PCI_HDR_TYPE0: netc_f1_pci_hdr_type0::NETC_F1_PCI_HDR_TYPE0::instance(),
             NETC_F2_PCI_HDR_TYPE0: netc_f2_pci_hdr_type0::NETC_F2_PCI_HDR_TYPE0::instance(),

--- a/src/imxrt1189_cm7.rs
+++ b/src/imxrt1189_cm7.rs
@@ -3617,6 +3617,47 @@ pub mod msgintr {
     }
 }
 #[path = "."]
+pub mod mu_apps_s3mua {
+    #[doc = "S3MUA"]
+    pub const MU_APPS_S3MUA: *const RegisterBlock = 0x4752_0000 as *const RegisterBlock;
+    #[doc = "S3MUA"]
+    pub const MU_RT_S3MUA: *const RegisterBlock = 0x4754_0000 as *const RegisterBlock;
+    #[path = "blocks/imxrt1189_cm33/mu_apps_s3mua.rs"]
+    mod blocks;
+    pub use blocks::*;
+    pub type Instance<const N: u8> = crate::Instance<RegisterBlock, N>;
+    #[doc = r" The const generic instance N is meaningless."]
+    pub type MU_APPS_S3MUA = Instance<255u8>;
+    impl crate::private::Sealed for MU_APPS_S3MUA {}
+    impl crate::Valid for MU_APPS_S3MUA {}
+    impl MU_APPS_S3MUA {
+        #[doc = r" Acquire a vaild, but possibly aliased, instance."]
+        #[doc = r""]
+        #[doc = r" # Safety"]
+        #[doc = r""]
+        #[doc = r" See [the struct-level safety documentation](crate::Instance)."]
+        #[inline]
+        pub const unsafe fn instance() -> Self {
+            Instance::new(MU_APPS_S3MUA)
+        }
+    }
+    #[doc = r" The const generic instance N is meaningless."]
+    pub type MU_RT_S3MUA = Instance<254u8>;
+    impl crate::private::Sealed for MU_RT_S3MUA {}
+    impl crate::Valid for MU_RT_S3MUA {}
+    impl MU_RT_S3MUA {
+        #[doc = r" Acquire a vaild, but possibly aliased, instance."]
+        #[doc = r""]
+        #[doc = r" # Safety"]
+        #[doc = r""]
+        #[doc = r" See [the struct-level safety documentation](crate::Instance)."]
+        #[inline]
+        pub const unsafe fn instance() -> Self {
+            Instance::new(MU_RT_S3MUA)
+        }
+    }
+}
+#[path = "."]
 pub mod netc_f0_pci_hdr_type0 {
     #[doc = "NETC PCI Express ECAM PF config"]
     pub const NETC_F0_PCI_HDR_TYPE0: *const RegisterBlock = 0x6000_0000 as *const RegisterBlock;
@@ -5885,6 +5926,8 @@ pub struct Instances {
     pub MSGINTR4: msgintr::MSGINTR4,
     pub MSGINTR5: msgintr::MSGINTR5,
     pub MSGINTR6: msgintr::MSGINTR6,
+    pub MU_APPS_S3MUA: mu_apps_s3mua::MU_APPS_S3MUA,
+    pub MU_RT_S3MUA: mu_apps_s3mua::MU_RT_S3MUA,
     pub NETC_F0_PCI_HDR_TYPE0: netc_f0_pci_hdr_type0::NETC_F0_PCI_HDR_TYPE0,
     pub NETC_F1_PCI_HDR_TYPE0: netc_f1_pci_hdr_type0::NETC_F1_PCI_HDR_TYPE0,
     pub NETC_F2_PCI_HDR_TYPE0: netc_f2_pci_hdr_type0::NETC_F2_PCI_HDR_TYPE0,
@@ -6106,6 +6149,8 @@ impl Instances {
             MSGINTR4: msgintr::MSGINTR4::instance(),
             MSGINTR5: msgintr::MSGINTR5::instance(),
             MSGINTR6: msgintr::MSGINTR6::instance(),
+            MU_APPS_S3MUA: mu_apps_s3mua::MU_APPS_S3MUA::instance(),
+            MU_RT_S3MUA: mu_apps_s3mua::MU_RT_S3MUA::instance(),
             NETC_F0_PCI_HDR_TYPE0: netc_f0_pci_hdr_type0::NETC_F0_PCI_HDR_TYPE0::instance(),
             NETC_F1_PCI_HDR_TYPE0: netc_f1_pci_hdr_type0::NETC_F1_PCI_HDR_TYPE0::instance(),
             NETC_F2_PCI_HDR_TYPE0: netc_f2_pci_hdr_type0::NETC_F2_PCI_HDR_TYPE0::instance(),

--- a/tests/s3mu_1180.rs
+++ b/tests/s3mu_1180.rs
@@ -1,0 +1,11 @@
+#![cfg(any(feature = "imxrt1189_cm33", feature = "imxrt1189_cm7",))]
+
+use core::mem::offset_of;
+use imxrt_ral as ral;
+
+#[test]
+fn check_transmit_receive_register_offsets() {
+    use ral::mu_apps_s3mua::RegisterBlock;
+    assert_eq!(offset_of!(RegisterBlock, TR), 0x200);
+    assert_eq!(offset_of!(RegisterBlock, RR), 0x280);
+}


### PR DESCRIPTION
Haven't tested this on hardware, and I haven't studied the `imxrt-ral` block. But the starting addresses match the reference manual contents.

This requires us to relax the code generation requirements in `raltool` to permit un-numbered instance groups. See the commit message for details and alternatives.