### PR TITLE
Add MASK[UPDATE_MASK] field for 1170 FlexPWM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 Add support for NXP's i.MX RT 1189 dual-core MCUs. An `"imxrt1189_cm33"` feature
 targets the Cortex-M33, and an `"imxrt1189_cm7"` feature targets the Cortex-M7.
 
+Add the `MASK[UPDATE_MASK]` fields for FlexPWM on 1170 MCUs.
+
 ## [0.6.1] 2024-12-19
 
 Remove the following peripheral instances from the 1176 API. The base address

--- a/devices/imxrt1176_cm4.yaml
+++ b/devices/imxrt1176_cm4.yaml
@@ -198,6 +198,15 @@ PWM?:
         bitWidth: 1
         access: read-write
 
+# Missing in these SVDs, but documented in the reference manual.
+"PWM*":
+  MASK:
+    _add:
+      UPDATE_MASK:
+        bitOffset: 12
+        bitWidth: 4
+        access: read-write
+
 MCM:
   _add:
     _interrupts:

--- a/devices/imxrt1176_cm7.yaml
+++ b/devices/imxrt1176_cm7.yaml
@@ -138,6 +138,15 @@ PWM?:
         bitWidth: 1
         access: read-write
 
+# Missing in these SVDs, but documented in the reference manual.
+"PWM*":
+  MASK:
+    _add:
+      UPDATE_MASK:
+        bitOffset: 12
+        bitWidth: 4
+        access: read-write
+
 CM7_MCM:
   _add:
     _interrupts:

--- a/src/blocks/imxrt1176_cm4/pwm.rs
+++ b/src/blocks/imxrt1176_cm4/pwm.rs
@@ -109,6 +109,13 @@ pub mod MASK {
             pub const MASKA_1: u16 = 0x01;
         }
     }
+    pub mod UPDATE_MASK {
+        pub const offset: u16 = 12;
+        pub const mask: u16 = 0x0f << offset;
+        pub mod R {}
+        pub mod W {}
+        pub mod RW {}
+    }
 }
 #[doc = "Software Controlled Output Register"]
 pub mod SWCOUT {


### PR DESCRIPTION
They're documented in rev 3 of the i.MX RT 1170 reference manual. I noticed they're missing when adding output masking in https://github.com/imxrt-rs/imxrt-hal/pull/198.